### PR TITLE
Fix Spacing on TanStack Router Home Page

### DIFF
--- a/app/routes/router.v1._index.tsx
+++ b/app/routes/router.v1._index.tsx
@@ -193,11 +193,11 @@ export default function TanStackRouterRoute() {
             </h3>
             <p className="text-sm text-gray-800 dark:text-gray-200 leading-6">
               Hoist your data fetching and avoid waterfalls with TanStack
-              Router's loader API and get
+              Router's loader API and get{' '}
               <span className="font-semibold text-teal-500 dark:text-teal-400">
                 instant navigations with built-in caching and automatic
                 preloading
-              </span>{' '}
+              </span>
               . Need something more custom? Router's API is{' '}
               <span className="font-semibold text-teal-500 dark:text-teal-400">
                 designed to work with your favorite client-side cache libraries!


### PR DESCRIPTION
This PR fixes some spacing issue on the TanStack Router home page.

## Screenshot of Issue
<img width="300" alt="Screen Shot 2023-12-31 at 10 57 00 AM" src="https://github.com/TanStack/tanstack.com/assets/34516986/80ea0aa9-719a-42b9-be40-96c05cb3d56e">

## Screenshot of Fix
<img width="300" alt="Screen Shot 2023-12-31 at 11 19 59 AM" src="https://github.com/TanStack/tanstack.com/assets/34516986/8bba4b96-68c8-41e6-90a9-4a2ec00207bd">
