### PR TITLE
fix: place carbon ads on the right hand side and not left menu sidebar

### DIFF
--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -218,9 +218,6 @@ export function Docs({
       <div className="flex-1 flex flex-col gap-4 px-4 whitespace-nowrap overflow-y-auto text-base pb-[300px]">
         {menuItems}
       </div>
-      <div className="carbon-small absolute bottom-0 w-full">
-        <Carbon />
-      </div>
     </div>
   )
 
@@ -312,6 +309,9 @@ export function Docs({
               <BytesForm />
             </li>
           </ul>
+        </div>
+        <div className="carbon-small p-6 fixed bottom-0">
+          <Carbon />
         </div>
       </aside>
     </div>

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -4,7 +4,6 @@ import { Link, NavLink, Outlet } from '@remix-run/react'
 import { MetaFunction } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
 import { DefaultCatchBoundary } from '~/components/DefaultCatchBoundary'
-import { Carbon } from '~/components/Carbon'
 import { seo } from '~/utils/seo'
 
 export const ErrorBoundary = DefaultErrorBoundary
@@ -117,9 +116,6 @@ export default function RouteBlog() {
       <div></div>
       <div className="flex-1 flex flex-col gap-4 px-4 whitespace-nowrap overflow-y-auto text-base">
         {menuItems}
-      </div>
-      <div className="carbon-small absolute bottom-0 w-full">
-        <Carbon />
       </div>
     </div>
   )

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -118,7 +118,7 @@
 }
 
 .carbon-small .carbon-wrap .carbon-img {
-  @apply w-[50%] pt-2 !pointer-events-auto rounded-tr-lg border-t border-r border-gray-500 border-opacity-10 overflow-hidden;
+  @apply w-[50%] pt-2 !pointer-events-auto rounded-tl-lg border-t border-r border-gray-500 border-opacity-10 overflow-hidden place-items-end;
 }
 
 .carbon-small .carbon-wrap .carbon-img img {
@@ -126,14 +126,14 @@
 }
 
 .carbon-small .carbon-wrap .carbon-text {
-  @apply bg-white dark:bg-gray-800 rounded-tr-lg !pb-6 !m-0 !pointer-events-auto border-t border-r border-gray-500 border-opacity-10;
+  @apply bg-white dark:bg-gray-800 rounded-tl-lg !pb-6 !m-0 !pointer-events-auto border-t border-r border-gray-500 border-opacity-10;
 }
 
 .carbon-small .carbon-wrap .carbon-poweredby {
   @apply absolute bottom-0 right-0;
 }
 
-code[class*="language-"] {
+code[class*='language-'] {
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/app/styles/carbon.css
+++ b/app/styles/carbon.css
@@ -30,7 +30,7 @@
 }
 #carbonads .carbon-img {
   display: block;
-  margin: 0;
+  margin: 0 0 0 147px;
   line-height: 1;
 }
 #carbonads .carbon-img img {


### PR DESCRIPTION
Before:

![image](https://github.com/TanStack/tanstack.com/assets/26438624/9634e290-ef09-46a8-b7aa-bf8811090e5f)

After:

![image](https://github.com/TanStack/tanstack.com/assets/26438624/6faad250-4b6d-4aba-8ed4-cb09acf54a7c)


Small fix,  place carbon ads on the right sidebar so that they do not interfere with the left sidebar menu navigation ..