### PR TITLE
✨ feat(Search): add data-theme attr to document

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -47,8 +47,8 @@ export let links: LinksFunction = () => {
       media: '(prefers-color-scheme: dark)',
     },
     {
-			rel: "stylesheet",
-			href: docSearchStyles
+      rel: "stylesheet",
+      href: docSearchStyles
     },
     {
       rel: 'stylesheet',
@@ -122,8 +122,8 @@ function Document({
           }}
         ></script>
 				<script
-					dangerouslySetInnerHTML={{
-						__html: `
+          dangerouslySetInnerHTML={{
+            __html: `
               try {
                 if (matchMedia("(prefers-color-scheme: dark)").matches) {
                   document.documentElement.setAttribute("data-theme", "dark");
@@ -132,7 +132,7 @@ function Document({
                 }
               } catch (error) {}
             `,
-					}}
+          }}
 				></script>
       </head>
       <body>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -47,7 +47,7 @@ export let links: LinksFunction = () => {
       media: '(prefers-color-scheme: dark)',
     },
     {
-      rel: "stylesheet",
+      rel: 'stylesheet',
       href: docSearchStyles
     },
     {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,7 +15,7 @@ import type { LinksFunction, MetaFunction } from '@remix-run/node'
 import styles from './styles/app.generated.css'
 import prismThemeLight from './styles/prismThemeLight.css'
 import prismThemeDark from './styles/prismThemeDark.css'
-import docsearchCss from '@docsearch/css/dist/style.css'
+import docSearchStyles from '@docsearch/css/dist/style.css'
 import { CgSpinner } from 'react-icons/cg'
 
 import { seo } from './utils/seo'
@@ -47,8 +47,8 @@ export let links: LinksFunction = () => {
       media: '(prefers-color-scheme: dark)',
     },
     {
-      rel: 'stylesheet',
-      href: docsearchCss,
+			rel: "stylesheet",
+			href: docSearchStyles
     },
     {
       rel: 'stylesheet',
@@ -121,6 +121,19 @@ function Document({
             `,
           }}
         ></script>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `
+              try {
+                if (matchMedia("(prefers-color-scheme: dark)").matches) {
+                  document.documentElement.setAttribute("data-theme", "dark");
+                } else {
+                  document.documentElement.removeAttribute('data-theme');
+                }
+              } catch (error) {}
+            `,
+					}}
+				></script>
       </head>
       <body>
         {children}


### PR DESCRIPTION
Based on the [@docsearch/css](https://docsearch.algolia.com/docs/styling/) package[ _variables.css](https://github.com/algolia/docsearch/blob/2c64362067376a76575b7b5131972f71c920a406/packages/docsearch-css/src/_variables.css#L51).

A quick way to add dark mode to the DocSearch component.

Can obviously be improved, but I'd suggest to leave it until there's some work done on allowing to toggle between the themes as a user. @TkDodo needs his dark mode docs search when he's steaming! 