### PR TITLE
Fix the page titles for Form and Store

### DIFF
--- a/app/routes/form.$version.docs.$.tsx
+++ b/app/routes/form.$version.docs.$.tsx
@@ -19,7 +19,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
 
 export const meta: MetaFunction = ({ data }) => {
   return seo({
-    title: `${data?.title} | TanStack Query Docs`,
+    title: `${data?.title} | TanStack Form Docs`,
     description: data?.description,
   })
 }

--- a/app/routes/form.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/form.$version.docs.framework.$framework.$.tsx
@@ -19,7 +19,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
 
 export const meta: MetaFunction = ({ data }) => {
   return seo({
-    title: `${data?.title} | TanStack Query Docs`,
+    title: `${data?.title} | TanStack Form Docs`,
     description: data?.description,
   })
 }

--- a/app/routes/form.$version.docs.framework.$framework.tsx
+++ b/app/routes/form.$version.docs.framework.$framework.tsx
@@ -5,7 +5,7 @@ import { Outlet } from '@remix-run/react'
 export const meta: MetaFunction = () => {
   return seo({
     title:
-      'TanStack Query Docs | React Query, Solid Query, Svelte Query, Vue Query',
+      'TanStack Form Docs | React Form, Solid Form, Svelte Form, Vue Form',
   })
 }
 

--- a/app/routes/store.$version.docs.$.tsx
+++ b/app/routes/store.$version.docs.$.tsx
@@ -19,7 +19,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
 
 export const meta: MetaFunction = ({ data }) => {
   return seo({
-    title: `${data?.title} | TanStack Query Docs`,
+    title: `${data?.title} | TanStack Store Docs`,
     description: data?.description,
   })
 }

--- a/app/routes/store.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/store.$version.docs.framework.$framework.$.tsx
@@ -19,7 +19,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
 
 export const meta: MetaFunction = ({ data }) => {
   return seo({
-    title: `${data?.title} | TanStack Query Docs`,
+    title: `${data?.title} | TanStack Store Docs`,
     description: data?.description,
   })
 }

--- a/app/routes/store.$version.docs.framework.$framework.tsx
+++ b/app/routes/store.$version.docs.framework.$framework.tsx
@@ -5,7 +5,7 @@ import { Outlet } from '@remix-run/react'
 export const meta: MetaFunction = () => {
   return seo({
     title:
-      'TanStack Query Docs | React Query, Solid Query, Svelte Query, Vue Query',
+      'TanStack Store Docs | React Store, Solid Store, Svelte Store, Vue Store',
   })
 }
 


### PR DESCRIPTION
Some of the pages for `TanStack/Form` and `TanStack/Store` had wrong titles:

<img width="436" alt="image" src="https://github.com/TanStack/tanstack.com/assets/43729152/b33e318b-b292-4f2c-b8b7-931e05c80e75">
