### PR TITLE
docs(router): update bundle size

### DIFF
--- a/app/routes/_libraries.router.$version.index.tsx
+++ b/app/routes/_libraries.router.$version.index.tsx
@@ -238,7 +238,7 @@ function RouterVersionIndex() {
             'Parallel Route Loaders',
             '1st-class Search Param APIs',
             'Nested/Layout Routes',
-            'Lightweight (12kb)',
+            'Lightweight (19kb)',
             'Suspense + Transitions',
             'Strict Navigation',
             'Auto-completed Paths',


### PR DESCRIPTION
According to `https://pkg-size.dev/@tanstack%2Freact-router@1.26.10?no-peers`, the bundle size when bundling with `esbuild` is at 19KB gzip (for version 1.26.10)