### PR TITLE
fix: change replacement token

### DIFF
--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -77,7 +77,7 @@ function replaceSections(text: string, frontmatter: graymatter.GrayMatterFile<st
   let result = text
   // RegExp defining token pair to dicover sections in the document
   // [//]: # (<Section Token>)
-  const sectionRegex = /\[\/\/\]: # \(([a-zA-Z\d]*)\)[\S\s]*?\[\/\/\]: # \(([a-zA-Z\d]*)\)/g
+  const sectionRegex = /\[\/\/\]: # '([a-zA-Z\d]*)'[\S\s]*?\[\/\/\]: # '([a-zA-Z\d]*)'/g
 
   // Find all sections in origin file
   const substitutes = new Map<string, RegExpMatchArray>()


### PR DESCRIPTION
Changing token used to perform content replacement due to prettier.
When formatting document token gets changed and would be broken, therefore it's better to align it to the format prefered by prettier