### PR TITLE
(fix: docs) - Switcher unselectable on mobile/tablet

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -124,9 +124,9 @@ export function Docs({
           border-t border-gray-500 border-opacity-20 bg-gray-100 text-lg
           dark:bg-gray-900"
         >
+          {framework ? <FrameworkSelect framework={framework} availableFrameworks={availableFrameworks} /> : null }
           {menuItems}
         </div>
-        {framework ? <FrameworkSelect framework={framework} availableFrameworks={availableFrameworks} /> : null }
       </details>
     </div>
   );


### PR DESCRIPTION
The current framework switcher position in mobile and tablet view prevents it from being selectable. Here is a video of the current behavior. 

https://user-images.githubusercontent.com/45807386/208134155-a1b334ec-0b2a-46dd-9cce-86c5280c8b63.mov

This PR just just places the framework switcher at the top of the menu. 

https://user-images.githubusercontent.com/45807386/208134376-92151a9c-98a5-4551-a4dd-4ecea468ae79.mov

This change doesn't affect anything on desktop view since the sidebar menu for it is a separate component. Please let me know if you have any questions, concerns regarding this change and I'll be sure to answer them ASAP.