### PR TITLE
fix: Redirect old query docs path

### DIFF
--- a/app/routes/query.$version.docs.$.tsx
+++ b/app/routes/query.$version.docs.$.tsx
@@ -2,13 +2,18 @@ import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { repo, getBranch } from '~/projects/query'
 import { DefaultErrorBoundary } from '~/components/DefaultErrorBoundary'
 import { seo } from '~/utils/seo'
-import { useLoaderData, useParams } from '@remix-run/react'
+import { redirect, useLoaderData, useParams } from '@remix-run/react'
 import { loadDocs } from '~/utils/docs'
 import { Doc } from '~/components/Doc'
 
 export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, version } = context.params
   const { url } = context.request
+
+  // Temporary fix for old docs structure
+  if (url.includes('/docs/react/')) {
+    throw redirect(url.replace('/docs/react/', '/docs/framework/react/'))
+  }
 
   return loadDocs({
     repo,


### PR DESCRIPTION
Fixes #156, https://github.com/TanStack/query/issues/6772