### PR TITLE
style: enhance sponsor link hover transition

### DIFF
--- a/app/components/SponsorPack.tsx
+++ b/app/components/SponsorPack.tsx
@@ -44,6 +44,7 @@ export default function SponsorPack({ sponsors }: { sponsors: any }) {
               .spon-link {
                 transition: all .2s ease;
                 transform: translate(-50%, -50%);
+                will-change: transform;
               }
 
               .spon-link:hover {


### PR DESCRIPTION
When hovering over a sponsor link/logo, the transition snaps.

Move the transition to the GPU by adding the CSS declaration `will-change: transform;`.
This makes the transition smoother and fixes the snapping.

https://github.com/TanStack/tanstack.com/assets/69698193/c057b0b5-31cb-42b5-a095-711f64b09d65