### PR TITLE
Allow js as a code-snippet language

### DIFF
--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -18,6 +18,7 @@ function isLanguageSupported(lang: string): lang is Language {
     lang === 'cpp' ||
     lang === 'css' ||
     lang === 'javascript' ||
+    lang === 'js' ||
     lang === 'jsx' ||
     lang === 'coffeescript' ||
     lang === 'actionscript' ||


### PR DESCRIPTION
The react-query documents contain markdown files with js as a code-snippet language. 
These show up (incorrectly) as bash in the documentation.