### PR TITLE
fix: Markdown iframe (youtube video) width

### DIFF
--- a/app/components/RenderMarkdown.tsx
+++ b/app/components/RenderMarkdown.tsx
@@ -43,6 +43,7 @@ const defaultComponents: Record<string, FC> = {
   h4: makeHeading('h4'),
   h5: makeHeading('h5'),
   h6: makeHeading('h6'),
+  iframe: (props) => <iframe {...props} className="w-full" />,
   code: ({ className = '', ...props }: React.HTMLProps<HTMLElement>) => {
     return (
       <code


### PR DESCRIPTION
YouTube videos in markdown files weren't using the full container width like they were with MDX. This PR adds the `w-full` tailwind class to iframes.