### PR TITLE
Docs sidebar callout + style tweaks

### DIFF
--- a/app/components/BytesForm.tsx
+++ b/app/components/BytesForm.tsx
@@ -10,24 +10,25 @@ export default function BytesForm() {
   return (
     <form onSubmit={handleSubmit}>
       <div data-element="fields" className="grid relative">
-        <figure
-          className="absolute right-0"
-          style={{ bottom: '72px', right: '-10px' }}
-        >
-          <img
-            height={40}
-            width={40}
-            src={require('../images/bytes.svg')}
-            alt="Bytes"
+        <div className="relative">
+          <figure
+            className="absolute right-[-8px] bottom-3 md:bottom-4"
+          >
+            <img
+              height={38}
+              width={38}
+              src={require('../images/bytes.svg')}
+              alt="Bytes"
+            />
+          </figure>
+          <input
+            className="text-xs md:text-base border border-black/50 dark:border-white/50 rounded p-2 mb-1 md:mb-2 w-full bg-transparent"
+            name="email_address"
+            placeholder="Your email address"
+            type="email"
+            required
           />
-        </figure>
-        <input
-          className="text-xs md:text-base border border-black/50 dark:border-white/50 rounded p-2 mb-1 md:mb-2 w-full bg-transparent"
-          name="email_address"
-          placeholder="Your email address"
-          type="email"
-          required
-        />
+        </div>
         <button
           type="submit"
           className="text-xs md:text-base mb-4 border rounded bg-rose-600 border-none text-white p-2"

--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -21,7 +21,7 @@ export function Doc({
       <div className="h-4" />
       <div className="h-px bg-gray-500 opacity-20" />
       <div className="h-4" />
-      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none">
+      <div className="prose prose-gray prose-md dark:prose-invert max-w-none">
         <Mdx code={code} />
       </div>
       <div className="h-12" />

--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -288,8 +288,7 @@ export function Docs({
             </div>
           </div>
         </div>
-        {/* TODO: Is there a better way to do this? */}
-          <div className="p-4 max-w-[240px] shrink-0 border-l hidden md:block">
+          <div className="p-4 max-w-[240px] shrink-0 border-l border-gray-200 dark:border-white/10 hidden md:block">
           {config?.docSearch?.indexName?.includes('query') ? (
               <DocsCalloutQueryGG />
             ) : (

--- a/app/components/Docs.tsx
+++ b/app/components/Docs.tsx
@@ -12,12 +12,11 @@ import { last } from '~/utils/utils'
 import { Carbon } from './Carbon'
 import { LinkOrA } from './LinkOrA'
 import { Search } from './Search'
-import { gradientText } from '~/routes/query/$version/index'
-import BytesForm from './BytesForm'
 import type { SelectProps } from './Select'
 import { Select } from './Select'
 import { useLocalStorage } from '~/utils/useLocalStorage'
-import { LogoQueryGGSmall } from '~/components/LogoQueryGGSmall'
+import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
+import { DocsCalloutBytes } from '~/components/DocsCalloutBytes'
 
 export type DocsConfig = {
   docSearch: {
@@ -233,128 +232,112 @@ export function Docs({
   )
 
   return (
-    <div className="min-h-screen flex flex-col lg:flex-row w-full">
+    <div className="max-w-[1400px] min-h-screen mx-auto flex flex-col lg:flex-row w-full">
       {smallMenu}
       {largeMenu}
-      <div className="flex-1 min-w-0 min-h-0 flex relative justify-center">
-        {children || <Outlet />}
-        <div
-          className="fixed bottom-0 left-0 right-0
-                      lg:pl-[250px] z-10"
-        >
-          <div className="p-4 flex justify-center gap-4">
-            {prevItem ? (
-              <LinkOrA
-                to={
-                  v2
-                    ? prevItem.to
-                    : framework
-                    ? `../${prevItem.to}`
-                    : prevItem.to
-                }
-                className="flex gap-2 items-center py-1 px-2 text-sm self-start rounded-md
-              bg-white text-gray-600 dark:bg-black dark:text-gray-400
-              shadow-lg dark:border dark:border-gray-800
-              lg:text-lg"
-              >
-                <FaArrowLeft /> {prevItem.label}
-              </LinkOrA>
-            ) : null}
-            {nextItem ? (
-              <LinkOrA
-                to={
-                  v2
-                    ? nextItem.to
-                    : framework
-                    ? `../${nextItem.to}`
-                    : nextItem.to
-                }
-                className="py-1 px-2 text-sm self-end rounded-md
-                bg-white dark:bg-black
-                shadow-lg dark:border dark:border-gray-800
-                lg:text-lg
-                "
-              >
-                <div className="flex gap-2 items-center font-bold">
-                  <span
-                    className={`bg-gradient-to-r ${colorFrom} ${colorTo} bg-clip-text text-transparent`}
-                  >
-                    {nextItem.label}
-                  </span>{' '}
-                  <FaArrowRight className={textColor} />
-                </div>
-              </LinkOrA>
-            ) : null}
-          </div>
-        </div>
-      </div>
-      {showBytes ? (
-        <div className="w-[300px] max-w-[350px] fixed top-1/2 right-2 z-30 -translate-y-1/2 shadow-lg">
-          <div className="bg-white dark:bg-gray-800 border border-black/10 dark:border-white/10 p-4 md:p-6 rounded-lg">
-            {config?.docSearch?.indexName?.includes('query') ? (
-              <div className="space-y-4">
-                <h6 className="text-[.7rem] md:text-[.9em] uppercase font-black">
-                  Want to Skip the Docs?
-                </h6>
-                <LogoQueryGGSmall className="w-full" />
-                <blockquote className="text-sm -indent-[.45em] pl-2">
-                  “This course is the best way to learn how to use React Query in real-world applications.”
-                  <cite className="italic block text-right">—Tanner Linsley</cite>
-                </blockquote>
-                <a
-                  className="block w-full px-4 py-2 bg-gradient-to-r from-rose-500 to-violet-500 text-white rounded uppercase font-bold text-sm text-center"
-                  href="https://query.gg?from=tanstack"
-                  target="_blank"
-                  rel="noreferrer"
-                >Check it out</a>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                <div className="space-y-1 md:space-y-2">
-                  <h6 className="text-[.7rem] md:text-[.9em] uppercase font-black">
-                    Subscribe to Bytes
-                  </h6>
-                  <p className="text-xs md:text-sm">
-                    Your weekly dose of JavaScript news. Delivered every Monday to
-                    over 100,000 devs, for free.
-                  </p>
-                </div>
-                <BytesForm />
-              </div>
-            )}
-            <button
-              className="absolute top-0 right-0 p-2 hover:text-red-500 opacity:30 hover:opacity-100"
-              onClick={() => {
-                setShowBytes(false)
-              }}
-            >
-              <FaTimes />
-            </button>
-          </div>
-        </div>
-      ) : (
-        <button
-          className="fixed right-0 top-1/2 -translate-y-[50px] "
-          onClick={() => {
-            setShowBytes(true)
-          }}
-        >
+      <div className="flex w-full lg:w-[calc(100%-250px)]">
+        <div className="min-w-0 min-h-0 flex relative justify-center">
+          {children || <Outlet />}
           <div
-            className="origin-bottom-right -rotate-90 text-xs bg-white dark:bg-gray-800 border border-gray-100
-          hover:bg-rose-600 hover:text-white p-1 px-2 rounded-t-md shadow-md dark:border-0"
+            className="fixed bottom-0 left-0 right-0
+                        lg:pl-[250px] z-10"
           >
-            {config?.docSearch?.indexName?.includes('query') ? (
-              <>
-                <strong><span role="img" aria-label="crystal ball">&#128302;</span> Skip the docs?</strong>
-              </>
+            <div className="p-4 flex justify-center gap-4">
+              {prevItem ? (
+                <LinkOrA
+                  to={
+                    v2
+                      ? prevItem.to
+                      : framework
+                      ? `../${prevItem.to}`
+                      : prevItem.to
+                  }
+                  className="flex gap-2 items-center py-1 px-2 text-sm self-start rounded-md
+                bg-white text-gray-600 dark:bg-black dark:text-gray-400
+                shadow-lg dark:border dark:border-gray-800
+                lg:text-lg"
+                >
+                  <FaArrowLeft /> {prevItem.label}
+                </LinkOrA>
+              ) : null}
+              {nextItem ? (
+                <LinkOrA
+                  to={
+                    v2
+                      ? nextItem.to
+                      : framework
+                      ? `../${nextItem.to}`
+                      : nextItem.to
+                  }
+                  className="py-1 px-2 text-sm self-end rounded-md
+                  bg-white dark:bg-black
+                  shadow-lg dark:border dark:border-gray-800
+                  lg:text-lg
+                  "
+                >
+                  <div className="flex gap-2 items-center font-bold">
+                    <span
+                      className={`bg-gradient-to-r ${colorFrom} ${colorTo} bg-clip-text text-transparent`}
+                    >
+                      {nextItem.label}
+                    </span>{' '}
+                    <FaArrowRight className={textColor} />
+                  </div>
+                </LinkOrA>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {/* TODO: Is there a better way to do this? */}
+          <div className="p-4 max-w-[240px] shrink-0 border-l hidden md:block">
+          {config?.docSearch?.indexName?.includes('query') ? (
+              <DocsCalloutQueryGG />
             ) : (
-              <>
-                Subscribe to <strong>Bytes</strong>
-              </>
+              <DocsCalloutBytes />
             )}
           </div>
-        </button>
-      )}
+        {showBytes ? (
+          <div className="w-[300px] max-w-[350px] fixed md:hidden top-1/2 right-2 z-30 -translate-y-1/2 shadow-lg">
+            <div className="bg-white dark:bg-gray-800 border border-black/10 dark:border-white/10 p-4 md:p-6 rounded-lg">
+              {config?.docSearch?.indexName?.includes('query') ? (
+                <DocsCalloutQueryGG />
+              ) : (
+                <DocsCalloutBytes />
+              )}
+              <button
+                className="absolute top-0 right-0 p-2 hover:text-red-500 opacity:30 hover:opacity-100"
+                onClick={() => {
+                  setShowBytes(false)
+                }}
+              >
+                <FaTimes />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            className="right-0 top-1/2 -translate-y-[50px] fixed md:hidden"
+            onClick={() => {
+              setShowBytes(true)
+            }}
+          >
+            <div
+              className="origin-bottom-right -rotate-90 text-xs bg-white dark:bg-gray-800 border border-gray-100
+            hover:bg-rose-600 hover:text-white p-1 px-2 rounded-t-md shadow-md dark:border-0"
+            >
+              {config?.docSearch?.indexName?.includes('query') ? (
+                <>
+                  <strong><span role="img" aria-label="crystal ball">&#128302;</span> Skip the docs?</strong>
+                </>
+              ) : (
+                <>
+                  Subscribe to <strong>Bytes</strong>
+                </>
+              )}
+            </div>
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/components/DocsCalloutBytes.tsx
+++ b/app/components/DocsCalloutBytes.tsx
@@ -1,0 +1,18 @@
+import BytesForm from '~/components/BytesForm'
+
+export function DocsCalloutBytes(props: React.HTMLProps<HTMLDivElement>) {
+  return (
+    <div className="space-y-4" {...props}>
+      <div className="space-y-1 md:space-y-2">
+        <h6 className="text-[.7rem] md:text-[.9em] uppercase font-black">
+          Subscribe to Bytes
+        </h6>
+        <p className="text-xs md:text-sm">
+          Your weekly dose of JavaScript news. Delivered every Monday to
+          over 100,000 devs, for free.
+        </p>
+      </div>
+      <BytesForm />
+    </div>
+  )
+}

--- a/app/components/DocsCalloutQueryGG.tsx
+++ b/app/components/DocsCalloutQueryGG.tsx
@@ -1,0 +1,22 @@
+import { LogoQueryGGSmall } from '~/components/LogoQueryGGSmall'
+
+export function DocsCalloutQueryGG(props: React.HTMLProps<HTMLDivElement>) {
+  return (
+    <div className="space-y-4" {...props}>
+      <h6 className="text-[.7rem] md:text-[.9em] uppercase font-black">
+        Want to Skip the Docs?
+      </h6>
+      <LogoQueryGGSmall className="w-full" />
+      <blockquote className="text-sm -indent-[.45em] pl-2">
+        “This course is the best way to learn how to use React Query in real-world applications.”
+        <cite className="italic block text-right">—Tanner Linsley</cite>
+      </blockquote>
+      <a
+        className="block w-full px-4 py-2 bg-gradient-to-r from-rose-500 to-violet-500 text-white rounded uppercase font-bold text-sm text-center"
+        href="https://query.gg?from=tanstack"
+        target="_blank"
+        rel="noreferrer"
+      >Check it out</a>
+    </div>
+  )
+}

--- a/app/routes/query/$version/index.tsx
+++ b/app/routes/query/$version/index.tsx
@@ -17,7 +17,7 @@ import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import { VscPreview, VscWand } from 'react-icons/vsc'
 import { TbHeartHandshake } from 'react-icons/tb'
-import SponsorPack from '~/components/SponsorPack'
+// import SponsorPack from '~/components/SponsorPack'
 import { PPPBanner } from '~/components/PPPBanner'
 import { getBranch, latestVersion, repo } from '~/routes/query'
 import { Logo } from '~/components/Logo'
@@ -79,18 +79,18 @@ const menu = [
   },
 ]
 
-export const loader = async (context: LoaderArgs) => {
-  const { getSponsorsForSponsorPack } = require('~/server/sponsors')
+// export const loader = async (context: LoaderArgs) => {
+//   const { getSponsorsForSponsorPack } = require('~/server/sponsors')
 
-  const sponsors = await getSponsorsForSponsorPack()
+//   const sponsors = await getSponsorsForSponsorPack()
 
-  return json({
-    sponsors,
-  })
-}
+//   return json({
+//     sponsors,
+//   })
+// }
 
 export default function RouteVersion() {
-  const { sponsors } = useLoaderData<typeof loader>()
+  // const { sponsors } = useLoaderData<typeof loader>()
   const { version } = useParams()
   const branch = getBranch(version)
   const [framework, setFramework] = React.useState<Framework>('react')
@@ -432,7 +432,7 @@ export default function RouteVersion() {
               aspectRatio: '1/1',
             }}
           >
-            <SponsorPack sponsors={sponsors} />
+            {/* <SponsorPack sponsors={sponsors} /> */}
           </div>
           <div className="text-center">
             <a

--- a/app/routes/query/$version/index.tsx
+++ b/app/routes/query/$version/index.tsx
@@ -17,7 +17,7 @@ import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import { VscPreview, VscWand } from 'react-icons/vsc'
 import { TbHeartHandshake } from 'react-icons/tb'
-// import SponsorPack from '~/components/SponsorPack'
+import SponsorPack from '~/components/SponsorPack'
 import { PPPBanner } from '~/components/PPPBanner'
 import { getBranch, latestVersion, repo } from '~/routes/query'
 import { Logo } from '~/components/Logo'
@@ -79,18 +79,18 @@ const menu = [
   },
 ]
 
-// export const loader = async (context: LoaderArgs) => {
-//   const { getSponsorsForSponsorPack } = require('~/server/sponsors')
+export const loader = async (context: LoaderArgs) => {
+  const { getSponsorsForSponsorPack } = require('~/server/sponsors')
 
-//   const sponsors = await getSponsorsForSponsorPack()
+  const sponsors = await getSponsorsForSponsorPack()
 
-//   return json({
-//     sponsors,
-//   })
-// }
+  return json({
+    sponsors,
+  })
+}
 
 export default function RouteVersion() {
-  // const { sponsors } = useLoaderData<typeof loader>()
+  const { sponsors } = useLoaderData<typeof loader>()
   const { version } = useParams()
   const branch = getBranch(version)
   const [framework, setFramework] = React.useState<Framework>('react')
@@ -432,7 +432,7 @@ export default function RouteVersion() {
               aspectRatio: '1/1',
             }}
           >
-            {/* <SponsorPack sponsors={sponsors} /> */}
+            <SponsorPack sponsors={sponsors} />
           </div>
           <div className="text-center">
             <a

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -104,7 +104,7 @@
     margin-bottom: 0 !important;
   }
 
-  .anchor-heading + p {
+  .anchor-heading + * {
     margin-top: 0 !important;
   }
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -99,6 +99,14 @@
   .anchor-heading:hover > *:after {
     @apply opacity-50;
   }
+
+  :has(+ .anchor-heading) {
+    margin-bottom: 0 !important;
+  }
+
+  .anchor-heading + p {
+    margin-top: 0 !important;
+  }
 }
 
 .carbon-small {


### PR DESCRIPTION
### Overview

This PR:
- Adds sidebar to docs pages at medium+ viewport widths
  - query.gg callout on Query docs pages
  - Bytes callout on all other docs pages
  - Fixed, dismissible callout remains for small viewports
- Improves readability of docs pages
  - Increases main column font size
  - Adds max-width to container to restrict line length
  - Reduces margin for headlines within prose
- Adjusts placement of Bytes logo in Bytes signup

### Previews:

**Query docs sidebar (large view):**

![Query-docs-sidebar-large](https://github.com/TanStack/tanstack.com/assets/871315/1d96798f-70a2-4b5b-b7d3-8b3d093a0f6b)
![Query-docs-sidebar-dark](https://github.com/TanStack/tanstack.com/assets/871315/199a97c8-c504-47e8-890f-366a2b5e69da)

**Other docs sidebar (large view):**

![Tanstack-docs-sidebar-large](https://github.com/TanStack/tanstack.com/assets/871315/73e6e6d4-e16b-41de-b576-40f1c9417dfc)

**Query docs sidebar (medium):**

![Query-docs-sidebar-medium](https://github.com/TanStack/tanstack.com/assets/871315/4ed42ca9-d015-4715-a598-fc2b6201826c)

**Query docs fixed callout open & closed (small view):**

<p><img width="974" alt="Screen Shot 2023-10-25 at 3 30 41 PM" src="https://github.com/TanStack/tanstack.com/assets/871315/e3aaf1e4-3913-43ba-bdd6-a1ba663ae62d"></p>

**Adjusted Bytes logo placement before & after:**

<img width="1108" alt="Screen Shot 2023-10-25 at 3 32 32 PM" src="https://github.com/TanStack/tanstack.com/assets/871315/728b180b-92d4-4b81-951c-58d509266be3">