### PR TITLE
Add Angular to the framework picker for Store

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -276,6 +276,8 @@ export function DocsLayout({
                                   ? 'text-orange-500'
                                   : child.badge === 'vue'
                                   ? 'text-green-500'
+                                  : child.badge === 'angular'
+                                  ? 'text-fuchsia-500'
                                   : 'text-gray-500'
                               }`}
                             >

--- a/app/projects/store.ts
+++ b/app/projects/store.ts
@@ -1,6 +1,7 @@
 import reactLogo from '~/images/react-logo.svg'
 import solidLogo from '~/images/solid-logo.svg'
 import vueLogo from '~/images/vue-logo.svg'
+import angularLogo from '~/images/angular-logo.svg'
 
 export const repo = 'tanstack/store'
 
@@ -16,6 +17,7 @@ export const frameworks = {
   react: { label: 'React', logo: reactLogo, value: 'react' },
   solid: { label: 'Solid', logo: solidLogo, value: 'solid' },
   vue: { label: 'Vue', logo: vueLogo, value: 'vue' },
+  angular: { label: 'Angular', logo: angularLogo, value: 'angular' },
 } as const
 
 export type Framework = keyof typeof frameworks


### PR DESCRIPTION
We have docs for Angular now for TanStack Store (see https://github.com/TanStack/store/pull/41).