### PR TITLE
docs: Fix incorrect ogImage link

### DIFF
--- a/app/libraries/store.ts
+++ b/app/libraries/store.ts
@@ -7,7 +7,7 @@ export const storeProject: Library = {
   to: '/store',
   tagline: `Framework agnostic data store with reactive framework adapters`,
   description: `The immutable-reactive data store that powers the core of TanStack libraries and their framework adapters.`,
-  ogImage: 'https://github.com/tanstack/config/raw/main/media/repo-header.png',
+  ogImage: 'https://github.com/tanstack/store/raw/main/media/repo-header.png',
   badge: 'new',
   bgStyle: 'bg-stone-700',
   textStyle: 'text-stone-500',


### PR DESCRIPTION
I found incorrect ogImage link in `store.ts` and fixed like this :)

```typescript
export const storeProject: Library = {
  id: 'store',
  name: 'TanStack Store',
  cardStyles: `shadow-xl shadow-stone-700/20 dark:shadow-lg dark:shadow-stone-500/20 text-stone-500 dark:text-stone-400 border-2 border-transparent hover:border-current`,
  to: '/store',
  tagline: `Framework agnostic data store with reactive framework adapters`,
  description: `The immutable-reactive data store that powers the core of TanStack libraries and their framework adapters.`,
  // ogImage: 'https://github.com/tanstack/config/raw/main/media/repo-header.png',  // before
  ogImage: 'https://github.com/tanstack/store/raw/main/media/repo-header.png', // fixed
  badge: 'new',
  bgStyle: 'bg-stone-700',
  textStyle: 'text-stone-500',
  repo: 'tanstack/store',
  latestBranch: 'main',
  latestVersion: 'v0',
  availableVersions: ['v0'],
  colorFrom: 'from-stone-500',
  colorTo: 'to-stone-700',
  textColor: 'text-stone-700',
  frameworks: ['react', 'solid', 'vue', 'angular'],
  scarfId: '302d0fef-cb3f-43c6-b45c-f055b9745edb',
  defaultDocs: 'framework/react/overview',
}
```

