### PR TITLE
fix: Show correct framework sidebar

### DIFF
--- a/app/utils/config.ts
+++ b/app/utils/config.ts
@@ -48,15 +48,6 @@ const configSchema = z.object({
 
 export type ConfigSchema = z.infer<typeof configSchema>
 
-export function getCurrentlySelectedFrameworkFromLocalStorage(
-  selectedFramework?: string
-) {
-  const framework =
-    selectedFramework || localStorage.getItem('framework') || 'react'
-
-  return framework
-}
-
 /**
   Fetch the config file for the project and validate it.
   */
@@ -83,6 +74,24 @@ export async function getTanstackDocsConfig(repo: string, branch: string) {
   }
 }
 
+/**
+ * Use framework in URL path
+ * Otherwise use framework in localStorage if it exists for this project
+ * Otherwise fallback to react
+ */
+export function useCurrentFramework(frameworks: AvailableOptions) {
+  const { framework: paramsFramework } = useParams()
+  const localStorageFramework = localStorage.getItem('framework')
+
+  return paramsFramework
+    ? paramsFramework
+    : localStorageFramework
+    ? frameworks[localStorageFramework]
+      ? localStorageFramework
+      : 'react'
+    : 'react'
+}
+
 export const useDocsConfig = ({
   config,
   frameworks,
@@ -98,12 +107,7 @@ export const useDocsConfig = ({
   const match = matches[matches.length - 1]
   const params = useParams()
   const version = params.version!
-  const localStorageFramework = localStorage.getItem('framework')
-  const framework = localStorageFramework
-    ? frameworks[localStorageFramework]
-      ? localStorageFramework
-      : 'react'
-    : 'react'
+  const framework = useCurrentFramework(frameworks)
   const navigate = useNavigate()
 
   const frameworkMenuItems =


### PR DESCRIPTION
Currently, if you navigate to a framework route like `/query/latest/docs/framework/vue/guides/ssr`, but your previously selected framework (which gets saved in local storage) was a different framework (e.g. react), it will render the correct document, but the sidebar will show the local storage framework's options.

This hook prioritises the framework in the URL over the framework in local storage when choosing the sidebar docs to display.