### PR TITLE
feat: Standardize the config format of TanStack project docs

### DIFF
--- a/app/projects/form.tsx
+++ b/app/projects/form.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Link, useMatches, useNavigate, useParams } from '@remix-run/react'
-import { generatePath, useMatchesData } from '~/utils/utils'
+import { generatePath } from '~/utils/utils'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -8,30 +8,7 @@ import svelteLogo from '~/images/svelte-logo.svg'
 import angularLogo from '~/images/angular-logo.svg'
 import { FaDiscord, FaGithub } from 'react-icons/fa/index'
 import type { AvailableOptions } from '~/components/Select'
-import type { ReactNode } from 'react'
-
-export type FrameworkMenu = {
-  framework: string
-  menuItems: MenuItem[]
-}
-
-export type MenuItem = {
-  label: string | ReactNode
-  children: {
-    label: string | ReactNode
-    to: string
-  }[]
-}
-
-export type GithubDocsConfig = {
-  docSearch: {
-    appId: string
-    apiKey: string
-    indexName: string
-  }
-  menu: MenuItem[]
-  frameworkMenus: FrameworkMenu[]
-}
+import type { ConfigSchema, MenuItem } from '~/utils/config'
 
 export type Framework = 'react' | 'svelte' | 'vue' | 'solid'
 
@@ -98,7 +75,7 @@ export function getBranch(argVersion?: string) {
   return ['latest', latestVersion].includes(version) ? latestBranch : version
 }
 
