### PR TITLE
fix: Invalid versions redirect to latest

### DIFF
--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -1,13 +1,24 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { json } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { Outlet, useLoaderData } from '@remix-run/react'
 import { DocsLayout } from '~/components/DocsLayout'
-import { createLogo, getBranch, repo, useFormDocsConfig } from '~/projects/form'
+import {
+  availableVersions,
+  createLogo,
+  getBranch,
+  repo,
+  useFormDocsConfig,
+} from '~/projects/form'
 import { getTanstackDocsConfig } from '~/utils/config'
 
 export const loader = async (context: LoaderFunctionArgs) => {
   const { version } = context.params
   const branch = getBranch(version)
+
+  if (!availableVersions.concat('latest').includes(version!)) {
+    throw redirect(context.request.url.replace(version!, 'latest'))
+  }
+
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
 
   return json({

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
-import { json, useLoaderData } from '@remix-run/react'
+import { json, redirect, useLoaderData } from '@remix-run/react'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
@@ -9,12 +9,18 @@ import {
   createLogo,
   repo,
   useQueryDocsConfig,
+  availableVersions,
 } from '~/projects/query'
 import { getTanstackDocsConfig } from '~/utils/config'
 
 export const loader = async (context: LoaderFunctionArgs) => {
   const { version } = context.params
   const branch = getBranch(version)
+
+  if (!availableVersions.concat('latest').includes(version!)) {
+    throw redirect(context.request.url.replace(version!, 'latest'))
+  }
+
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
 
   return json({

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -1,7 +1,8 @@
-import { type LoaderFunctionArgs, json } from '@remix-run/node'
+import { type LoaderFunctionArgs, json, redirect } from '@remix-run/node'
 import { Outlet, useLoaderData } from '@remix-run/react'
 import { DocsLayout } from '~/components/DocsLayout'
 import {
+  availableVersions,
   createLogo,
   getBranch,
   repo,
@@ -12,6 +13,11 @@ import { getTanstackDocsConfig } from '~/utils/config'
 export const loader = async (context: LoaderFunctionArgs) => {
   const { version } = context.params
   const branch = getBranch(version)
+
+  if (!availableVersions.concat('latest').includes(version!)) {
+    throw redirect(context.request.url.replace(version!, 'latest'))
+  }
+
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
 
   return json({

--- a/app/routes/table.$version.docs.tsx
+++ b/app/routes/table.$version.docs.tsx
@@ -1,9 +1,10 @@
-import { Outlet, json, useLoaderData } from '@remix-run/react'
+import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import {
   getBranch,
   createLogo,
   repo,
   useTableDocsConfig,
+  availableVersions,
 } from '~/projects/table'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -14,6 +15,11 @@ import { getTanstackDocsConfig } from '~/utils/config'
 export const loader = async (context: LoaderFunctionArgs) => {
   const version = context.params.version
   const branch = getBranch(version)
+
+  if (!availableVersions.concat('latest').includes(version!)) {
+    throw redirect(context.request.url.replace(version!, 'latest'))
+  }
+
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
 
   return json({

--- a/app/routes/virtual.$version.docs.tsx
+++ b/app/routes/virtual.$version.docs.tsx
@@ -1,5 +1,6 @@
-import { Outlet, json, useLoaderData } from '@remix-run/react'
+import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import {
+  availableVersions,
   createLogo,
   getBranch,
   repo,
@@ -13,6 +14,11 @@ import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 export const loader = async (context: LoaderFunctionArgs) => {
   const version = context.params.version
   const branch = getBranch(version)
+
+  if (!availableVersions.concat('latest').includes(version!)) {
+    throw redirect(context.request.url.replace(version!, 'latest'))
+  }
+
   const tanstackDocsConfig = await getTanstackDocsConfig(repo, branch)
 
   return json({


### PR DESCRIPTION
Fixes the error that occurs for invalid versions (e.g. /table/v9/docs) described on #153