### PR TITLE
Try fixing algolia search for Query again

### DIFF
--- a/app/routes/query.$version.docs.$.tsx
+++ b/app/routes/query.$version.docs.$.tsx
@@ -10,17 +10,6 @@ export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, version } = context.params
   const { url } = context.request
 
-  const reactReferencePages = '/docs/react/reference'
-  const vueReferencePages = '/docs/vue/reference'
-
-  if (url.includes(reactReferencePages)) {
-    throw redirect(url.replace(reactReferencePages, '/docs/reference'))
-  }
-
-  if (url.includes(vueReferencePages)) {
-    throw redirect(url.replace(vueReferencePages, '/docs/reference'))
-  }
-
   // Temporary fix for old docs structure
   if (url.includes('/docs/react/')) {
     throw redirect(url.replace('/docs/react/', '/docs/framework/react/'))

--- a/app/routes/query.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/query.$version.docs.framework.$framework.$.tsx
@@ -10,12 +10,21 @@ export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, framework, version } = context.params
   const { url } = context.request
 
+  let redirectPath = url.replace(/\/docs.*/, '/docs/framework/react/overview')
+
+  if (url.includes(`docs/framework/${framework}/reference`)) {
+    redirectPath = url.replace(
+      `docs/framework/${framework}/reference`,
+      'docs/reference'
+    )
+  }
+
   return loadDocs({
     repo,
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/framework/react/overview'),
+    redirectPath,
   })
 }
 

--- a/app/routes/query.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/query.$version.docs.framework.$framework.$.tsx
@@ -10,21 +10,12 @@ export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, framework, version } = context.params
   const { url } = context.request
 
-  let redirectPath = url.replace(/\/docs.*/, '/docs/framework/react/overview')
-
-  if (url.includes(`docs/framework/${framework}/reference`)) {
-    redirectPath = url.replace(
-      `docs/framework/${framework}/reference`,
-      'docs/reference'
-    )
-  }
-
   return loadDocs({
     repo,
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath,
+    redirectPath: url.replace(`/framework/${framework}`, ''),
   })
 }
 


### PR DESCRIPTION
https://github.com/TanStack/tanstack.com/pull/160 fixed this route:
- https://tanstack.com/query/latest/docs/react/reference/QueryClient
but broke this one:
- https://tanstack.com/query/latest/docs/react/reference/hydration

When I was making that PR I was unaware of the fact that not all `reference` docs are in same directory in `tanstack/query`. We currently have three directories named "reference":
- docs/framework/react/reference
- docs/framework/vue/reference
- docs/reference

