### PR TITLE
fix Search redirect path

### DIFF
--- a/app/routes/router.$version.docs.$.tsx
+++ b/app/routes/router.$version.docs.$.tsx
@@ -15,7 +15,7 @@ export const loader = async (context: LoaderFunctionArgs) => {
     branch: getBranch(version),
     docPath: `docs/${docsPath}`,
     currentPath: url,
-    redirectPath: url.replace(/\/docs.*/, '/docs/framework/react/overview'),
+    redirectPath: url.replace(/\/docs(.*)/, '/docs/framework/react$1'),
   })
 }
 


### PR DESCRIPTION
Search results in router docs still point to urls like: `/router/v1/docs/api/router/useParamsHook` which allways redirects to `https://tanstack.com/router/v1/docs/framework/react/overview`.
Fixes #187