### PR TITLE
Fix: Change "Router" to "Ranger" in Ranger homepage partner section

### DIFF
--- a/app/routes/ranger.v1._index.tsx
+++ b/app/routes/ranger.v1._index.tsx
@@ -255,7 +255,7 @@ export default function TanStackRouterRoute() {
                         dark:bg-gray-800 dark:shadow-none"
         >
           <span className="flex items-center gap-2 p-12 text-4xl text-rose-500 font-black uppercase">
-            Router <TbHeartHandshake /> You?
+            Ranger <TbHeartHandshake /> You?
           </span>
           <div className="flex flex-col p-4 gap-4">
             <div>


### PR DESCRIPTION
Text in the Tanstack Ranger home page was referring to it as "Router" instead of "Ranger"

https://tanstack.com/ranger/v1#:~:text=Partners-,ROUTER,-YOU%3F

![image](https://github.com/TanStack/tanstack.com/assets/100495707/3790191f-15bf-4e16-8252-4e54fce5eea5)
