### PR TITLE
fix: title and descriptions on the docs examples route and using the params fields when throwing redirects in the loader

### DIFF
--- a/app/routes/$libraryId.$version.docs.framework.$framework.examples.$.tsx
+++ b/app/routes/$libraryId.$version.docs.framework.$framework.examples.$.tsx
@@ -16,10 +16,10 @@ export const Route = createFileRoute(
     return seo({
       title: `${capitalize(params.framework)} ${library.name} ${slugToTitle(
         params._splat
-      )} Example | TanStack Form Docs`,
+      )} Example | ${library.name} Docs`,
       description: `An example showing how to implement ${slugToTitle(
         params._splat
-      )} in ${capitalize(params.framework)} Form`,
+      )} in ${capitalize(params.framework)} using ${library.name}.`,
     })
   },
   component: Example,

--- a/app/routes/$libraryId.$version.docs.index.tsx
+++ b/app/routes/$libraryId.$version.docs.index.tsx
@@ -7,7 +7,13 @@ export const Route = createFileRoute('/$libraryId/$version/docs/')({
     const library = getLibrary(libraryId)
 
     throw redirect({
-      to: `/$libraryId/$version/docs/${library.defaultDocs || 'overview'}`,
+      // to: `/$libraryId/$version/docs/${library.defaultDocs || 'overview'}`,
+      to: '/$libraryId/$version/docs/$',
+      params: {
+        libraryId,
+        version: ctx.params.version,
+        _splat: library.defaultDocs || 'overview',
+      },
     })
   },
 })

--- a/app/routes/$libraryId.index.tsx
+++ b/app/routes/$libraryId.index.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/$libraryId/')({
-  loader: () => {
+  loader: ({ params }) => {
     throw redirect({
       to: '/$libraryId/$version',
       params: {
+        libraryId: params.libraryId,
         version: 'latest',
       },
     })


### PR DESCRIPTION
Fixes:
* Incorrect title and description on the example pages.

Chore:
* Passing in the params to the redirect throws on couple pages in their loaders.