### PR TITLE
fix: Framework text colour with v2 docs layout

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -118,11 +118,11 @@ export function DocsLayout({
                                 child.badge === 'react'
                                   ? 'text-sky-500'
                                   : child.badge === 'solid'
-                                  ? 'bg-blue-500'
+                                  ? 'text-blue-500'
                                   : child.badge === 'svelte'
-                                  ? 'bg-orange-500'
+                                  ? 'text-orange-500'
                                   : child.badge === 'vue'
-                                  ? 'bg-green-500'
+                                  ? 'text-green-500'
                                   : 'text-gray-500'
                               }`}
                             >


### PR DESCRIPTION
Currently, for the v2 layout (form/store), the react and "core" docs have text coloured, while other frameworks have their background coloured. I think this was a bug, so I've changed it so text is coloured - here is the difference.

## Before:
![image](https://github.com/TanStack/tanstack.com/assets/1667261/ba8205b0-8030-41c9-964c-6aebc5024066)

## After:
![image](https://github.com/TanStack/tanstack.com/assets/1667261/c74d5c39-b5c3-4973-bf8c-2d867f092fb5)
