### PR TITLE
refactor: Simplify docs logic, fix loading framework from localStorage

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -11,6 +11,7 @@ import { Select } from '~/components/Select'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
 import { DocsCalloutBytes } from '~/components/DocsCalloutBytes'
+import { DocsLogo } from '~/components/DocsLogo'
 import type { DocsConfig } from '~/utils/config'
 
 export function DocsLayout({
@@ -19,7 +20,6 @@ export function DocsLayout({
   colorFrom,
   colorTo,
   textColor,
-  logo,
   config,
   children,
 }: {
@@ -28,7 +28,6 @@ export function DocsLayout({
   colorFrom: string
   colorTo: string
   textColor: string
-  logo: React.ReactNode
   config: DocsConfig
   children: React.ReactNode
 }) {
@@ -125,6 +124,15 @@ export function DocsLayout({
       </div>
     )
   })
+
+  const logo = (
+    <DocsLogo
+      name={name}
+      version={version}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+    />
+  )
 
   const smallMenu = (
     <div

--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -2,7 +2,7 @@ import { DocSearch } from '@docsearch/react'
 import * as React from 'react'
 import { CgClose, CgMenuLeft } from 'react-icons/cg'
 import { FaArrowLeft, FaArrowRight, FaTimes } from 'react-icons/fa'
-import { NavLink, Outlet, useMatches } from '@remix-run/react'
+import { NavLink, useMatches } from '@remix-run/react'
 import { last } from '~/utils/utils'
 import { Carbon } from '~/components/Carbon'
 import { LinkOrA } from '~/components/LinkOrA'
@@ -14,6 +14,8 @@ import { DocsCalloutBytes } from '~/components/DocsCalloutBytes'
 import type { DocsConfig } from '~/utils/config'
 
 export function DocsLayout({
+  name,
+  version,
   colorFrom,
   colorTo,
   textColor,
@@ -21,12 +23,14 @@ export function DocsLayout({
   config,
   children,
 }: {
+  name: string
+  version: string
   colorFrom: string
   colorTo: string
   textColor: string
   logo: React.ReactNode
   config: DocsConfig
-  children?: any
+  children: React.ReactNode
 }) {
   const frameworkConfig = config.frameworkConfig
   const versionConfig = config.versionConfig
@@ -218,7 +222,7 @@ export function DocsLayout({
       {largeMenu}
       <div className="flex w-full lg:w-[calc(100%-250px)] flex-1">
         <div className="min-w-0 min-h-0 flex relative justify-center flex-1">
-          {children || <Outlet />}
+          {children}
           <div
             className="fixed bottom-0 left-0 right-0
                         lg:pl-[250px] z-10"

--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -12,6 +12,7 @@ import { Select } from '~/components/Select'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
 import { DocsCalloutBytes } from '~/components/DocsCalloutBytes'
+import type { MenuItem } from '~/utils/config'
 
 export type DocsConfig = {
   docSearch: {
@@ -19,14 +20,7 @@ export type DocsConfig = {
     indexName: string
     apiKey: string
   }
-  menu: {
-    label: string | React.ReactNode
-    children: {
-      label: string | React.ReactNode
-      to: string
-      badge?: string
-    }[]
-  }[]
+  menu: MenuItem[]
 }
 
 export function DocsLayout({

--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -7,21 +7,11 @@ import { last } from '~/utils/utils'
 import { Carbon } from '~/components/Carbon'
 import { LinkOrA } from '~/components/LinkOrA'
 import { Search } from '~/components/Search'
-import type { SelectProps } from '~/components/Select'
 import { Select } from '~/components/Select'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
 import { DocsCalloutBytes } from '~/components/DocsCalloutBytes'
-import type { MenuItem } from '~/utils/config'
-
-export type DocsConfig = {
-  docSearch: {
-    appId: string
-    indexName: string
-    apiKey: string
-  }
-  menu: MenuItem[]
-}
+import type { DocsConfig } from '~/utils/config'
 
 export function DocsLayout({
   colorFrom,
@@ -29,8 +19,6 @@ export function DocsLayout({
   textColor,
   logo,
   config,
-  framework,
-  version,
   children,
 }: {
   colorFrom: string
@@ -38,10 +26,10 @@ export function DocsLayout({
   textColor: string
   logo: React.ReactNode
   config: DocsConfig
-  framework?: SelectProps
-  version?: SelectProps
   children?: any
 }) {
+  const frameworkConfig = config.frameworkConfig
+  const versionConfig = config.versionConfig
   const matches = useMatches()
   const lastMatch = last(matches)
 
@@ -158,20 +146,20 @@ export function DocsLayout({
           dark:bg-gray-900"
         >
           <div className="flex gap-4">
-            {framework?.selected ? (
+            {frameworkConfig?.selected ? (
               <Select
-                label={framework.label}
-                selected={framework.selected}
-                available={framework.available}
-                onSelect={framework.onSelect}
+                label={frameworkConfig.label}
+                selected={frameworkConfig.selected}
+                available={frameworkConfig.available}
+                onSelect={frameworkConfig.onSelect}
               />
             ) : null}
-            {version?.selected ? (
+            {versionConfig?.selected ? (
               <Select
-                label={version.label}
-                selected={version.selected}
-                available={version.available}
-                onSelect={version.onSelect}
+                label={versionConfig.label}
+                selected={versionConfig.selected}
+                available={versionConfig.available}
+                onSelect={versionConfig.onSelect}
               />
             ) : null}
           </div>
@@ -192,22 +180,22 @@ export function DocsLayout({
         />
       </div>
       <div className="flex gap-2 px-4">
-        {framework?.selected ? (
+        {frameworkConfig?.selected ? (
           <Select
             className="flex-[3_1_0%]"
-            label={framework.label}
-            selected={framework.selected}
-            available={framework.available}
-            onSelect={framework.onSelect}
+            label={frameworkConfig.label}
+            selected={frameworkConfig.selected}
+            available={frameworkConfig.available}
+            onSelect={frameworkConfig.onSelect}
           />
         ) : null}
-        {version?.selected ? (
+        {versionConfig?.selected ? (
           <Select
             className="flex-[2_1_0%]"
-            label={version.label}
-            selected={version.selected}
-            available={version.available}
-            onSelect={version.onSelect}
+            label={versionConfig.label}
+            selected={versionConfig.selected}
+            available={versionConfig.available}
+            onSelect={versionConfig.onSelect}
           />
         ) : null}
       </div>

--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -38,7 +38,6 @@ export function DocsLayout({
   framework,
   version,
   children,
-  v2,
 }: {
   colorFrom: string
   colorTo: string
@@ -48,7 +47,6 @@ export function DocsLayout({
   framework?: SelectProps
   version?: SelectProps
   children?: any
-  v2?: boolean
 }) {
   const matches = useMatches()
   const lastMatch = last(matches)
@@ -92,7 +90,7 @@ export function DocsLayout({
                   </a>
                 ) : (
                   <NavLink
-                    to={v2 ? child.to : framework ? '../' + child.to : child.to}
+                    to={child.to}
                     onClick={() => {
                       detailsRef.current.removeAttribute('open')
                     }}
@@ -246,13 +244,7 @@ export function DocsLayout({
             <div className="p-4 flex justify-center gap-4">
               {prevItem ? (
                 <LinkOrA
-                  to={
-                    v2
-                      ? prevItem.to
-                      : framework
-                      ? `../${prevItem.to}`
-                      : prevItem.to
-                  }
+                  to={prevItem.to}
                   className="flex gap-2 items-center py-1 px-2 text-sm self-start rounded-md
                 bg-white text-gray-600 dark:bg-black dark:text-gray-400
                 shadow-lg dark:border dark:border-gray-800
@@ -263,13 +255,7 @@ export function DocsLayout({
               ) : null}
               {nextItem ? (
                 <LinkOrA
-                  to={
-                    v2
-                      ? nextItem.to
-                      : framework
-                      ? `../${nextItem.to}`
-                      : nextItem.to
-                  }
+                  to={nextItem.to}
                   className="py-1 px-2 text-sm self-end rounded-md
                   bg-white dark:bg-black
                   shadow-lg dark:border dark:border-gray-800

--- a/app/components/DocsLogo.tsx
+++ b/app/components/DocsLogo.tsx
@@ -1,0 +1,26 @@
+import { Link } from '@remix-run/react'
+
+type Props = {
+  name: string
+  version: string
+  colorFrom: string
+  colorTo: string
+}
+
+export const DocsLogo = (props: Props) => {
+  const { name, version, colorFrom, colorTo } = props
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
+
+  return (
+    <>
+      <Link to="/" className="font-light">
+        TanStack
+      </Link>
+      <Link to="../../" className={`font-bold`}>
+        <span className={`${gradientText}`}>{name}</span>{' '}
+        <span className="text-sm align-super">{version}</span>
+      </Link>
+    </>
+  )
+}

--- a/app/projects/form.tsx
+++ b/app/projects/form.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -12,8 +11,9 @@ export const latestBranch = 'main'
 export const latestVersion = 'v0'
 export const availableVersions = ['v0']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-yellow-500 to-yellow-600'
+export const colorFrom = 'from-yellow-500'
+export const colorTo = 'to-yellow-600'
+export const textColor = 'text-yellow-600'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -22,20 +22,6 @@ const frameworks = {
 } as const
 
 export type Framework = keyof typeof frameworks
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to="../../" className={`font-bold`}>
-      <span className={`${gradientText}`}>Form</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const localMenu: MenuItem = {
   label: 'Menu',

--- a/app/projects/query.tsx
+++ b/app/projects/query.tsx
@@ -5,7 +5,6 @@ import vueLogo from '~/images/vue-logo.svg'
 import svelteLogo from '~/images/svelte-logo.svg'
 import angularLogo from '~/images/angular-logo.svg'
 import { useDocsConfig } from '~/utils/config'
-import { Link } from '@remix-run/react'
 import type { ConfigSchema, MenuItem } from '~/utils/config'
 
 export const repo = 'tanstack/query'
@@ -14,8 +13,9 @@ export const latestBranch = 'main'
 export const latestVersion = 'v5'
 export const availableVersions = ['v5', 'v4', 'v3']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-amber-500'
+export const colorFrom = 'from-red-500'
+export const colorTo = 'to-amber-500'
+export const textColor = 'text-amber-500'
 
 export const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -26,20 +26,6 @@ export const frameworks = {
 } as const
 
 export type Framework = keyof typeof frameworks
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to=".." className="font-bold">
-      <span className={`${gradientText}`}>Query</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const localMenu: MenuItem = {
   label: 'Menu',

--- a/app/projects/ranger.tsx
+++ b/app/projects/ranger.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import { FaDiscord, FaGithub } from 'react-icons/fa/index'
 import { useDocsConfig } from '~/utils/config'
@@ -10,28 +9,15 @@ export const latestBranch = 'main'
 export const latestVersion = 'v0'
 export const availableVersions = ['v0']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
+export const colorFrom = 'from-lime-500'
+export const colorTo = 'to-emerald-500'
+export const textColor = 'text-emerald-500'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
 } as const
 
 export type Framework = keyof typeof frameworks
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to=".." className="font-bold">
-      <span className={`${gradientText}`}>Ranger</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 const localMenu: MenuItem = {
   label: 'Menu',

--- a/app/projects/router.tsx
+++ b/app/projects/router.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import { FaDiscord, FaGithub } from 'react-icons/fa/index'
 import { useDocsConfig } from '~/utils/config'
@@ -10,28 +9,15 @@ export const latestBranch = 'main'
 export const latestVersion = 'v1'
 export const availableVersions = ['v1']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-lime-500 to-emerald-500'
+export const colorFrom = 'from-lime-500'
+export const colorTo = 'to-emerald-500'
+export const textColor = 'text-emerald-500'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
 } as const
 
 export type Framework = keyof typeof frameworks
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to=".." className="font-bold">
-      <span className={`${gradientText}`}>Router</span>
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const localMenu: MenuItem = {
   label: 'Menu',

--- a/app/projects/store.tsx
+++ b/app/projects/store.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -12,8 +11,9 @@ export const latestBranch = 'main'
 export const latestVersion = 'v0'
 export const availableVersions = ['v0']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-gray-500 to-gray-700'
+export const colorFrom = 'from-gray-500'
+export const colorTo = 'to-gray-700'
+export const textColor = 'text-gray-700'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -22,20 +22,6 @@ const frameworks = {
 } as const
 
 export type Framework = keyof typeof frameworks
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to="../../" className={`font-bold`}>
-      <span className={`${gradientText}`}>Store</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const localMenu: MenuItem = {
   label: 'Menu',

--- a/app/projects/table.tsx
+++ b/app/projects/table.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -13,8 +12,9 @@ export const latestBranch = 'main'
 export const latestVersion = 'v8'
 export const availableVersions = ['v8']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-blue-600'
+export const colorFrom = 'from-teal-500'
+export const colorTo = 'to-blue-600'
+export const textColor = 'text-blue-600'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -56,20 +56,6 @@ export const localMenu: MenuItem = {
     },
   ],
 }
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to="../../" className={`font-bold`}>
-      <span className={`${gradientText}`}>Table</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const useTableDocsConfig = (config: ConfigSchema) => {
   return useDocsConfig({

--- a/app/projects/virtual.tsx
+++ b/app/projects/virtual.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@remix-run/react'
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
@@ -12,8 +11,9 @@ export const latestBranch = 'main'
 export const latestVersion = 'v3'
 export const availableVersions = ['v3']
 
-export const gradientText =
-  'inline-block text-transparent bg-clip-text bg-gradient-to-r from-rose-500 to-violet-600'
+export const colorFrom = 'from-rose-500'
+export const colorTo = 'to-violet-600'
+export const textColor = 'text-violet-600'
 
 const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
@@ -55,20 +55,6 @@ export const localMenu: MenuItem = {
     },
   ],
 }
-
-export const createLogo = (version?: string) => (
-  <>
-    <Link to="/" className="font-light">
-      TanStack
-    </Link>
-    <Link to=".." className="font-bold">
-      <span className={`${gradientText}`}>Virtual</span>{' '}
-      <span className="text-sm align-super">
-        {version === 'latest' ? latestVersion : version}
-      </span>
-    </Link>
-  </>
-)
 
 export const useVirtualDocsConfig = (config: ConfigSchema) => {
   return useDocsConfig({

--- a/app/routes/form.$version._index.tsx
+++ b/app/routes/form.$version._index.tsx
@@ -17,7 +17,13 @@ import { Footer } from '~/components/Footer'
 import { VscPreview, VscWand } from 'react-icons/vsc'
 import { TbHeartHandshake } from 'react-icons/tb'
 import SponsorPack from '~/components/SponsorPack'
-import { getBranch, gradientText, latestVersion, repo } from '~/projects/form'
+import {
+  colorFrom,
+  colorTo,
+  getBranch,
+  latestVersion,
+  repo,
+} from '~/projects/form'
 import { Logo } from '~/components/Logo'
 import { getSponsorsForSponsorPack } from '~/server/sponsors'
 import type { Framework } from '~/projects/form'
@@ -128,7 +134,11 @@ export default function RouteVersion() {
             md:text-6xl
             lg:text-7xl`}
             >
-              <span className={gradientText}>TanStack Form</span>{' '}
+              <span
+                className={`inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`}
+              >
+                TanStack Form
+              </span>{' '}
               <span
                 className="text-[.5em] align-super text-black animate-bounce
               dark:text-white"

--- a/app/routes/form.$version._index.tsx
+++ b/app/routes/form.$version._index.tsx
@@ -98,6 +98,8 @@ export default function RouteVersion() {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
 
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
+
   return (
     <>
       <div className="flex flex-col gap-20 md:gap-32">
@@ -134,11 +136,7 @@ export default function RouteVersion() {
             md:text-6xl
             lg:text-7xl`}
             >
-              <span
-                className={`inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`}
-              >
-                TanStack Form
-              </span>{' '}
+              <span className={gradientText}>TanStack Form</span>{' '}
               <span
                 className="text-[.5em] align-super text-black animate-bounce
               dark:text-white"

--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -4,10 +4,12 @@ import { Outlet, useLoaderData } from '@remix-run/react'
 import { DocsLayout } from '~/components/DocsLayout'
 import {
   availableVersions,
-  createLogo,
+  colorFrom,
+  colorTo,
   getBranch,
   latestVersion,
   repo,
+  textColor,
   useFormDocsConfig,
 } from '~/projects/form'
 import { getTanstackDocsConfig } from '~/utils/config'
@@ -35,10 +37,9 @@ export default function Component() {
     <DocsLayout
       name="Form"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-rose-500'}
-      colorTo={'to-violet-500'}
-      textColor={'text-violet-500'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -6,6 +6,7 @@ import {
   availableVersions,
   createLogo,
   getBranch,
+  latestVersion,
   repo,
   useFormDocsConfig,
 } from '~/projects/form'
@@ -32,6 +33,8 @@ export default function Component() {
   let config = useFormDocsConfig(tanstackDocsConfig)
   return (
     <DocsLayout
+      name="Form"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-rose-500'}
       colorTo={'to-violet-500'}

--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -37,8 +37,6 @@ export default function Component() {
       colorTo={'to-violet-500'}
       textColor={'text-violet-500'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/routes/form.$version.docs.tsx
+++ b/app/routes/form.$version.docs.tsx
@@ -32,7 +32,6 @@ export default function Component() {
   let config = useFormDocsConfig(tanstackDocsConfig)
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-rose-500'}
       colorTo={'to-violet-500'}

--- a/app/routes/query.$version._index.tsx
+++ b/app/routes/query.$version._index.tsx
@@ -18,7 +18,13 @@ import { VscPreview, VscWand } from 'react-icons/vsc'
 import { TbHeartHandshake } from 'react-icons/tb'
 import SponsorPack from '~/components/SponsorPack'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
-import { getBranch, gradientText, latestVersion, repo } from '~/projects/query'
+import {
+  colorFrom,
+  colorTo,
+  getBranch,
+  latestVersion,
+  repo,
+} from '~/projects/query'
 import { Logo } from '~/components/Logo'
 import { LogoQueryGG } from '~/components/LogoQueryGG'
 import { getSponsorsForSponsorPack } from '~/server/sponsors'
@@ -93,6 +99,8 @@ export default function RouteVersion() {
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <>

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -49,8 +49,6 @@ export default function RouteFrameworkParam() {
         colorTo={'to-violet-500'}
         textColor={'text-violet-500'}
         config={config}
-        framework={config.frameworkConfig}
-        version={config.versionConfig}
       />
     </>
   )

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -44,7 +44,6 @@ export default function RouteFrameworkParam() {
     <>
       <QueryGGBanner />
       <DocsLayout
-        v2={true}
         logo={createLogo(version)}
         colorFrom={'from-rose-500'}
         colorTo={'to-violet-500'}

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -6,7 +6,9 @@ import { DocsLayout } from '~/components/DocsLayout'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
 import {
   getBranch,
-  createLogo,
+  colorFrom,
+  colorTo,
+  textColor,
   repo,
   useQueryDocsConfig,
   availableVersions,
@@ -47,10 +49,9 @@ export default function RouteFrameworkParam() {
       <DocsLayout
         name="Query"
         version={version === 'latest' ? latestVersion : version!}
-        logo={createLogo(version)}
-        colorFrom={'from-rose-500'}
-        colorTo={'to-violet-500'}
-        textColor={'text-violet-500'}
+        colorFrom={colorFrom}
+        colorTo={colorTo}
+        textColor={textColor}
         config={config}
       >
         <Outlet />

--- a/app/routes/query.$version.docs.tsx
+++ b/app/routes/query.$version.docs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
-import { json, redirect, useLoaderData } from '@remix-run/react'
+import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
@@ -10,6 +10,7 @@ import {
   repo,
   useQueryDocsConfig,
   availableVersions,
+  latestVersion,
 } from '~/projects/query'
 import { getTanstackDocsConfig } from '~/utils/config'
 
@@ -44,12 +45,16 @@ export default function RouteFrameworkParam() {
     <>
       <QueryGGBanner />
       <DocsLayout
+        name="Query"
+        version={version === 'latest' ? latestVersion : version!}
         logo={createLogo(version)}
         colorFrom={'from-rose-500'}
         colorTo={'to-violet-500'}
         textColor={'text-violet-500'}
         config={config}
-      />
+      >
+        <Outlet />
+      </DocsLayout>
     </>
   )
 }

--- a/app/routes/ranger.$version._index.tsx
+++ b/app/routes/ranger.$version._index.tsx
@@ -12,7 +12,7 @@ import { json } from '@remix-run/node'
 import { TbHeartHandshake, TbZoomQuestion } from 'react-icons/tb'
 import { VscPreview } from 'react-icons/vsc'
 import { RiLightbulbFlashLine } from 'react-icons/ri'
-import { gradientText, getBranch } from '~/projects/ranger'
+import { colorFrom, colorTo, getBranch } from '~/projects/ranger'
 import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import SponsorPack from '~/components/SponsorPack'
@@ -88,6 +88,8 @@ export default function TanStackRouterRoute() {
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <div className="flex flex-col gap-20 md:gap-32">

--- a/app/routes/ranger.$version.docs.tsx
+++ b/app/routes/ranger.$version.docs.tsx
@@ -45,8 +45,6 @@ export default function DocsRoute() {
       colorTo={'to-emerald-500'}
       textColor={'text-emerald-500'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/routes/ranger.$version.docs.tsx
+++ b/app/routes/ranger.$version.docs.tsx
@@ -5,8 +5,10 @@ import {
   useRangerDocsConfig,
   repo,
   getBranch,
-  createLogo,
+  colorTo,
   latestVersion,
+  colorFrom,
+  textColor,
 } from '~/projects/ranger'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -43,10 +45,9 @@ export default function DocsRoute() {
     <DocsLayout
       name="Ranger"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-lime-500'}
-      colorTo={'to-emerald-500'}
-      textColor={'text-emerald-500'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/ranger.$version.docs.tsx
+++ b/app/routes/ranger.$version.docs.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react'
 import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import {
+  availableVersions,
   useRangerDocsConfig,
   repo,
   getBranch,
   createLogo,
+  latestVersion,
 } from '~/projects/ranger'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
 import { getTanstackDocsConfig } from '~/utils/config'
 import type { MetaFunction, LoaderFunctionArgs } from '@remix-run/node'
-import { availableVersions } from '~/projects/form'
 
 export const loader = async (context: LoaderFunctionArgs) => {
   const { version } = context.params
@@ -40,6 +41,8 @@ export default function DocsRoute() {
   let config = useRangerDocsConfig(tanstackDocsConfig)
   return (
     <DocsLayout
+      name="Ranger"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-lime-500'}
       colorTo={'to-emerald-500'}

--- a/app/routes/ranger.$version.docs.tsx
+++ b/app/routes/ranger.$version.docs.tsx
@@ -40,7 +40,6 @@ export default function DocsRoute() {
   let config = useRangerDocsConfig(tanstackDocsConfig)
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-lime-500'}
       colorTo={'to-emerald-500'}

--- a/app/routes/router.$version._index.tsx
+++ b/app/routes/router.$version._index.tsx
@@ -12,7 +12,7 @@ import { json } from '@remix-run/node'
 import { TbHeartHandshake, TbZoomQuestion } from 'react-icons/tb'
 import { VscPreview } from 'react-icons/vsc'
 import { RiLightbulbFlashLine } from 'react-icons/ri'
-import { gradientText, getBranch } from '~/projects/router'
+import { colorFrom, colorTo, getBranch } from '~/projects/router'
 import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import SponsorPack from '~/components/SponsorPack'
@@ -90,6 +90,8 @@ export default function TanStackRouterRoute() {
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <div className="flex flex-col gap-20 md:gap-32">

--- a/app/routes/router.$version.docs.tsx
+++ b/app/routes/router.$version.docs.tsx
@@ -45,8 +45,6 @@ export default function DocsRoute() {
       colorTo={'to-emerald-500'}
       textColor={'text-emerald-500'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/routes/router.$version.docs.tsx
+++ b/app/routes/router.$version.docs.tsx
@@ -4,9 +4,11 @@ import {
   repo,
   getBranch,
   useRouterDocsConfig,
-  createLogo,
   availableVersions,
   latestVersion,
+  colorFrom,
+  colorTo,
+  textColor,
 } from '~/projects/router'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -43,10 +45,9 @@ export default function DocsRoute() {
     <DocsLayout
       name="Router"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-lime-500'}
-      colorTo={'to-emerald-500'}
-      textColor={'text-emerald-500'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/router.$version.docs.tsx
+++ b/app/routes/router.$version.docs.tsx
@@ -40,7 +40,6 @@ export default function DocsRoute() {
 
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-lime-500'}
       colorTo={'to-emerald-500'}

--- a/app/routes/router.$version.docs.tsx
+++ b/app/routes/router.$version.docs.tsx
@@ -6,6 +6,7 @@ import {
   useRouterDocsConfig,
   createLogo,
   availableVersions,
+  latestVersion,
 } from '~/projects/router'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -40,6 +41,8 @@ export default function DocsRoute() {
 
   return (
     <DocsLayout
+      name="Router"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-lime-500'}
       colorTo={'to-emerald-500'}

--- a/app/routes/store.$version._index.tsx
+++ b/app/routes/store.$version._index.tsx
@@ -9,7 +9,7 @@ import { Footer } from '~/components/Footer'
 import { VscPreview } from 'react-icons/vsc'
 import { TbHeartHandshake } from 'react-icons/tb'
 import SponsorPack from '~/components/SponsorPack'
-import { gradientText, latestVersion, repo } from '~/projects/store'
+import { colorFrom, colorTo, latestVersion, repo } from '~/projects/store'
 import { Logo } from '~/components/Logo'
 import { getSponsorsForSponsorPack } from '~/server/sponsors'
 
@@ -75,6 +75,8 @@ export const loader = async () => {
 export default function RouteVersion() {
   const { sponsors } = useLoaderData<typeof loader>()
   const { version } = useParams()
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <>

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -32,7 +32,6 @@ export default function Component() {
 
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-gray-700'}
       colorTo={'to-gray-900'}

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -5,6 +5,7 @@ import {
   availableVersions,
   createLogo,
   getBranch,
+  latestVersion,
   repo,
   useStoreDocsConfig,
 } from '~/projects/store'
@@ -32,6 +33,8 @@ export default function Component() {
 
   return (
     <DocsLayout
+      name="Store"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-gray-700'}
       colorTo={'to-gray-900'}

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -37,8 +37,6 @@ export default function Component() {
       colorTo={'to-gray-900'}
       textColor={'text-gray-700'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -7,6 +7,9 @@ import {
   getBranch,
   latestVersion,
   repo,
+  textColor,
+  colorFrom,
+  colorTo,
   useStoreDocsConfig,
 } from '~/projects/store'
 import { getTanstackDocsConfig } from '~/utils/config'
@@ -35,10 +38,9 @@ export default function Component() {
     <DocsLayout
       name="Store"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-gray-700'}
-      colorTo={'to-gray-900'}
-      textColor={'text-gray-700'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/store.$version.docs.tsx
+++ b/app/routes/store.$version.docs.tsx
@@ -3,7 +3,6 @@ import { Outlet, useLoaderData } from '@remix-run/react'
 import { DocsLayout } from '~/components/DocsLayout'
 import {
   availableVersions,
-  createLogo,
   getBranch,
   latestVersion,
   repo,

--- a/app/routes/table.$version._index.tsx
+++ b/app/routes/table.$version._index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-icons/fa'
 import { Link, useLoaderData } from '@remix-run/react'
 import { json } from '@remix-run/node'
-import { gradientText, getBranch } from '~/projects/table'
+import { colorFrom, colorTo, getBranch } from '~/projects/table'
 import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import { IoIosBody } from 'react-icons/io'
@@ -93,6 +93,8 @@ export default function ReactTableRoute() {
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <div className="flex flex-col gap-20 md:gap-32">

--- a/app/routes/table.$version.docs.tsx
+++ b/app/routes/table.$version.docs.tsx
@@ -50,8 +50,6 @@ export default function RouteReactTable() {
       colorTo={'to-blue-500'}
       textColor={'text-blue-500'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/routes/table.$version.docs.tsx
+++ b/app/routes/table.$version.docs.tsx
@@ -45,7 +45,6 @@ export default function RouteReactTable() {
 
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-teal-500'}
       colorTo={'to-blue-500'}

--- a/app/routes/table.$version.docs.tsx
+++ b/app/routes/table.$version.docs.tsx
@@ -5,6 +5,7 @@ import {
   repo,
   useTableDocsConfig,
   availableVersions,
+  latestVersion,
 } from '~/projects/table'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -45,6 +46,8 @@ export default function RouteReactTable() {
 
   return (
     <DocsLayout
+      name="Table"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-teal-500'}
       colorTo={'to-blue-500'}

--- a/app/routes/table.$version.docs.tsx
+++ b/app/routes/table.$version.docs.tsx
@@ -1,11 +1,13 @@
 import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import {
   getBranch,
-  createLogo,
   repo,
   useTableDocsConfig,
   availableVersions,
   latestVersion,
+  colorFrom,
+  colorTo,
+  textColor,
 } from '~/projects/table'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -48,10 +50,9 @@ export default function RouteReactTable() {
     <DocsLayout
       name="Table"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-teal-500'}
-      colorTo={'to-blue-500'}
-      textColor={'text-blue-500'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/virtual.$version._index.tsx
+++ b/app/routes/virtual.$version._index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-icons/fa'
 import { Link, useLoaderData } from '@remix-run/react'
 import { json } from '@remix-run/node'
-import { gradientText, getBranch } from '~/projects/virtual'
+import { colorFrom, colorTo, getBranch } from '~/projects/virtual'
 import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
 import { IoIosBody } from 'react-icons/io'
@@ -94,6 +94,8 @@ export default function ReactTableRoute() {
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
+
+  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${colorFrom} ${colorTo}`
 
   return (
     <div className="flex flex-col gap-20 md:gap-32">

--- a/app/routes/virtual.$version.docs.tsx
+++ b/app/routes/virtual.$version.docs.tsx
@@ -1,11 +1,13 @@
 import { Outlet, json, redirect, useLoaderData } from '@remix-run/react'
 import {
   availableVersions,
-  createLogo,
   getBranch,
   latestVersion,
   repo,
   useVirtualDocsConfig,
+  colorFrom,
+  colorTo,
+  textColor,
 } from '~/projects/virtual'
 import { seo } from '~/utils/seo'
 import { DocsLayout } from '~/components/DocsLayout'
@@ -45,10 +47,9 @@ export default function RouteVirtual() {
     <DocsLayout
       name="Virtual"
       version={version === 'latest' ? latestVersion : version!}
-      logo={createLogo(version)}
-      colorFrom={'from-rose-500'}
-      colorTo={'to-violet-500'}
-      textColor={'text-violet-500'}
+      colorFrom={colorFrom}
+      colorTo={colorTo}
+      textColor={textColor}
       config={config}
     >
       <Outlet />

--- a/app/routes/virtual.$version.docs.tsx
+++ b/app/routes/virtual.$version.docs.tsx
@@ -42,7 +42,6 @@ export default function RouteVirtual() {
 
   return (
     <DocsLayout
-      v2={true}
       logo={createLogo(version)}
       colorFrom={'from-rose-500'}
       colorTo={'to-violet-500'}

--- a/app/routes/virtual.$version.docs.tsx
+++ b/app/routes/virtual.$version.docs.tsx
@@ -3,6 +3,7 @@ import {
   availableVersions,
   createLogo,
   getBranch,
+  latestVersion,
   repo,
   useVirtualDocsConfig,
 } from '~/projects/virtual'
@@ -42,6 +43,8 @@ export default function RouteVirtual() {
 
   return (
     <DocsLayout
+      name="Virtual"
+      version={version === 'latest' ? latestVersion : version!}
       logo={createLogo(version)}
       colorFrom={'from-rose-500'}
       colorTo={'to-violet-500'}

--- a/app/routes/virtual.$version.docs.tsx
+++ b/app/routes/virtual.$version.docs.tsx
@@ -47,8 +47,6 @@ export default function RouteVirtual() {
       colorTo={'to-violet-500'}
       textColor={'text-violet-500'}
       config={config}
-      framework={config.frameworkConfig}
-      version={config.versionConfig}
     >
       <Outlet />
     </DocsLayout>

--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -15,6 +15,7 @@ export type MenuItem = {
   children: {
     label: string | React.ReactNode
     to: string
+    badge?: string
   }[]
 }
 
@@ -24,7 +25,6 @@ const menuItemSchema = z.object({
     z.object({
       label: z.string(),
       to: z.string(),
-
       badge: z.string().optional(),
     })
   ),
@@ -200,3 +200,5 @@ export const useDocsConfig = ({
     versionConfig,
   }
 }
+
+export type DocsConfig = ReturnType<typeof useDocsConfig>

--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -42,7 +42,7 @@ const configSchema = z.object({
     indexName: z.string(),
   }),
   menu: z.array(menuItemSchema),
-  frameworkMenus: z.array(frameworkMenuSchema).optional(),
+  frameworkMenus: z.array(frameworkMenuSchema),
   users: z.array(z.string()).optional(),
 })
 
@@ -98,33 +98,23 @@ export const useDocsConfig = ({
   const match = matches[matches.length - 1]
   const params = useParams()
   const version = params.version!
-  const framework = localStorage.getItem('framework') || 'react'
+  const localStorageFramework = localStorage.getItem('framework')
+  const framework = localStorageFramework
+    ? frameworks[localStorageFramework]
+      ? localStorageFramework
+      : 'react'
+    : 'react'
   const navigate = useNavigate()
 
   const frameworkMenuItems =
-    config.frameworkMenus?.find((d) => d.framework === framework)?.menuItems ??
+    config.frameworkMenus.find((d) => d.framework === framework)?.menuItems ??
     []
 
   const frameworkConfig = useMemo(() => {
-    if (!config.frameworkMenus) {
-      return undefined
-    }
-
-    const availableFrameworks = config.frameworkMenus?.reduce(
-      (acc: AvailableOptions, menuEntry) => {
-        if (menuEntry.framework in frameworks) {
-          acc[menuEntry.framework] =
-            frameworks[menuEntry.framework as keyof typeof frameworks]
-        }
-        return acc
-      },
-      { react: frameworks['react'] }
-    )
-
     return {
       label: 'Framework',
       selected: frameworks[framework] ? framework : 'react',
-      available: availableFrameworks,
+      available: frameworks,
       onSelect: (option: { label: string; value: string }) => {
         const url = generatePath(match.id, {
           ...match.params,
@@ -136,7 +126,7 @@ export const useDocsConfig = ({
         navigate(url)
       },
     }
-  }, [config, frameworks, framework, match, navigate])
+  }, [frameworks, framework, match, navigate])
 
   const versionConfig = useMemo(() => {
     const available = availableVersions.reduce(
@@ -169,16 +159,8 @@ export const useDocsConfig = ({
     }
   }, [version, match, navigate, availableVersions])
 
-  const docSearch: NonNullable<ConfigSchema['docSearch']> =
-    config.docSearch || {
-      appId: '',
-      apiKey: '',
-      indexName: '',
-    }
-
   return {
     ...config,
-    docSearch,
     menu: [
       localMenu,
       // Merge the two menus together based on their group labels

--- a/tanstack-docs-config.schema.json
+++ b/tanstack-docs-config.schema.json
@@ -4,7 +4,7 @@
   "title": "TanStack Docs Config",
   "description": "Config file for the documentation of a TanStack project.",
   "type": "object",
-  "required": ["docSearch", "menu"],
+  "required": ["docSearch", "menu", "frameworkMenus"],
   "additionalProperties": false,
   "properties": {
     "$schema": {


### PR DESCRIPTION
- Removed `v2`, `frameworkConfig` and `versionConfig` options on `<DocsLayout />`
- Moved `createLogo` logic into `<DocsLogo />` component
- Replaced `gradientText` with `colorFrom` and `colorTo`, which are now also applied to `<DocsLayout />`
- Marked `frameworkMenus` as required field in `config.json`
- Fixed missing docs when the framework saved in localStorage isn't available for that project