### PR TITLE
fix: a11y - code blocks should have keyboard access

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -132,3 +132,8 @@
 .carbon-small .carbon-wrap .carbon-poweredby {
   @apply absolute bottom-0 right-0;
 }
+
+code[class*="language-"] {
+  white-space: pre-wrap;
+  word-break: break-all;
+}


### PR DESCRIPTION
Code blocks on TanStack sites currently fail accessibility tests due to this issue:

https://dequeuniversity.com/rules/axe/3.5/scrollable-region-focusable

The reason is that the content is not visible when the code block overflows, like so:

<img width="821" alt="Screenshot 2023-04-28 at 22 55 51" src="https://user-images.githubusercontent.com/12116098/235261179-0b700e88-21a7-4b14-b328-5bd0a0d5f8b3.png">

This style change makes the code block wrap so that it does not overflow, like this:

<img width="819" alt="Screenshot 2023-04-28 at 22 56 21" src="https://user-images.githubusercontent.com/12116098/235261219-807da317-f952-4d11-909c-fc05f3c40562.png">

This fixes the issue and makes it much more usable on mobile I think.