### PR TITLE
Improve code sample spacing on smaller screens

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -177,7 +177,7 @@ export function Docs({
   );
 
   return (
-    <div className="min-h-screen block lg:grid lg:grid-cols-[250px_minmax(500px,_1fr)_minmax(300px,_400px)] w-full">
+    <div className="min-h-screen flex flex-col  lg:grid lg:grid-cols-[250px_minmax(500px,_1fr)_minmax(300px,_400px)] w-full">
       {smallMenu}
       {largeMenu}
       <div className="flex-1 min-h-0 flex relative justify-center">

--- a/app/routes/query/v4/docs/examples/$.tsx
+++ b/app/routes/query/v4/docs/examples/$.tsx
@@ -52,7 +52,7 @@ export default function RouteReactQueryDocs() {
           className="flex-1 w-full overflow-hidden lg:rounded-l-2xl shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
         />
       </div>
-      <div className="h-16 lg:mt-2" />
+      <div className="lg:h-16 lg:mt-2" />
     </div>
   )
 }

--- a/app/routes/router/v4/docs/examples/$.tsx
+++ b/app/routes/router/v4/docs/examples/$.tsx
@@ -52,7 +52,7 @@ export default function RouteReactTableDocs() {
           className="flex-1 w-full overflow-hidden lg:rounded-l-2xl shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
         />
       </div>
-      <div className="h-16 lg:mt-2" />
+      <div className="lg:h-16 lg:mt-2" />
     </div>
   )
 }

--- a/app/routes/table/v8/docs/examples/$.tsx
+++ b/app/routes/table/v8/docs/examples/$.tsx
@@ -55,7 +55,7 @@ export default function RouteReactTableDocs() {
           className="flex-1 w-full overflow-hidden lg:rounded-l-2xl shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
         />
       </div>
-      <div className="h-16 lg:mt-2" />
+      <div className="lg:h-16 lg:mt-2" />
     </div>
   )
 }

--- a/app/routes/virtual/v3/docs/examples/$.tsx
+++ b/app/routes/virtual/v3/docs/examples/$.tsx
@@ -52,7 +52,7 @@ export default function RouteReactTableDocs() {
           className="flex-1 w-full overflow-hidden lg:rounded-l-2xl shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
         />
       </div>
-      <div className="h-16 lg:mt-2" />
+      <div className="lg:h-16 lg:mt-2" />
     </div>
   )
 }


### PR DESCRIPTION
Based on this conversation: https://twitter.com/tan_stack/status/1566932860841340929

Current:
<img width="856" alt="Screen Shot 2022-09-06 at 10 14 56 AM" src="https://user-images.githubusercontent.com/6193042/188583014-1892d2ec-e864-47c4-9c73-8f0ff536a9e4.png">


The code sandboxes don't grow in height because the Docs parent is a block on smaller devices. This makes it almost unusable for smaller devices or a laptop side by side.

After: 
<img width="855" alt="Screen Shot 2022-09-06 at 10 13 20 AM" src="https://user-images.githubusercontent.com/6193042/188582688-4b9d91ea-3d3d-494e-b85e-d74c64c3baf4.png">

Also removed a "Spacer" block that is intended to make room for the prev / next nav buttons. On mobile it just created unneeded space between the Subscriber box and the code sandbox.

I think the experience could be even a bit better by creating an alternative subscriber box on smaller devices. Something horizontal instead of vertical.

Note: This should affect all code examples across tanstack, not just the table ones. (Query etc.)