-export const useReactFormDocsConfig = () => {
+export const useReactFormDocsConfig = (config: ConfigSchema) => {
   const matches = useMatches()
   const match = matches[matches.length - 1]
   const params = useParams()
@@ -107,17 +84,21 @@ export const useReactFormDocsConfig = () => {
     params.framework || localStorage.getItem('framework') || 'react'
   const navigate = useNavigate()
 
-  const config = useMatchesData(`/form/${version}`) as GithubDocsConfig
-
   const frameworkMenuItems =
-    config.frameworkMenus.find((d) => d.framework === framework)?.menuItems ??
+    config.frameworkMenus?.find((d) => d.framework === framework)?.menuItems ??
     []
 
   const frameworkConfig = useMemo(() => {
-    const availableFrameworks = config.frameworkMenus.reduce(
+    if (!config.frameworkMenus) {
+      return undefined
+    }
+
+    const availableFrameworks = config.frameworkMenus?.reduce(
       (acc: AvailableOptions, menuEntry) => {
-        acc[menuEntry.framework as string] =
-          frameworks[menuEntry.framework as keyof typeof frameworks]
+        if (menuEntry.framework in frameworks) {
+          acc[menuEntry.framework] =
+            frameworks[menuEntry.framework as keyof typeof frameworks]
+        }
         return acc
       },
       { react: frameworks['react'] }
@@ -125,7 +106,7 @@ export const useReactFormDocsConfig = () => {
 
     return {
       label: 'Framework',
-      selected: framework!,
+      selected: framework,
       available: availableFrameworks,
       onSelect: (option: { label: string; value: string }) => {
         const url = generatePath(match.id, {
@@ -171,8 +152,16 @@ export const useReactFormDocsConfig = () => {
     }
   }, [version, match, navigate])
 
+  const docSearch: NonNullable<ConfigSchema['docSearch']> =
+    config.docSearch || {
+      appId: '',
+      apiKey: '',
+      indexName: '',
+    }
+
   return {
     ...config,
+    docSearch,
     menu: [
       localMenu,
       // Merge the two menus together based on their group labels

--- a/app/projects/query.tsx
+++ b/app/projects/query.tsx
@@ -1,6 +1,3 @@
-import { useRouteLoaderData } from '@remix-run/react'
-import type { QueryConfigLoader } from '~/routes/query.$version.docs'
-
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-amber-500'
 
@@ -38,15 +35,3 @@ export function getBranch(argVersion?: string) {
 }
 
 export type Framework = 'angular' | 'react' | 'svelte' | 'vue' | 'solid'
-
-export const useQueryDocsConfig = () => {
-  const queryConfigLoaderData = useRouteLoaderData<QueryConfigLoader>(
-    'routes/query.$version.docs'
-  )
-
-  if (!queryConfigLoaderData?.tanstackDocsConfig) {
-    throw new Error('Config could not be read for tanstack/query!')
-  }
-
-  return queryConfigLoaderData
-}

--- a/app/projects/query.tsx
+++ b/app/projects/query.tsx
@@ -1,5 +1,5 @@
-import { useMatchesData } from '~/utils/utils'
-import type { ReactNode } from 'react'
+import { useRouteLoaderData } from '@remix-run/react'
+import type { QueryConfigLoader } from '~/routes/query.$version'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-amber-500'
@@ -37,30 +37,16 @@ export function getBranch(argVersion?: string) {
   )
 }
 
-export type Menu = {
-  framework: string
-  menuItems: MenuItem[]
-}
-
-export type MenuItem = {
-  label: string | ReactNode
-  children: {
-    label: string | ReactNode
-    to: string
-  }[]
-}
-
-export type GithubDocsConfig = {
-  docSearch: {
-    appId: string
-    apiKey: string
-    indexName: string
-  }
-  menu: Menu[]
-  users: string[]
-}
-
 export type Framework = 'angular' | 'react' | 'svelte' | 'vue' | 'solid'
 
-export const useReactQueryDocsConfig = (version?: string) =>
-  useMatchesData(`/query/${version}`) as GithubDocsConfig
+export const useQueryDocsConfig = () => {
+  const queryConfigLoaderData = useRouteLoaderData<QueryConfigLoader>(
+    'routes/query.$version'
+  )
+
+  if (!queryConfigLoaderData?.tanstackDocsConfig) {
+    throw new Error('Config could not be read for tanstack/query!')
+  }
+
+  return queryConfigLoaderData
+}

--- a/app/projects/query.tsx
+++ b/app/projects/query.tsx
@@ -1,5 +1,5 @@
 import { useRouteLoaderData } from '@remix-run/react'
-import type { QueryConfigLoader } from '~/routes/query.$version'
+import type { QueryConfigLoader } from '~/routes/query.$version.docs'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-amber-500'
@@ -41,7 +41,7 @@ export type Framework = 'angular' | 'react' | 'svelte' | 'vue' | 'solid'
 
 export const useQueryDocsConfig = () => {
   const queryConfigLoaderData = useRouteLoaderData<QueryConfigLoader>(
-    'routes/query.$version'
+    'routes/query.$version.docs'
   )
 
   if (!queryConfigLoaderData?.tanstackDocsConfig) {

--- a/app/projects/ranger.tsx
+++ b/app/projects/ranger.tsx
@@ -1,21 +1,6 @@
-import { useRouteLoaderData } from '@remix-run/react'
-import type { RangerConfigV1Loader } from '~/routes/ranger.v1.docs'
-
 export const repo = 'tanstack/ranger'
 
 export const v1branch = 'main'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
-
-export const useRangerV1Config = () => {
-  const rangerConfigLoaderData = useRouteLoaderData<RangerConfigV1Loader>(
-    'routes/ranger.v1.docs'
-  )
-
-  if (!rangerConfigLoaderData?.tanstackDocsConfig) {
-    throw new Error(`Config could not be read for ${repo}!`)
-  }
-
-  return rangerConfigLoaderData.tanstackDocsConfig
-}

--- a/app/projects/ranger.tsx
+++ b/app/projects/ranger.tsx
@@ -1,5 +1,5 @@
 import { useRouteLoaderData } from '@remix-run/react'
-import type { RangerConfigV1Loader } from '~/routes/ranger.v1'
+import type { RangerConfigV1Loader } from '~/routes/ranger.v1.docs'
 
 export const repo = 'tanstack/ranger'
 
@@ -9,11 +9,13 @@ export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
 
 export const useRangerV1Config = () => {
-  const tableConfigLoaderData =
-    useRouteLoaderData<RangerConfigV1Loader>('routes/ranger.v1')
-  if (!tableConfigLoaderData?.tanstackDocsConfig) {
-    throw new Error('Config could not be read for tanstack/table!')
+  const rangerConfigLoaderData = useRouteLoaderData<RangerConfigV1Loader>(
+    'routes/ranger.v1.docs'
+  )
+
+  if (!rangerConfigLoaderData?.tanstackDocsConfig) {
+    throw new Error(`Config could not be read for ${repo}!`)
   }
 
-  return tableConfigLoaderData.tanstackDocsConfig
+  return rangerConfigLoaderData.tanstackDocsConfig
 }

--- a/app/projects/ranger.tsx
+++ b/app/projects/ranger.tsx
@@ -1,5 +1,5 @@
-import type { DocsConfig } from '~/components/Docs'
-import { useMatchesData } from '~/utils/utils'
+import { useRouteLoaderData } from '@remix-run/react'
+import type { RangerConfigV1Loader } from '~/routes/ranger.v1'
 
 export const repo = 'tanstack/ranger'
 
@@ -8,5 +8,12 @@ export const v1branch = 'main'
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
 
-export const useRangerV1Config = () =>
-  useMatchesData('/ranger/v1') as DocsConfig
+export const useRangerV1Config = () => {
+  const tableConfigLoaderData =
+    useRouteLoaderData<RangerConfigV1Loader>('routes/ranger.v1')
+  if (!tableConfigLoaderData?.tanstackDocsConfig) {
+    throw new Error('Config could not be read for tanstack/table!')
+  }
+
+  return tableConfigLoaderData.tanstackDocsConfig
+}

--- a/app/projects/router.tsx
+++ b/app/projects/router.tsx
@@ -1,5 +1,5 @@
-import type { DocsConfig } from '~/components/Docs'
-import { useMatchesData } from '~/utils/utils'
+import { useRouteLoaderData } from '@remix-run/react'
+import type { RouterConfigLoaderData } from '~/routes/router.v1'
 
 export const repo = 'tanstack/router'
 
@@ -8,5 +8,12 @@ export const v1branch = 'main'
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
 
-export const useRouterV1Config = () =>
-  useMatchesData('/router/v1') as DocsConfig
+export const useRouterV1Config = () => {
+  const routerConfigLoaderData =
+    useRouteLoaderData<RouterConfigLoaderData>('routes/router.v1')
+  if (!routerConfigLoaderData?.tanstackDocsConfig) {
+    throw new Error('Config could not be read for tanstack/router!')
+  }
+
+  return routerConfigLoaderData.tanstackDocsConfig
+}

--- a/app/projects/router.tsx
+++ b/app/projects/router.tsx
@@ -1,19 +1,6 @@
-import { useRouteLoaderData } from '@remix-run/react'
-import type { RouterConfigLoaderData } from '~/routes/router.v1'
-
 export const repo = 'tanstack/router'
 
 export const v1branch = 'main'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
-
-export const useRouterV1Config = () => {
-  const routerConfigLoaderData =
-    useRouteLoaderData<RouterConfigLoaderData>('routes/router.v1')
-  if (!routerConfigLoaderData?.tanstackDocsConfig) {
-    throw new Error('Config could not be read for tanstack/router!')
-  }
-
-  return routerConfigLoaderData.tanstackDocsConfig
-}

--- a/app/projects/table.tsx
+++ b/app/projects/table.tsx
@@ -1,5 +1,5 @@
-import type { DocsConfig } from '~/components/Docs'
-import { useMatchesData } from '~/utils/utils'
+import { useRouteLoaderData } from '@remix-run/react'
+import type { TableConfigLoaderData } from '~/routes/table.v8'
 
 export const repo = 'tanstack/table'
 
@@ -8,5 +8,12 @@ export const v8branch = 'main'
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600'
 
-export const useReactTableV8Config = () =>
-  useMatchesData('/table/v8') as DocsConfig
+export const useReactTableV8Config = () => {
+  const tableConfigLoaderData =
+    useRouteLoaderData<TableConfigLoaderData>('routes/table.v8')
+  if (!tableConfigLoaderData?.tanstackDocsConfig) {
+    throw new Error('Config could not be read for tanstack/table!')
+  }
+
+  return tableConfigLoaderData.tanstackDocsConfig
+}

--- a/app/projects/table.tsx
+++ b/app/projects/table.tsx
@@ -1,19 +1,6 @@
-import { useRouteLoaderData } from '@remix-run/react'
-import type { TableConfigLoaderData } from '~/routes/table.v8'
-
 export const repo = 'tanstack/table'
 
 export const v8branch = 'main'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600'
-
-export const useReactTableV8Config = () => {
-  const tableConfigLoaderData =
-    useRouteLoaderData<TableConfigLoaderData>('routes/table.v8')
-  if (!tableConfigLoaderData?.tanstackDocsConfig) {
-    throw new Error('Config could not be read for tanstack/table!')
-  }
-
-  return tableConfigLoaderData.tanstackDocsConfig
-}

--- a/app/projects/virtual.tsx
+++ b/app/projects/virtual.tsx
@@ -1,5 +1,5 @@
-import type { DocsConfig } from '~/components/Docs'
-import { useMatchesData } from '~/utils/utils'
+import { useRouteLoaderData } from '@remix-run/react'
+import type { VirtualConfigLoaderData } from '~/routes/virtual.v3'
 
 export const repo = 'tanstack/virtual'
 
@@ -8,5 +8,12 @@ export const v3branch = 'main'
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-rose-500 to-violet-600'
 
-export const useVirtualV3Config = () =>
-  useMatchesData('/virtual/v3') as DocsConfig
+export const useVirtualV3Config = () => {
+  const virtualConfigData =
+    useRouteLoaderData<VirtualConfigLoaderData>('routes/virtual.v3')
+  if (!virtualConfigData?.tanstackDocsConfig) {
+    throw new Error('Config could not be read for tanstack/virtual!')
+  }
+
+  return virtualConfigData.tanstackDocsConfig
+}

--- a/app/projects/virtual.tsx
+++ b/app/projects/virtual.tsx
@@ -1,19 +1,6 @@
-import { useRouteLoaderData } from '@remix-run/react'
-import type { VirtualConfigLoaderData } from '~/routes/virtual.v3'
-
 export const repo = 'tanstack/virtual'
 
 export const v3branch = 'main'
 
 export const gradientText =
   'inline-block text-transparent bg-clip-text bg-gradient-to-r from-rose-500 to-violet-600'
-
-export const useVirtualV3Config = () => {
-  const virtualConfigData =
-    useRouteLoaderData<VirtualConfigLoaderData>('routes/virtual.v3')
-  if (!virtualConfigData?.tanstackDocsConfig) {
-    throw new Error('Config could not be read for tanstack/virtual!')
-  }
-
-  return virtualConfigData.tanstackDocsConfig
-}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -161,7 +161,7 @@ function sample(arr: any[], random = Math.random()) {
 }
 
 export default function Index() {
-  const data = useActionData()
+  const data = useActionData<typeof action>()
   const { sponsors, randomNumber } = useLoaderData<typeof loader>()
   const navigation = useNavigation()
   const isLoading = navigation.state === 'submitting'

--- a/app/routes/blog.$.tsx
+++ b/app/routes/blog.$.tsx
@@ -36,7 +36,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
   })
 }
 
-export const meta: MetaFunction = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
   return seo({
     title: `${data?.title ?? 'Docs'} | TanStack Blog`,
     description: data?.description,

--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -1,10 +1,29 @@
-import { Outlet, useParams } from '@remix-run/react'
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { json } from '@remix-run/node'
+import { Outlet, useLoaderData } from '@remix-run/react'
 import { Docs } from '~/components/Docs'
-import { createLogo, useReactFormDocsConfig } from '~/projects/form'
+import {
+  createLogo,
+  getBranch,
+  repo,
+  useReactFormDocsConfig,
+} from '~/projects/form'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader = async (context: LoaderFunctionArgs) => {
+  const branch = getBranch(context.params.version)
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
+  const { version } = context.params
+
+  return json({
+    tanstackDocsConfig,
+    version,
+  })
+}
 
 export default function Component() {
-  const { version } = useParams()
-  let config = useReactFormDocsConfig()
+  const { version, tanstackDocsConfig } = useLoaderData<typeof loader>()
+  let config = useReactFormDocsConfig(tanstackDocsConfig)
   return (
     <Docs
       {...{

--- a/app/routes/form.$version.tsx
+++ b/app/routes/form.$version.tsx
@@ -1,22 +1,8 @@
 import { Link, Outlet, useLocation } from '@remix-run/react'
-import { json } from '@remix-run/node'
-import type { LoaderFunctionArgs } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClientOnlyRender } from '~/utils/useClientOnlyRender'
-import { repo, getBranch, latestVersion } from '~/projects/form'
-
-export const loader = async (context: LoaderFunctionArgs) => {
-  const branch = getBranch(context.params.version)
-  const config = await fetchRepoFile(repo, branch, `docs/config.json`)
-
-  if (!config) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(JSON.parse(config))
-}
+import { latestVersion } from '~/projects/form'
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/query.$version.docs.$framework.tsx
+++ b/app/routes/query.$version.docs.$framework.tsx
@@ -40,8 +40,6 @@ export const loader = async (context: LoaderFunctionArgs) => {
   })
 }
 
-export type QueryConfigLoader = typeof loader
-
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
   solid: { label: 'Solid', logo: solidLogo, value: 'solid' },

--- a/app/routes/query.$version.docs.$framework.tsx
+++ b/app/routes/query.$version.docs.$framework.tsx
@@ -11,9 +11,8 @@ import {
   gradientText,
   latestVersion,
   repo,
-  useReactQueryDocsConfig,
+  useQueryDocsConfig,
 } from '~/projects/query'
-import type { MenuItem } from '~/projects/query'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -21,6 +20,7 @@ import svelteLogo from '~/images/svelte-logo.svg'
 import angularLogo from '~/images/angular-logo.svg'
 import type { AvailableOptions } from '~/components/Select'
 import { generatePath } from '~/utils/utils'
+import type { MenuItem } from '~/utils/config'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -81,13 +81,15 @@ export default function RouteFrameworkParam() {
   const matches = useMatches()
   const match = matches[matches.length - 1]
   const navigate = useNavigate()
-  const params = useParams()
-  const framework = params.framework
-  const version = params.version
-  let config = useReactQueryDocsConfig(version)
+  const { version, framework } = useParams()
+  const { tanstackDocsConfig } = useQueryDocsConfig()
+
+  let config = tanstackDocsConfig
 
   const docsConfig = React.useMemo(() => {
-    const frameworkMenu = config.menu.find((d) => d.framework === framework)
+    const frameworkMenu = config.frameworkMenus?.find(
+      (d) => d.framework === framework
+    )
     if (!frameworkMenu) return null
     return {
       ...config,
@@ -96,7 +98,11 @@ export default function RouteFrameworkParam() {
   }, [framework, config])
 
   const frameworkConfig = React.useMemo(() => {
-    const availableFrameworks = config.menu.reduce(
+    if (!config.frameworkMenus) {
+      return undefined
+    }
+
+    const availableFrameworks = config.frameworkMenus.reduce(
       (acc: AvailableOptions, menuEntry) => {
         acc[menuEntry.framework as string] =
           frameworks[menuEntry.framework as keyof typeof frameworks]
@@ -117,7 +123,7 @@ export default function RouteFrameworkParam() {
         navigate(url)
       },
     }
-  }, [config.menu, framework, match, navigate])
+  }, [framework, match, navigate, config.frameworkMenus])
 
   const versionConfig = React.useMemo(() => {
     const available = availableVersions.reduce(

--- a/app/routes/query.$version.docs.$framework.tsx
+++ b/app/routes/query.$version.docs.$framework.tsx
@@ -1,17 +1,23 @@
 import * as React from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import type { MetaFunction } from '@remix-run/node'
-import { Link, useMatches, useNavigate, useParams } from '@remix-run/react'
+import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
+import {
+  Link,
+  json,
+  useLoaderData,
+  useMatches,
+  useNavigate,
+} from '@remix-run/react'
 import { seo } from '~/utils/seo'
 import type { DocsConfig } from '~/components/Docs'
 import { Docs } from '~/components/Docs'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
 import {
   availableVersions,
+  getBranch,
   gradientText,
   latestVersion,
   repo,
-  useQueryDocsConfig,
 } from '~/projects/query'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
@@ -20,7 +26,21 @@ import svelteLogo from '~/images/svelte-logo.svg'
 import angularLogo from '~/images/angular-logo.svg'
 import type { AvailableOptions } from '~/components/Select'
 import { generatePath } from '~/utils/utils'
-import type { MenuItem } from '~/utils/config'
+import { getTanstackDocsConfig, type MenuItem } from '~/utils/config'
+
+export const loader = async (context: LoaderFunctionArgs) => {
+  const branch = getBranch(context.params.version)
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
+  const { version, framework } = context.params
+
+  return json({
+    tanstackDocsConfig,
+    framework,
+    version,
+  })
+}
+
+export type QueryConfigLoader = typeof loader
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -81,8 +101,8 @@ export default function RouteFrameworkParam() {
   const matches = useMatches()
   const match = matches[matches.length - 1]
   const navigate = useNavigate()
-  const { version, framework } = useParams()
-  const { tanstackDocsConfig } = useQueryDocsConfig()
+  const { tanstackDocsConfig, version, framework } =
+    useLoaderData<typeof loader>()
 
   let config = tanstackDocsConfig
 

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -1,4 +1,21 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node'
 import { Outlet } from '@remix-run/react'
+import { getBranch, repo } from '~/projects/query'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader = async (context: LoaderFunctionArgs) => {
+  const branch = getBranch(context.params.version)
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
+  const { version, framework } = context.params
+
+  return json({
+    tanstackDocsConfig,
+    framework,
+    version,
+  })
+}
+
+export type QueryConfigLoader = typeof loader
 
 export default function RouteDocsParam() {
   return <Outlet />

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -1,21 +1,4 @@
-import { type LoaderFunctionArgs, json } from '@remix-run/node'
 import { Outlet } from '@remix-run/react'
-import { getBranch, repo } from '~/projects/query'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async (context: LoaderFunctionArgs) => {
-  const branch = getBranch(context.params.version)
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
-  const { version, framework } = context.params
-
-  return json({
-    tanstackDocsConfig,
-    framework,
-    version,
-  })
-}
-
-export type QueryConfigLoader = typeof loader
 
 export default function RouteDocsParam() {
   return <Outlet />

--- a/app/routes/query.$version.tsx
+++ b/app/routes/query.$version.tsx
@@ -1,24 +1,7 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import { json } from '@remix-run/node'
-import type { LoaderFunctionArgs } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { repo, getBranch, latestVersion } from '~/projects/query'
+import { latestVersion } from '~/projects/query'
 import { RedirectVersionBanner } from '~/components/RedirectVersionBanner'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async (context: LoaderFunctionArgs) => {
-  const branch = getBranch(context.params.version)
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
-  const { version, framework } = context.params
-
-  return json({
-    tanstackDocsConfig,
-    framework,
-    version,
-  })
-}
-
-export type QueryConfigLoader = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/query.$version.tsx
+++ b/app/routes/query.$version.tsx
@@ -2,20 +2,23 @@ import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
 import { json } from '@remix-run/node'
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { repo, getBranch, latestVersion } from '~/projects/query'
 import { RedirectVersionBanner } from '~/components/RedirectVersionBanner'
+import { getTanstackDocsConfig } from '~/utils/config'
 
 export const loader = async (context: LoaderFunctionArgs) => {
   const branch = getBranch(context.params.version)
-  const config = await fetchRepoFile(repo, branch, `docs/config.json`)
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
+  const { version, framework } = context.params
 
-  if (!config) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(JSON.parse(config))
+  return json({
+    tanstackDocsConfig,
+    framework,
+    version,
+  })
 }
+
+export type QueryConfigLoader = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/ranger.v1.docs.tsx
+++ b/app/routes/ranger.v1.docs.tsx
@@ -1,11 +1,27 @@
 import * as React from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import { Link } from '@remix-run/react'
+import { Link, json } from '@remix-run/react'
 import type { MetaFunction } from '@remix-run/node'
-import { gradientText, useRangerV1Config } from '~/projects/ranger'
+import {
+  gradientText,
+  repo,
+  useRangerV1Config,
+  v1branch,
+} from '~/projects/ranger'
 import { seo } from '~/utils/seo'
 import type { DocsConfig } from '~/components/Docs'
 import { Docs } from '~/components/Docs'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader = async () => {
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
+
+  return json({
+    tanstackDocsConfig,
+  })
+}
+
+export type RangerConfigV1Loader = typeof loader
 
 const logo = (
   <>

--- a/app/routes/ranger.v1.docs.tsx
+++ b/app/routes/ranger.v1.docs.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import { Link, json } from '@remix-run/react'
+import { Link, json, useLoaderData } from '@remix-run/react'
 import type { MetaFunction } from '@remix-run/node'
-import {
-  gradientText,
-  repo,
-  useRangerV1Config,
-  v1branch,
-} from '~/projects/ranger'
+import { gradientText, repo, v1branch } from '~/projects/ranger'
 import { seo } from '~/utils/seo'
-import type { DocsConfig } from '~/components/Docs'
 import { Docs } from '~/components/Docs'
 import { getTanstackDocsConfig } from '~/utils/config'
 
@@ -20,8 +14,6 @@ export const loader = async () => {
     tanstackDocsConfig,
   })
 }
-
-export type RangerConfigV1Loader = typeof loader
 
 const logo = (
   <>
@@ -69,15 +61,14 @@ export const meta: MetaFunction = () => {
 }
 
 export default function DocsRoute() {
-  let config = useRangerV1Config()
+  const { tanstackDocsConfig } = useLoaderData<typeof loader>()
 
-  config = React.useMemo(
-    () =>
-      ({
-        ...config,
-        menu: [localMenu, ...config.menu],
-      } as DocsConfig),
-    [config]
+  const config = React.useMemo(
+    () => ({
+      ...tanstackDocsConfig,
+      menu: [localMenu, ...tanstackDocsConfig.menu],
+    }),
+    [tanstackDocsConfig]
   )
 
   return (

--- a/app/routes/ranger.v1.tsx
+++ b/app/routes/ranger.v1.tsx
@@ -2,23 +2,20 @@ import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
 import type { LoaderFunction } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { v1branch } from '~/projects/ranger'
+import { getTanstackDocsConfig } from '~/utils/config'
+
 export const loader: LoaderFunction = async () => {
-  const config = await fetchRepoFile(
-    'tanstack/ranger',
-    v1branch,
-    `docs/config.json`
-  )
+  const repo = 'tanstack/ranger'
 
-  const parsedConfig = JSON.parse(config ?? '')
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
 
-  if (!parsedConfig) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(parsedConfig)
+  return json({
+    tanstackDocsConfig,
+  })
 }
+
+export type RangerConfigV1Loader = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/ranger.v1.tsx
+++ b/app/routes/ranger.v1.tsx
@@ -1,21 +1,5 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import type { LoaderFunction } from '@remix-run/node'
-import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { v1branch } from '~/projects/ranger'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader: LoaderFunction = async () => {
-  const repo = 'tanstack/ranger'
-
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
-
-export type RangerConfigV1Loader = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/router.v1.docs.tsx
+++ b/app/routes/router.v1.docs.tsx
@@ -1,10 +1,5 @@
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import {
-  type ClientLoaderFunctionArgs,
-  Link,
-  json,
-  useLoaderData,
-} from '@remix-run/react'
+import { Link, json, useLoaderData } from '@remix-run/react'
 import type { LoaderFunction, MetaFunction } from '@remix-run/node'
 import { gradientText, repo, v1branch } from '~/projects/router'
 import { seo } from '~/utils/seo'
@@ -63,21 +58,13 @@ export const meta: MetaFunction = () => {
   })
 }
 
-export const clientLoader = async ({
-  serverLoader,
-}: ClientLoaderFunctionArgs) => {
-  const { tanstackDocsConfig } = await serverLoader<typeof loader>()
+export default function DocsRoute() {
+  const { tanstackDocsConfig } = useLoaderData<typeof loader>()
 
   const config = {
     ...tanstackDocsConfig,
     menu: [localMenu, ...tanstackDocsConfig.menu],
   }
-
-  return config
-}
-
-export default function DocsRoute() {
-  const config = useLoaderData<typeof clientLoader>()
 
   return (
     <Docs

--- a/app/routes/router.v1.docs.tsx
+++ b/app/routes/router.v1.docs.tsx
@@ -1,11 +1,23 @@
-import * as React from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import { Link } from '@remix-run/react'
-import type { MetaFunction } from '@remix-run/node'
-import { gradientText, useRouterV1Config } from '~/projects/router'
+import {
+  type ClientLoaderFunctionArgs,
+  Link,
+  json,
+  useLoaderData,
+} from '@remix-run/react'
+import type { LoaderFunction, MetaFunction } from '@remix-run/node'
+import { gradientText, repo, v1branch } from '~/projects/router'
 import { seo } from '~/utils/seo'
-import type { DocsConfig } from '~/components/Docs'
 import { Docs } from '~/components/Docs'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader: LoaderFunction = async () => {
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
+
+  return json({
+    tanstackDocsConfig,
+  })
+}
 
 const logo = (
   <>
@@ -51,17 +63,21 @@ export const meta: MetaFunction = () => {
   })
 }
 
-export default function DocsRoute() {
-  let config = useRouterV1Config()
+export const clientLoader = async ({
+  serverLoader,
+}: ClientLoaderFunctionArgs) => {
+  const { tanstackDocsConfig } = await serverLoader<typeof loader>()
 
-  config = React.useMemo(
-    () =>
-      ({
-        ...config,
-        menu: [localMenu, ...config.menu],
-      } as DocsConfig),
-    [config]
-  )
+  const config = {
+    ...tanstackDocsConfig,
+    menu: [localMenu, ...tanstackDocsConfig.menu],
+  }
+
+  return config
+}
+
+export default function DocsRoute() {
+  const config = useLoaderData<typeof clientLoader>()
 
   return (
     <Docs

--- a/app/routes/router.v1.tsx
+++ b/app/routes/router.v1.tsx
@@ -1,21 +1,5 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import type { LoaderFunction } from '@remix-run/node'
-import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { v1branch } from '~/projects/router'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader: LoaderFunction = async () => {
-  const repo = 'tanstack/router'
-
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
-
-export type RouterConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/router.v1.tsx
+++ b/app/routes/router.v1.tsx
@@ -2,23 +2,20 @@ import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
 import type { LoaderFunction } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { v1branch } from '~/projects/router'
+import { getTanstackDocsConfig } from '~/utils/config'
+
 export const loader: LoaderFunction = async () => {
-  const config = await fetchRepoFile(
-    'tanstack/router',
-    v1branch,
-    `docs/config.json`
-  )
+  const repo = 'tanstack/router'
 
-  const parsedConfig = JSON.parse(config ?? '')
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v1branch)
 
-  if (!parsedConfig) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(parsedConfig)
+  return json({
+    tanstackDocsConfig,
+  })
 }
+
+export type RouterConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -1,10 +1,29 @@
-import { Outlet, useParams } from '@remix-run/react'
+import { type LoaderFunctionArgs, json } from '@remix-run/node'
+import { Outlet, useLoaderData } from '@remix-run/react'
 import { Docs } from '~/components/Docs'
-import { createLogo, useReactStoreDocsConfig } from '~/projects/store'
+import {
+  createLogo,
+  getBranch,
+  repo,
+  useReactStoreDocsConfig,
+} from '~/projects/store'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader = async (context: LoaderFunctionArgs) => {
+  const branch = getBranch(context.params.version)
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
+  const { version } = context.params
+
+  return json({
+    tanstackDocsConfig,
+    version,
+  })
+}
 
 export default function Component() {
-  const { version } = useParams()
-  let config = useReactStoreDocsConfig()
+  const { tanstackDocsConfig, version } = useLoaderData<typeof loader>()
+  let config = useReactStoreDocsConfig(tanstackDocsConfig)
+
   return (
     <Docs
       {...{

--- a/app/routes/store.$version.tsx
+++ b/app/routes/store.$version.tsx
@@ -1,22 +1,8 @@
 import { Link, Outlet, useLocation } from '@remix-run/react'
-import { json } from '@remix-run/node'
-import type { LoaderFunctionArgs } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClientOnlyRender } from '~/utils/useClientOnlyRender'
-import { repo, getBranch, latestVersion } from '~/projects/store'
-
-export const loader = async (context: LoaderFunctionArgs) => {
-  const branch = getBranch(context.params.version)
-  const config = await fetchRepoFile(repo, branch, `docs/config.json`)
-
-  if (!config) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(JSON.parse(config))
-}
+import { latestVersion } from '~/projects/store'
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/store.tsx
+++ b/app/routes/store.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { Outlet } from '@remix-run/react'
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { redirect } from '@remix-run/node'

--- a/app/routes/table.v8._index.tsx
+++ b/app/routes/table.v8._index.tsx
@@ -82,9 +82,6 @@ export const loader = async () => {
 
 export default function ReactTableRoute() {
   const { sponsors } = useLoaderData<typeof loader>()
-  // const config = useReactTableV8Config()
-  // const [params, setParams] = useSearchParams()
-  // const framework = params.get('framework') ?? 'react'
   const [framework, setFramework] = React.useState<
     'react' | 'svelte' | 'vue' | 'solid'
   >('react')

--- a/app/routes/table.v8.docs.tsx
+++ b/app/routes/table.v8.docs.tsx
@@ -1,5 +1,5 @@
+import { useMemo } from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
-import type { ClientLoaderFunctionArgs } from '@remix-run/react'
 import { Link, json, useLoaderData } from '@remix-run/react'
 import { gradientText, repo, v8branch } from '~/projects/table'
 import { seo } from '~/utils/seo'
@@ -7,26 +7,6 @@ import { Docs } from '~/components/Docs'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
 import type { MetaFunction } from '@remix-run/node'
 import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async () => {
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
-
-const logo = (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to=".." className={`font-bold`}>
-      <span className={`${gradientText}`}>Table</span>{' '}
-      <span className="text-sm align-super">v8</span>
-    </Link>
-  </>
-)
 
 const localMenu = {
   label: 'Menu',
@@ -54,6 +34,26 @@ const localMenu = {
   ],
 }
 
+export const loader = async () => {
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
+
+  return json({
+    tanstackDocsConfig,
+  })
+}
+
+const logo = (
+  <>
+    <Link to="/" className="font-light">
+      TanStack
+    </Link>
+    <Link to=".." className={`font-bold`}>
+      <span className={`${gradientText}`}>Table</span>{' '}
+      <span className="text-sm align-super">v8</span>
+    </Link>
+  </>
+)
+
 export const meta: MetaFunction = () => {
   return seo({
     title:
@@ -63,23 +63,18 @@ export const meta: MetaFunction = () => {
   })
 }
 
-export const clientLoader = async ({
-  serverLoader,
-}: ClientLoaderFunctionArgs) => {
-  const { tanstackDocsConfig } = await serverLoader<typeof loader>()
-
-  const config = {
-    ...tanstackDocsConfig,
-    menu: [localMenu, ...tanstackDocsConfig.menu],
-  }
-
-  return config
-}
-
 export const ErrorBoundary = DefaultErrorBoundary
 
 export default function RouteReactTable() {
-  const config = useLoaderData<typeof clientLoader>()
+  const { tanstackDocsConfig } = useLoaderData<typeof loader>()
+
+  const config = useMemo(
+    () => ({
+      ...tanstackDocsConfig,
+      menu: [localMenu, ...tanstackDocsConfig.menu],
+    }),
+    [tanstackDocsConfig]
+  )
 
   return (
     <Docs

--- a/app/routes/table.v8.docs.tsx
+++ b/app/routes/table.v8.docs.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react'
+import { useMemo } from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
 import { Link } from '@remix-run/react'
 import { gradientText, useReactTableV8Config } from '~/projects/table'
 import { seo } from '~/utils/seo'
-import { Docs } from '~/components/Docs'
+import { Docs, type DocsConfig } from '~/components/Docs'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
 import type { MetaFunction } from '@remix-run/node'
-import type { DocsConfig } from '~/components/Docs'
 
 const logo = (
   <>
@@ -58,14 +57,13 @@ export const meta: MetaFunction = () => {
 export const ErrorBoundary = DefaultErrorBoundary
 
 export default function RouteReactTable() {
-  let config = useReactTableV8Config()
+  let config: DocsConfig = useReactTableV8Config()
 
-  config = React.useMemo(
-    () =>
-      ({
-        ...config,
-        menu: [localMenu, ...config.menu],
-      } as DocsConfig),
+  config = useMemo(
+    () => ({
+      ...config,
+      menu: [localMenu, ...config.menu],
+    }),
     [config]
   )
 

--- a/app/routes/table.v8.tsx
+++ b/app/routes/table.v8.tsx
@@ -13,8 +13,6 @@ export const loader = async () => {
   })
 }
 
-export type TableConfigLoaderData = typeof loader
-
 export const ErrorBoundary = DefaultErrorBoundary
 
 export default function RouteReactTable() {

--- a/app/routes/table.v8.tsx
+++ b/app/routes/table.v8.tsx
@@ -1,17 +1,5 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { v8branch } from '~/projects/table'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async () => {
-  const repo = 'tanstack/table'
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/table.v8.tsx
+++ b/app/routes/table.v8.tsx
@@ -1,5 +1,19 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
+import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
+import { v8branch } from '~/projects/table'
+import { getTanstackDocsConfig } from '~/utils/config'
+
+export const loader = async () => {
+  const repo = 'tanstack/table'
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
+
+  return json({
+    tanstackDocsConfig,
+  })
+}
+
+export type TableConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/table.v8.tsx
+++ b/app/routes/table.v8.tsx
@@ -1,24 +1,19 @@
-import * as React from 'react'
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
 import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { v8branch } from '~/projects/table'
+import { getTanstackDocsConfig } from '~/utils/config'
+
 export const loader = async () => {
-  const config = await fetchRepoFile(
-    'tanstack/table',
-    v8branch,
-    `docs/config.json`
-  )
+  const repo = 'tanstack/table'
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
 
-  const parsedConfig = JSON.parse(config ?? '')
-
-  if (!parsedConfig) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(parsedConfig)
+  return json({
+    tanstackDocsConfig,
+  })
 }
+
+export type TableConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/table.v8.tsx
+++ b/app/routes/table.v8.tsx
@@ -1,19 +1,5 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { v8branch } from '~/projects/table'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async () => {
-  const repo = 'tanstack/table'
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v8branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
-
-export type TableConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/virtual.v3.docs.tsx
+++ b/app/routes/virtual.v3.docs.tsx
@@ -3,8 +3,9 @@ import { Link, json, useLoaderData } from '@remix-run/react'
 import { gradientText, repo, v3branch } from '~/projects/virtual'
 import { seo } from '~/utils/seo'
 import { Docs } from '~/components/Docs'
-import type { ClientLoaderFunctionArgs, MetaFunction } from '@remix-run/react'
+import type { MetaFunction } from '@remix-run/react'
 import { getTanstackDocsConfig } from '~/utils/config'
+import { useMemo } from 'react'
 
 export const loader = async () => {
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, v3branch)
@@ -62,21 +63,17 @@ export const meta: MetaFunction = () => {
       'Headless UI for virtualizing long scrollable lists with TS/JS, React, Solid, Svelte and Vue',
   })
 }
-export const clientLoader = async ({
-  serverLoader,
-}: ClientLoaderFunctionArgs) => {
-  const { tanstackDocsConfig } = await serverLoader<typeof loader>()
-
-  const config = {
-    ...tanstackDocsConfig,
-    menu: [localMenu, ...tanstackDocsConfig.menu],
-  }
-
-  return config
-}
 
 export default function RouteVirtual() {
-  const config = useLoaderData<typeof clientLoader>()
+  const { tanstackDocsConfig } = useLoaderData<typeof loader>()
+
+  const config = useMemo(
+    () => ({
+      ...tanstackDocsConfig,
+      menu: [localMenu, ...tanstackDocsConfig.menu],
+    }),
+    [tanstackDocsConfig]
+  )
 
   return (
     <Docs

--- a/app/routes/virtual.v3.docs.tsx
+++ b/app/routes/virtual.v3.docs.tsx
@@ -15,8 +15,6 @@ export const loader = async () => {
   })
 }
 
-export type VirtualConfigLoaderData = typeof loader
-
 const logo = (
   <>
     <Link to="/" className="font-light">

--- a/app/routes/virtual.v3.docs.tsx
+++ b/app/routes/virtual.v3.docs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { useMemo } from 'react'
 import { FaDiscord, FaGithub } from 'react-icons/fa'
 import { Link } from '@remix-run/react'
 import { gradientText, useVirtualV3Config } from '~/projects/virtual'
@@ -54,16 +54,15 @@ export const meta: MetaFunction = () => {
   })
 }
 
-export default function RouteReactTable() {
-  let config = useVirtualV3Config()
+export default function RouteVirtual() {
+  const tanstackConfig = useVirtualV3Config()
 
-  config = React.useMemo(
-    () =>
-      ({
-        ...config,
-        menu: [localMenu, ...config.menu],
-      } as DocsConfig),
-    [config]
+  const config: DocsConfig = useMemo(
+    () => ({
+      ...tanstackConfig,
+      menu: [localMenu, ...tanstackConfig.menu],
+    }),
+    [tanstackConfig]
   )
 
   return (

--- a/app/routes/virtual.v3.tsx
+++ b/app/routes/virtual.v3.tsx
@@ -1,23 +1,20 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
 import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { fetchRepoFile } from '~/utils/documents.server'
 import { v3branch } from '~/projects/virtual'
+import { getTanstackDocsConfig } from '~/utils/config'
+
 export const loader = async () => {
-  const config = await fetchRepoFile(
-    'tanstack/virtual',
-    v3branch,
-    `docs/config.json`
-  )
+  const repo = 'tanstack/virtual'
 
-  const parsedConfig = JSON.parse(config ?? '')
+  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v3branch)
 
-  if (!parsedConfig) {
-    throw new Error('Repo docs/config.json not found!')
-  }
-
-  return json(parsedConfig)
+  return json({
+    tanstackDocsConfig,
+  })
 }
+
+export type VirtualConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/routes/virtual.v3.tsx
+++ b/app/routes/virtual.v3.tsx
@@ -1,20 +1,5 @@
 import { Link, Outlet, useLocation, useSearchParams } from '@remix-run/react'
-import { json } from '@remix-run/node'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
-import { v3branch } from '~/projects/virtual'
-import { getTanstackDocsConfig } from '~/utils/config'
-
-export const loader = async () => {
-  const repo = 'tanstack/virtual'
-
-  const tanstackDocsConfig = await getTanstackDocsConfig(repo, v3branch)
-
-  return json({
-    tanstackDocsConfig,
-  })
-}
-
-export type VirtualConfigLoaderData = typeof loader
 
 export const ErrorBoundary = DefaultErrorBoundary
 

--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -57,14 +57,10 @@ export function getCurrentlySelectedFrameworkFromLocalStorage(
   Fetch the config file for the project and validate it.
   */
 export async function getTanstackDocsConfig(repo: string, branch: string) {
-  const config = await fetchRepoFile(
-    repo,
-    branch,
-    `docs/tanstack-docs-config.json`
-  )
+  const config = await fetchRepoFile(repo, branch, `docs/config.json`)
 
   if (!config) {
-    throw new Error('Repo docs/tanstack-docs-config.json not found!')
+    throw new Error('Repo docs/config.json not found!')
   }
 
   try {
@@ -79,6 +75,6 @@ export async function getTanstackDocsConfig(repo: string, branch: string) {
 
     return validationResult.data
   } catch (e) {
-    throw new Error('Invalid docs/tanstack-docs-config.json file')
+    throw new Error('Invalid docs/config.json file')
   }
 }

--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+import { fetchRepoFile } from './documents.server'
+
+export type FrameworkMenu = {
+  framework: string
+  menuItems: MenuItem[]
+}
+
+export type MenuItem = {
+  label: string | React.ReactNode
+  children: {
+    label: string | React.ReactNode
+    to: string
+  }[]
+}
+
+const menuItemSchema = z.object({
+  label: z.string(),
+  children: z.array(
+    z.object({
+      label: z.string(),
+      to: z.string(),
+
+      badge: z.string().optional(),
+    })
+  ),
+})
+
+const frameworkMenuSchema = z.object({
+  framework: z.string(),
+  menuItems: z.array(menuItemSchema),
+})
+
+const configSchema = z.object({
+  docSearch: z.object({
+    appId: z.string(),
+    apiKey: z.string(),
+    indexName: z.string(),
+  }),
+  menu: z.array(menuItemSchema),
+  frameworkMenus: z.array(frameworkMenuSchema).optional(),
+  users: z.array(z.string()).optional(),
+})
+
+export type ConfigSchema = z.infer<typeof configSchema>
+
+export function getCurrentlySelectedFrameworkFromLocalStorage(
+  selectedFramework?: string
+) {
+  const framework =
+    selectedFramework || localStorage.getItem('framework') || 'react'
+
+  return framework
+}
+
+/**
+  Fetch the config file for the project and validate it.
+  */
+export async function getTanstackDocsConfig(repo: string, branch: string) {
+  const config = await fetchRepoFile(
+    repo,
+    branch,
+    `docs/tanstack-docs-config.json`
+  )
+
+  if (!config) {
+    throw new Error('Repo docs/tanstack-docs-config.json not found!')
+  }
+
+  try {
+    const tanstackDocsConfigFromJson = JSON.parse(config)
+    const validationResult = configSchema.safeParse(tanstackDocsConfigFromJson)
+
+    if (!validationResult.success) {
+      // Log the issues that come up during validation
+      console.error(JSON.stringify(validationResult.error, null, 2))
+      throw new Error('Zod validation failed')
+    }
+
+    return validationResult.data
+  } catch (e) {
+    throw new Error('Invalid docs/tanstack-docs-config.json file')
+  }
+}

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,24 +1,3 @@
-import { useMemo } from 'react'
-import { useMatches } from '@remix-run/react'
-
-/**
- * This base hook is used in other hooks to quickly search for specific data
- * across all loader data using useMatches.
- * @param {string} id The route id
- * @returns {JSON|undefined} The router data or undefined if not found
- */
-export function useMatchesData(
-  pathname: string
-): Record<string, unknown> | undefined {
-  const matches = useMatches()
-  const route = useMemo(
-    // @ts-ignore
-    () => matches.find((match) => match.pathname === pathname),
-    [matches, pathname]
-  )
-  return route?.data
-}
-
 export function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "remark-gfm": "^1.0.0",
     "remove-markdown": "^0.5.0",
     "tailwind-merge": "^1.14.0",
-    "tiny-invariant": "^1.3.1"
+    "tiny-invariant": "^1.3.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@docsearch/css':
     specifier: ^3.5.2
@@ -95,6 +91,9 @@ dependencies:
   tiny-invariant:
     specifier: ^1.3.1
     version: 1.3.1
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@remix-run/dev':
@@ -7901,6 +7900,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
+
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
@@ -7908,3 +7911,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/tanstack-docs-config.schema.json
+++ b/tanstack-docs-config.schema.json
@@ -41,9 +41,15 @@
               "required": ["label", "to"],
               "additionalProperties": false,
               "properties": {
-                "label": "string",
-                "to": "string",
-                "badge": "string"
+                "label": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "badge": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -76,11 +82,16 @@
                   "items": {
                     "type": "object",
                     "required": ["label", "to"],
-                    "additionalProperties": false,
                     "properties": {
-                      "label": "string",
-                      "to": "string",
-                      "badge": "string"
+                      "label": {
+                        "type": "string"
+                      },
+                      "to": {
+                        "type": "string"
+                      },
+                      "badge": {
+                        "type": "string"
+                      }
                     }
                   }
                 }

--- a/tanstack-docs-config.schema.json
+++ b/tanstack-docs-config.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TanStack/tanstack.com/blob/main/tanstack-docs.config.schema.json",
+  "title": "TanStack Docs Config",
+  "description": "Config file for the documentation of a TanStack project.",
+  "type": "object",
+  "required": ["docSearch", "menu"],
+  "additionalProperties": false,
+  "properties": {
+    "docSearch": {
+      "description": "Data for Algolia Search.",
+      "type": "object",
+      "required": ["appId", "apiKey", "indexName"],
+      "properties": {
+        "appId": {
+          "type": "string"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "indexName": {
+          "type": "string"
+        }
+      }
+    },
+    "menu": {
+      "description": "Doc pages that are NOT framework-specific.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "children"],
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "to"],
+              "additionalProperties": false,
+              "properties": {
+                "label": "string",
+                "to": "string",
+                "badge": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "frameworkMenus": {
+      "description": "Doc pages that are framework-specific.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["framework", "menuItems"],
+        "additionalProperties": false,
+        "properties": {
+          "framework": {
+            "type": "string"
+          },
+          "menuItems": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "children"],
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "children": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["label", "to"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "label": "string",
+                      "to": "string",
+                      "badge": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The idea was proposed here by Tanner: https://github.com/TanStack/tanstack.com/pull/131#discussion_r1439085212

# TL;DR

Currently the docs of the TanStack projects use different `config.json` formats, causing a bit of a mess. The format of `TanStack Form` can fit all the other projects if we add a `users` key to it (for `TanStack Query`).

# The new config format

See the `zod` schema here: https://github.com/fulopkovacs/tanstack.com/blob/3426fc7df794e5de381903a1ee7bfb81baf0148b/app/utils/config.ts#L33

# ✨ JSON Schema ✨ 
I wrote a fancy JSON Schema that our editors can use to validate `docs/config.json` files, and in the future we could use this to validate the schemas in the CI of the projects.


Here's a demo of installing the schema in VSCode, and using it for validation:


https://github.com/TanStack/tanstack.com/assets/43729152/922721d7-9f57-4e11-9896-862f70e8bcb6




This is the code snippet I copy-paste into `settings.json` in the video:

```json
  "json.schemas": [
    {
      "fileMatch": [
        "docs/config.json"
      ],
      "url": "https://raw.githubusercontent.com/fulopkovacs/tanstack.com/tanstack-docs-config/tanstack-docs-config.schema.json"
    }
  ]
```

# Comparing the current doc configs of the TanStack projects

> [!NOTE]
> ~I didn't want to spam the projects with PR-s, so I linked the new config files from my forks. When you test this PR you can copy the each new config file from there to `docs/tanstack-docs-config.json`.~ **Edit:** I opened up PR-s where they were necessary.

| project             | top-level keys of the old format                                                        |  changes                                                          |
| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | --|
| TanStack Query      | `docSearch`, `menu`(only framework-specific pages, no core docs),`users`  | [v3](https://github.com/TanStack/query/pull/6741/files), [v4](https://github.com/TanStack/query/pull/6742/files), [v5](https://github.com/TanStack/query/pull/6740/files) |
| TanStack Table (v8) | `docSearch`, `menu` (mixes core and framework-specific docs)               | ✅ no changes |
| TanStack Virtual    | `docSearch`, `menu` (mixes core and framework-specific docs)              | ✅ no changes |
| TanStack Ranger     | `docSearch`, `menu` (mixes core and framework-specific docs)              | ✅ no changes |
| TanStack Router     | `docSearch`, `menu` (currently only React docs)                            | ✅ no changes |
| TanStack Form       | `docSearch`, `menu` (core docs), `frameworkMenus` (framework-specific)     | ✅ no changes |
| TanStack Store      | `docSearch`, `menu` (core docs), `frameworkMenus` (framework-specific)      | ✅ no changes |
| React Charts        | doesn't use a `config.json` file, docs are not in the Remix app          | -                                                                             | - |



