### PR TITLE
Adjust sizing of main content area for readability

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -124,7 +124,7 @@ export function Docs({
   );
 
   const largeMenu = (
-    <div className="hidden lg:flex w-[250px] flex-col gap-4 h-screen sticky top-0 z-20">
+    <div className="hidden lg:flex flex-col gap-4 h-screen sticky top-0 z-20">
       <div className="px-4 pt-4 flex gap-2 items-center text-2xl">{logo}</div>
       <div>
         <DocSearch
@@ -143,7 +143,7 @@ export function Docs({
   );
 
   const aside = (
-    <aside className="p-12">
+    <aside className="p-6 xl:p-12">
       <ul className="sticky top-10 border border-black/10 dark:border-white/10 p-6 rounded-lg max-w-[30ch]">
         {config?.docSearch?.indexName?.includes("query") && (
           <li className="mb-8">
@@ -177,10 +177,10 @@ export function Docs({
   );
 
   return (
-    <div className="min-h-screen block lg:grid lg:grid-cols-[auto_1fr_auto]">
+    <div className="min-h-screen block lg:grid lg:grid-cols-[250px_minmax(500px,_1fr)_minmax(300px,_400px)] w-full">
       {smallMenu}
       {largeMenu}
-      <div className="flex-1 min-h-0 flex relative">
+      <div className="flex-1 min-h-0 flex relative justify-center">
         <Outlet />
         <div
           className="fixed bottom-0 left-0 right-0

--- a/app/routes/query/v4/docs/$.tsx
+++ b/app/routes/query/v4/docs/$.tsx
@@ -66,7 +66,7 @@ export default function RouteReactQueryDocs() {
   const { title, code, filePath } = useLoaderData<typeof loader>()
 
   return (
-    <div className="p-4 lg:p-6 overflow-auto w-full">
+    <div className="p-4 lg:p-6 overflow-auto w-full max-w-3xl">
       {title ? <DocTitle>{title}</DocTitle> : null}
       <div className="h-4" />
       <div className="h-px bg-gray-500 opacity-20" />


### PR DESCRIPTION
PR to fix #20.

The content width has been constrained to max-w-3xl (768px). This also fixes the aside ad being "squashed" and the page overflowing horizontally:

<img width="1178" alt="CleanShot 2022-07-25 at 21 15 00@2x" src="https://user-images.githubusercontent.com/38015558/180856670-71e27980-c941-44cb-996c-53e27cdbdd07.png">
