### PR TITLE
feat: content replacement mechanism for referenced files

### DIFF
--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -23,55 +23,107 @@ export type DocFrontMatter = {
 async function fetchRemote(owner: string, repo: string, ref: string, filepath: string) {
   const href = new URL(`${owner}/${repo}/${ref}/${filepath}`, 'https://raw.githubusercontent.com/').href
   console.log('fetching file', href)
-  
+
   const response = await fetch(href, {
     headers: { 'User-Agent': `docs:${owner}/${repo}` },
   })
 
   if (!response.ok) {
-    return null;
+    return null
   }
 
   return await response.text()
 }
 
-export async function fetchRepoFile(
-  repoPair: string,
-  ref: string,
-  filepath: string
-) {
+async function fetchFs(repo: string, filepath: string) {
+  const localFilePath = path.resolve(__dirname, `../../${repo}`, filepath)
+
+  console.log('local path', __dirname, filepath, localFilePath)
+  const file = await fsp.readFile(localFilePath)
+  return file.toString()
+}
+
+function replaceContent(text: string, frontmatter: graymatter.GrayMatterFile<string>) {
+  let result = text
+  const replace = frontmatter.data.replace as Record<string, string> | undefined
+  if (replace) {
+    Object.entries(replace).forEach(([key, value]) => {
+      result = result.replace(new RegExp(key, 'g'), value)
+    })
+  }
+
+  return result
+}
+
+function replaceSections(text: string, frontmatter: graymatter.GrayMatterFile<string>) {
+  let result = text
+  const sectionRegex = /\[\/\/\]: # \(([a-zA-Z]*)\)[\S\s]*?\[\/\/\]: # \(([a-zA-Z]*)\)/g
+
+  const substitutes = new Map<string, RegExpMatchArray>()
+  for (const match of frontmatter.content.matchAll(sectionRegex)) {
+    substitutes.set(match[1], match)
+  }
+
+  if (substitutes.size > 0) {
+    const sections = new Map<string, RegExpMatchArray>()
+    for (const match of result.matchAll(sectionRegex)) {
+      sections.set(match[1], match)
+    }
+
+    Array.from(substitutes.entries())
+      .reverse()
+      .forEach(([key, value]) => {
+        const sectionMatch = sections.get(key)
+        if (sectionMatch) {
+          result =
+            result.slice(0, sectionMatch.index!) +
+            value[0] +
+            result.slice(sectionMatch.index! + sectionMatch[0].length, result.length)
+        }
+      })
+  }
+
+  return result
+}
+
+export async function fetchRepoFile(repoPair: string, ref: string, filepath: string) {
   const key = `${repoPair}:${ref}:${filepath}`
   let [owner, repo] = repoPair.split('/')
 
+  const ttl = process.env.NODE_ENV === 'development' ? 1 : 1 * 60 * 1000 // 5 minute
   const file = await fetchCached({
     key,
-    ttl: 1 * 60 * 1000, // 5 minute
+    ttl,
     fn: async () => {
-      const maxDepth = 4;
-      let currentDepth = 1;
+      const maxDepth = 4
+      let currentDepth = 1
+      let originFrontmatter: graymatter.GrayMatterFile<string> | undefined
       while (maxDepth > currentDepth) {
-        let text: string | null;
+        let text: string | null
         if (process.env.NODE_ENV === 'development') {
-          const localFilePath = path.resolve(__dirname, `../../${repo}`, filepath)
-
-          console.log('local path', __dirname, filepath, localFilePath)
-          const file = await fsp.readFile(localFilePath)
-          text = file.toString()
+          text = await fetchFs(repo, filepath)
         } else {
-          text = await fetchRemote(owner, repo, ref, filepath);
+          text = await fetchRemote(owner, repo, ref, filepath)
         }
-        
+
         if (text === null) {
-          return null;
+          return null
         }
         try {
           const frontmatter = extractFrontMatter(text)
-          if (!frontmatter.data.ref) return Promise.resolve(text)
+          if (!frontmatter.data.ref) {
+            if (originFrontmatter) {
+              text = replaceContent(text, originFrontmatter)
+              text = replaceSections(text, originFrontmatter)
+            }
+            return Promise.resolve(text)
+          }
           filepath = frontmatter.data.ref
+          originFrontmatter = frontmatter
         } catch (error) {
           return Promise.resolve(text)
         }
-        currentDepth++;
+        currentDepth++
       }
 
       return null
@@ -100,7 +152,6 @@ export async function markdownToMdx(content: string) {
 
 export function extractFrontMatter(content: string) {
   return graymatter.default(content, {
-    excerpt: (file: any) =>
-      (file.excerpt = file.content.split('\n').slice(0, 4).join('\n')),
+    excerpt: (file: any) => (file.excerpt = file.content.split('\n').slice(0, 4).join('\n')),
   })
 }


### PR DESCRIPTION
This PR adds two content replacement mechanism for documentation files (`origin`) that are referencing other files (`target`).
You can reference another file by adding `ref` directive in front-matter (ex. `ref: docs/react/quick-start.md`).

1. Simple string replacement
    - Add `replace` directive to front-matter in `origin` file with a `key-value` map of strings that should be replaced in the `target` file.
      ```
      replace: {
        'replace this': 'with this',
      }
      ```
2. Content section replacement
    - Section token is a pair of tokens following this pattern (This is a comment syntax for markdown files)
      ```
      [//]: # (Example)
      example section content
      [//]: # (Example)
      ```
    - Mark sections that can be replaced in the `target` file with section tokens
    - Provide new content for specific sections in `origin` file
    - Section can contain multi line markdown content

    Ex.
    `target` file `docs/react/overview.md`
    ```
    ---
    id: overview
    title: Overview
    ---
    Some line containing replace this string
    [//]: # (Example)
    This multiline markdown will be replaced
    With the content from origin file
    [//]: # (Example)
    ```

    `origin` file `docs/vue/overview.md`
    ```
    ---
    id: overview
    title: Overview
    ref: docs/react/overview.md
    replace: {
      'replace this': 'with this',
    }
    ---
    [//]: # (Example)
    This is content that will be inserted in place of old content
    [//]: # (Example)
    ```

    `result`
    ```
    ---
    id: overview
    title: Overview
    ---
    Some line containing with this string
    [//]: # (Example)
    This is content that will be inserted in place of old content
    [//]: # (Example)
    ```