### PR TITLE
fix(angular-query): WebContainers template for Stackblitz examples fixes broken Angular examples

### DIFF
--- a/app/routes/query.$version.docs.framework.$framework.examples.$.tsx
+++ b/app/routes/query.$version.docs.framework.$framework.examples.$.tsx
@@ -38,9 +38,11 @@ export default function RouteExamples() {
   }, [])
 
   const githubUrl = `https://github.com/${repo}/tree/${branch}/examples/${examplePath}`
+  // preset=node can be removed once Stackblitz runs Angular as webcontainer by default
+  // https://github.com/stackblitz/core/issues/2957
   const stackBlitzUrl = `https://stackblitz.com/github/${repo}/tree/${branch}/examples/${examplePath}?embed=1&theme=${
     isDark ? 'dark' : 'light'
-  }`
+  }&preset=node`
   const codesandboxUrl = `https://codesandbox.io/s/github/${repo}/tree/${branch}/examples/${examplePath}?embed=1&theme=${
     isDark ? 'dark' : 'light'
   }`


### PR DESCRIPTION
By default, StackBlitz runs Angular CLI applications with an Angular template. WebContainers work much better however. [StackBlitz are looking into changing this default](https://github.com/stackblitz/core/issues/2957) In the meantime this commit adds the `preset=node` parameter to the StackBlitz embed which makes sure a WebContainers template is used (as described in the linked StackBlitz issue).

I confirmed all other framework examples already run as WebContainers even without the parameter so nothing will change there. Once the default template changes, the parameter can be removed.

The Angular examples based on the Angular CLI are currently non-functional in Stackblitz. See screenshots for the Angular infinite query example with and without `preset=node`

<img width="1656" alt="Screenshot 2024-02-10 at 22 27 28" src="https://github.com/TanStack/tanstack.com/assets/6420061/f1d899bc-c6e8-415f-ae1d-be69b121a19e">
<img width="1656" alt="Screenshot 2024-02-10 at 22 27 32" src="https://github.com/TanStack/tanstack.com/assets/6420061/7156a86b-c25d-4d5c-a4ad-13e4f5bb6830">

