### PR TITLE
feat: alias markup as vue syntax highlight

### DIFF
--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -4,6 +4,9 @@ import invariant from 'tiny-invariant'
 import type { Language } from 'prism-react-renderer'
 import Highlight, { defaultProps, Prism } from 'prism-react-renderer'
 
+// @ts-ignore Alias markup as vue highlight
+Prism.languages.vue = Prism.languages.markup;
+
 function getLanguageFromClassName(className: string) {
   const match = className.match(/language-(\w+)/)
   return match ? match[1] : ''
@@ -22,14 +25,14 @@ export const CodeBlock: FC<HTMLAttributes<HTMLPreElement>> = ({ children }) => {
   const code = child.props.children || ''
   return (
     <div className="w-full max-w-full">
-      <Highlight {...defaultProps} code={code.trim()} language={lang || 'bash'}>
+      <Highlight {...defaultProps} code={code.trim()} language={lang}>
         {({ className, tokens, getLineProps, getTokenProps }) => (
           <div className="relative not-prose">
             <div
               className="absolute bg-white text-sm z-10 border border-gray-300 px-2 rounded-md -top-3 right-2
             dark:bg-gray-600 dark:border-0"
             >
-              {lang || 'text'}
+              {lang}
             </div>
             <div
               className="rounded-md font-normal w-full border border-gray-200


### PR DESCRIPTION
Aliasing `markup` as `vue` syntax highlight which is `good-enough`.
Removing lang fallback in jsx as it's already defaulted before.

This can also be aliased in a better way with a small refactor to split code `tag` and `lang` passed to the component, so if you do not like this solution, please let me know.