### PR TITLE
Update stackblitz embed src from /simple → /fixed

### DIFF
--- a/app/routes/ranger.$version._index.tsx
+++ b/app/routes/ranger.$version._index.tsx
@@ -317,7 +317,7 @@ export default function TanStackRouterRoute() {
       <div className="bg-white dark:bg-black">
         <iframe
           key={framework}
-          src={`https://stackblitz.com/github/${repo}/tree/${branch}/examples/${framework}/simple?embed=1&theme=${
+          src={`https://stackblitz.com/github/${repo}/tree/${branch}/examples/${framework}/basic?embed=1&theme=${
             isDark ? 'dark' : 'light'
           }`}
           title="tannerlinsley/react-ranger: basic"

--- a/app/routes/virtual.$version._index.tsx
+++ b/app/routes/virtual.$version._index.tsx
@@ -423,7 +423,7 @@ export default function ReactTableRoute() {
         <div className="bg-white dark:bg-black">
           <iframe
             key={framework}
-            src={`https://stackblitz.com/github/${repo}/tree/${branch}/examples/${framework}/simple?embed=1&theme=${
+            src={`https://stackblitz.com/github/${repo}/tree/${branch}/examples/${framework}/fixed?embed=1&theme=${
               isDark ? 'dark' : 'light'
             }`}
             title="tannerlinsley/react-table: dynamic"


### PR DESCRIPTION
fixes #174

- `examples/${framework}/simple` doesn’t exist in any of the `react`, `svelte`, or `vue` examples folders
- `examples/${framework}/fixed` does exist in all of the framework example folders and seems like the equivalent to “simple”