### PR TITLE
feat: show main sandbox files on load

### DIFF
--- a/app/routes/_libraries.table.$version.index.tsx
+++ b/app/routes/_libraries.table.$version.index.tsx
@@ -20,6 +20,7 @@ import agGridImage from '~/images/ag-grid.png'
 import { Await } from '@tanstack/react-router'
 import { Framework, getBranch } from '~/libraries'
 import { seo } from '~/utils/seo'
+import { getInitialSandboxFileName } from '~/utils/sandbox'
 
 const menu = [
   {
@@ -89,6 +90,8 @@ export default function TableVersionIndex() {
   const branch = getBranch(tableProject, version)
   const [framework, setFramework] = React.useState<Framework>('react')
   const [isDark, setIsDark] = React.useState(true)
+
+  const sandboxFirstFileName = getInitialSandboxFileName(framework)
 
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
@@ -449,7 +452,7 @@ export default function TableVersionIndex() {
             tableProject.repo
           }/tree/${branch}/examples/${framework}/basic?embed=1&theme=${
             isDark ? 'dark' : 'light'
-          }`}
+          }&file=${sandboxFirstFileName}`}
           title="tannerlinsley/react-table: basic"
           sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
           className="shadow-2xl"

--- a/app/utils/sandbox.ts
+++ b/app/utils/sandbox.ts
@@ -1,0 +1,12 @@
+import { type Framework } from '~/libraries'
+
+export const getInitialSandboxFileName = (framework: Framework) =>
+  framework === 'svelte'
+    ? 'src/App.svelte'
+    : framework === 'vue'
+    ? 'src/App.vue'
+    : framework === 'solid'
+    ? 'src/App.tsx'
+    : framework === 'angular'
+    ? 'src/app/app.component.ts'
+    : 'src/main.tsx'


### PR DESCRIPTION
Simply trying to get the docs to open the main file devs will be interested in by default

<img width="987" alt="image" src="https://github.com/TanStack/tanstack.com/assets/28243511/baac9146-2aa5-4de5-a522-97180bb63462">
