### PR TITLE
fix: docs page scrolling on mobile because of unnecessary grid usage

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -177,7 +177,7 @@ export function Docs({
   );
 
   return (
-    <div className="min-h-screen grid lg:grid-cols-[auto_1fr_auto]">
+    <div className="min-h-screen block lg:grid lg:grid-cols-[auto_1fr_auto]">
       {smallMenu}
       {largeMenu}
       <div className="flex-1 min-h-0 flex relative">


### PR DESCRIPTION
Very simple fix I found is getting rid of `display: grid` on mobile as it wasn't required, at least for now.

Grid is required on larger screens (`lg` unit) and I added it back there.

This fixes the weird scrolling bug on docs page.