### PR TITLE
docs: fixed sidebar issue

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -50,7 +50,6 @@ export function Docs({
   v2?: boolean
 }) {
   const matches = useMatches()
-  console.log(matches)
   const lastMatch = last(matches)
 
   const detailsRef = React.useRef<HTMLElement>(null!)
@@ -70,6 +69,15 @@ export function Docs({
   const index = flatMenu.findIndex((d) => d.to === relativePathname)
   const prevItem = flatMenu[index - 1]
   const nextItem = flatMenu[index + 1]
+  
+  document.body.style.overflow = 'visible'
+  const toggleBodyOverflow = () => {
+    if (detailsRef.current?.hasAttribute('open')) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'visible'
+    }
+  }
 
   const menuItems = config.menu.map((group, i) => {
     return (
@@ -147,6 +155,7 @@ export function Docs({
         ref={detailsRef as any}
         id="docs-details"
         className="border-b border-gray-500 border-opacity-20"
+        onToggle={toggleBodyOverflow}
       >
         <summary className="p-4 flex gap-2 items-center justify-between">
           <div className="flex gap-2 items-center text-xl md:text-2xl">
@@ -157,9 +166,9 @@ export function Docs({
           <Search {...config.docSearch} />
         </summary>
         <div
-          className="flex flex-col gap-4 p-4 whitespace-nowrap h-[0vh] overflow-y-auto
+          className="flex flex-col gap-4 p-4 whitespace-nowrap
           border-t border-gray-500 border-opacity-20 bg-gray-100 text-lg
-          dark:bg-gray-900"
+          dark:bg-gray-900 h-[100vh] overflow-y-auto pb-24"
         >
           <div className="flex gap-4">
             {framework?.selected ? (

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -83,10 +83,6 @@
     display: none;
   }
 
-  #docs-details[open] > summary + * {
-    height: 80vh;
-  }
-
   .anchor-heading {
     text-decoration: none !important;
   }


### PR DESCRIPTION
PR for Issue #82  
Fixes: 
- Sidebar is now full height and is displaying properly on all devices in Chrome DevTools
- Body overflow is turned off when sidebar is displayed to prevent double scrollbar issues

**Why not simply remove the overflow from the body and keep scrolling only inside scroll containers?** 
In order to preserve the functionality of `<ScrollRestoration />` on mobile, I needed to keep body overflow visible. Otherwise, we would lost the "scroll back to top" functionality on navigation between pages

**Why do we set `document.body.style.overflow = 'visible'` inside `Docs.tsx`?**
Since the `toggleBodyOverflow` function works only when sidebar is toggled on/off and does not return the body overflow value to `visible` if navigated to the main page (clicking on the logo), we have to set it explicitly to `visible` in the component itself. 

☝️ if you are aware of a better approach, please let me know, I would be happy to implement it :) 

