### PR TITLE
fixes `undefined` rendered into className

### DIFF
--- a/app/components/Mdx.tsx
+++ b/app/components/Mdx.tsx
@@ -41,11 +41,11 @@ const markdownComponents = {
   h4: makeHeading('h4'),
   h5: makeHeading('h5'),
   h6: makeHeading('h6'),
-  code: (props: React.HTMLProps<HTMLElement>) => {
+  code: ({ className = '', ...props }: React.HTMLProps<HTMLElement>) => {
     return (
       <code
         {...props}
-        className={`border border-gray-500 border-opacity-20 bg-gray-500 bg-opacity-10 rounded p-1 ${props.className}`}
+        className={`border border-gray-500 border-opacity-20 bg-gray-500 bg-opacity-10 rounded p-1${className ?? ` ${className}`}`}
       />
     )
   },


### PR DESCRIPTION
Probably a minor thing, but I noticed that `undefined` was being rendered into all code blocks and it was quick and easy to fix, so I fixed it.

| | |
| - | - |
| BEFORE | ![Screenshot_20221031_134311](https://user-images.githubusercontent.com/15232461/199074001-a9eea2b8-7b82-44f7-b067-526e572ade24.png) |
| AFTER | ![Screenshot_20221031_134515](https://user-images.githubusercontent.com/15232461/199074399-64d2372f-39e8-48a3-a2c7-d1a715c9928d.png) |

Here's a more in-context screenshot:
![Screenshot_20221031_133757](https://user-images.githubusercontent.com/15232461/199074537-5842e037-9405-4c5a-add0-d2cd9b638c8e.png)



