### PR TITLE
fix: typo email partners

### DIFF
--- a/app/routes/query/v4/index.tsx
+++ b/app/routes/query/v4/index.tsx
@@ -406,7 +406,7 @@ export default function ReactQueryRoute() {
                 Query as we are? Let's push the boundaries of Query together!
               </div>
               <a
-                href="mailto:parters@tanstack.com?subject=TanStack Query Partnership"
+                href="mailto:partners@tanstack.com?subject=TanStack Query Partnership"
                 className="text-blue-500 uppercase font-black text-sm"
               >
                 Let's chat

--- a/app/routes/router/v4/index.tsx
+++ b/app/routes/router/v4/index.tsx
@@ -329,7 +329,7 @@ export default function ReactTableRoute() {
               Router as we are? Let's push the boundaries of Router together!
             </div>
             <a
-              href="mailto:parters@tanstack.com?subject=TanStack Router Partnership"
+              href="mailto:partners@tanstack.com?subject=TanStack Router Partnership"
               className="text-blue-500 uppercase font-black text-sm"
             >
               Let's chat

--- a/app/routes/virtual/v3/index.tsx
+++ b/app/routes/virtual/v3/index.tsx
@@ -317,7 +317,7 @@ export default function ReactTableRoute() {
               Virtual as we are? Let's push the boundaries of Virtual together!
             </div>
             <a
-              href="mailto:parters@tanstack.com?subject=TanStack Virtual Partnership"
+              href="mailto:partners@tanstack.com?subject=TanStack Virtual Partnership"
               className="text-blue-500 uppercase font-black text-sm"
             >
               Let's chat


### PR DESCRIPTION
Fix what I assume is a small typo for the partners email links on three pages (https://github.com/search?q=org%3ATanStack+parters&type=code).

Let me know if you need me to rebase or if you squash merge!

