### PR TITLE
Fix Algolia for the /query/latest/docs/react/reference pages

### DIFF
--- a/app/routes/query.$version.docs.$.tsx
+++ b/app/routes/query.$version.docs.$.tsx
@@ -10,6 +10,17 @@ export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, version } = context.params
   const { url } = context.request
 
+  const reactReferencePages = '/docs/react/reference'
+  const vueReferencePages = '/docs/vue/reference'
+
+  if (url.includes(reactReferencePages)) {
+    throw redirect(url.replace(reactReferencePages, '/docs/reference'))
+  }
+
+  if (url.includes(vueReferencePages)) {
+    throw redirect(url.replace(vueReferencePages, '/docs/reference'))
+  }
+
   // Temporary fix for old docs structure
   if (url.includes('/docs/react/')) {
     throw redirect(url.replace('/docs/react/', '/docs/framework/react/'))


### PR DESCRIPTION
Without this fix, all the /query/[version]/docs/[vue/react]/reference pages redirect to /query/[version]/docs/framework/react/overview, which breaks Algolia Search.

See these urls:
- https://tanstack.com/query/latest/docs/react/reference/QueryClient 
- https://tanstack.com/query/latest/docs/vue/reference/QueryClient