### PR TITLE
fix: Redirect all missing framework-specific routes to core routes

### DIFF
--- a/app/routes/form.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/form.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/overview'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/query.$version.docs.$.tsx
+++ b/app/routes/query.$version.docs.$.tsx
@@ -10,9 +10,14 @@ export const loader = async (context: LoaderFunctionArgs) => {
   const { '*': docsPath, version } = context.params
   const { url } = context.request
 
-  // Temporary fix for old docs structure
+  // Temporary fix for old react docs structure
   if (url.includes('/docs/react/')) {
     throw redirect(url.replace('/docs/react/', '/docs/framework/react/'))
+  }
+
+  // Temporary fix for old vue docs structure
+  if (url.includes('/docs/vue/')) {
+    throw redirect(url.replace('/docs/vue/', '/docs/framework/vue/'))
   }
 
   return loadDocs({

--- a/app/routes/query.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/query.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(`/framework/${framework}`, ''),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/ranger.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/ranger.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/overview'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/router.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/router.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/framework/react/overview'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/store.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/store.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/overview'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/table.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/table.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/introduction'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 

--- a/app/routes/virtual.$version.docs.framework.$framework.$.tsx
+++ b/app/routes/virtual.$version.docs.framework.$framework.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/framework/${framework}/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/introduction'),
+    redirectPath: url.replace(`/docs/framework/${framework}/`, '/docs/'),
   })
 }
 


### PR DESCRIPTION
- Generalises the pattern introduced in #162
- Also fixes old vue path redirects for query (https://github.com/TanStack/query/issues/6770)