### PR TITLE
Add remark-gfm plugin to mdx option to support table in markdown

### DIFF
--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -56,14 +56,14 @@ export async function fetchRepoFile(
 }
 
 export async function markdownToMdx(content: string) {
-  const { default: rehypeSlug } =
+  const [{ default: rehypeSlug }, { default: remarkGfm }] =
     // @ts-ignore
-    await import('rehype-slug')
+    await Promise.all([import('rehype-slug'), import('remark-gfm')])
 
   const mdx = await bundleMDX<{ title: string }>({
     source: content,
     mdxOptions: (options) => {
-      // options.remarkPlugins = [...(options.remarkPlugins ?? []), rehypeSlug]
+      options.remarkPlugins = [...(options.remarkPlugins ?? []), remarkGfm]
       options.rehypePlugins = [...(options.rehypePlugins ?? []), rehypeSlug]
       return options
     },


### PR DESCRIPTION
### Problem
`mdx-bundler` does not support table in markdown, which causes docs broken.

https://github.com/kentcdodds/mdx-bundler/issues/81

### Solution
Add remark-gfm plugin into MdxBundler option so that it generates a table for markdown.

![localhost_3001_query_v4_docs_comparison](https://user-images.githubusercontent.com/4951716/189361410-0aceb36b-8a2d-4a1f-949a-a99e2aa6743b.png)