### PR TITLE
Add Angular to Query's description

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -43,7 +43,7 @@ const libraries = [
       `shadow-xl shadow-red-700/20 dark:shadow-lg dark:shadow-red-500/30 text-red-500 border-2 border-transparent hover:border-current`,
     to: '/query',
     tagline: `Powerful asynchronous state management, server-state utilities and data fetching`,
-    description: `Fetch, cache, update, and wrangle all forms of async data in your TS/JS, React, Vue, Solid & Svelte applications all without touching any "global state".`,
+    description: `Fetch, cache, update, and wrangle all forms of async data in your TS/JS, React, Vue, Solid, Svelte & Angular applications all without touching any "global state".`,
   },
   {
     name: 'TanStack Table',


### PR DESCRIPTION
The Query's mention to Angular currently exists on `tanstack.com/query` but not on the global TanStack homepage, so I simply added it.

_Before_
![image](https://github.com/TanStack/tanstack.com/assets/110823300/e5805468-c752-4f23-b061-2d25ca5a25a1)

_After_
![image](https://github.com/TanStack/tanstack.com/assets/110823300/9b36071e-e337-4207-98b3-5413bfc4e19b)
