### PR TITLE
fix missing space in Router landing

### DIFF
--- a/app/routes/router.v1._index.tsx
+++ b/app/routes/router.v1._index.tsx
@@ -137,7 +137,7 @@ export default function TanStackRouterRoute() {
         >
           <span className="underline decoration-dashed decoration-yellow-500 decoration-3 underline-offset-2">
             Modern and scalable
-          </span>
+          </span>{' '}
           routing for React applications
         </h2>
         <p


### PR DESCRIPTION
This adds back the missing space in the Router landing sub-header.