### PR TITLE
docs: add redirects for old adapters pages

### DIFF
--- a/app/routes/query/$.tsx
+++ b/app/routes/query/$.tsx
@@ -9,6 +9,24 @@ export const loader = (context: LoaderArgs) => {
 
 export function handleRedirectsFromV3(context: LoaderArgs) {
   const url = new URL(context.request.url);
+  
+  // Redirect old `adapters` pages
+  const adaptersRedirects = [
+    {from: "docs/react/adapters/vue-query", to: "docs/vue/overview"},
+    {from: "docs/react/adapters/solid-query", to: "docs/solid/overview"},
+    {from: "docs/react/adapters/svelte-query", to: "docs/svelte/overview"},
+  ]
+
+  adaptersRedirects.forEach((item) => {
+    if (url.pathname.startsWith(`/query/v4/${item.from}`)) {
+      throw redirect(
+        `/query/latest/${item.to}`,
+        301
+      );
+    }
+  });
+
+  // Redirect old query v3 docs
   // prettier-ignore
   const reactQueryv3List = [
     // {from: 'api/overview',to: 'docs/guide/overview',},

--- a/app/routes/query/$version/index.tsx
+++ b/app/routes/query/$version/index.tsx
@@ -493,7 +493,7 @@ export default function RouteVersion() {
           </div>
         </div>
 
-        {["svelte"].includes(framework) ? (
+        {[""].includes(framework) ? (
           <div className="px-2">
             <div className="p-8 text-center text-lg w-full max-w-screen-lg mx-auto bg-black text-white rounded-xl">
               Looking for the <strong>@tanstack/{framework}-query</strong>{" "}


### PR DESCRIPTION
@TkDodo 
- redirect old adapters pages to proper url with latest version
- show svelte adapter sandbox on main query page