### PR TITLE
add z-index to prevent elements overlapping

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -184,7 +184,7 @@ export function Docs({
         <Outlet />
         <div
           className="fixed bottom-0 left-0 right-0
-                      lg:pl-[250px]"
+                      lg:pl-[250px] z-10"
         >
           <div className="p-4 flex justify-center gap-4">
             {prevItem ? (


### PR DESCRIPTION
Current behaviour (elements overlapping):
<img width="444" alt="Снимок экрана 2022-08-11 в 22 56 02" src="https://user-images.githubusercontent.com/37879025/184228237-d18cd832-6714-4fcf-ab9f-16c3c059c338.png">
<img width="480" alt="Снимок экрана 2022-08-11 в 22 55 45" src="https://user-images.githubusercontent.com/37879025/184228253-2bf6d75e-a84e-451c-90a8-93b02e63e71c.png">

Fixed:
<img width="411" alt="Снимок экрана 2022-08-11 в 22 58 55" src="https://user-images.githubusercontent.com/37879025/184228576-99d56b18-ffc2-436b-819f-cf568117517d.png">
<img width="375" alt="Снимок экрана 2022-08-11 в 22 58 47" src="https://user-images.githubusercontent.com/37879025/184228624-facd8eef-1e24-4cd3-bbab-db789e9e8298.png">

