### PR TITLE
Router docs template: Rename default export to "router" instead of "table"

### DIFF
--- a/app/routes/virtual/v3/docs/$.tsx
+++ b/app/routes/virtual/v3/docs/$.tsx
@@ -62,7 +62,7 @@ export let meta: MetaFunction = ({ data }) => {
 export const ErrorBoundary = DefaultErrorBoundary
 export const CatchBoundary = DefaultCatchBoundary
 
-export default function RouteReactTableDocs() {
+export default function RouteReactRouterDocs() {
   const { title, code, filePath } = useLoaderData<typeof loader>()
 
   return (


### PR DESCRIPTION
I don't expect this to change or do anything, its more of change of consistency …