### PR TITLE
feat(router): opt-out of codesanbox examples

### DIFF
--- a/app/libraries/index.tsx
+++ b/app/libraries/index.tsx
@@ -53,6 +53,8 @@ export type Library = {
   scarfId?: string
   defaultDocs?: string
   handleRedirects?: (href: string) => void
+  hideCodesandboxUrl?: true
+  hideStackblitzUrl?: true
 }
 
 export const libraries = [

--- a/app/libraries/router.ts
+++ b/app/libraries/router.ts
@@ -21,4 +21,5 @@ export const routerProject: Library = {
   frameworks: ['react'],
   scarfId: '3d14fff2-f326-4929-b5e1-6ecf953d24f4',
   defaultDocs: 'framework/react/overview',
+  hideCodesandboxUrl: true,
 }

--- a/app/routes/$libraryId.$version.docs.framework.$framework.examples.$.tsx
+++ b/app/routes/$libraryId.$version.docs.framework.$framework.examples.$.tsx
@@ -52,6 +52,9 @@ export default function Example() {
     isDark ? 'dark' : 'light'
   }`
 
+  const hideStackblitz = !!library.hideStackblitzUrl
+  const hideCodesandbox = !!library.hideCodesandboxUrl
+
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-auto">
       <div className="p-4 lg:p-6">
@@ -68,22 +71,26 @@ export default function Example() {
             >
               <FaExternalLinkAlt /> Github
             </a>
-            <a
-              href={stackBlitzUrl}
-              target="_blank"
-              className="flex gap-1 items-center"
-              rel="noreferrer"
-            >
-              <FaExternalLinkAlt /> StackBlitz
-            </a>
-            <a
-              href={codesandboxUrl}
-              target="_blank"
-              className="flex gap-1 items-center"
-              rel="noreferrer"
-            >
-              <FaExternalLinkAlt /> CodeSandbox
-            </a>
+            {!hideStackblitz ? (
+              <a
+                href={stackBlitzUrl}
+                target="_blank"
+                className="flex gap-1 items-center"
+                rel="noreferrer"
+              >
+                <FaExternalLinkAlt /> StackBlitz
+              </a>
+            ) : null}
+            {!hideCodesandbox ? (
+              <a
+                href={codesandboxUrl}
+                target="_blank"
+                className="flex gap-1 items-center"
+                rel="noreferrer"
+              >
+                <FaExternalLinkAlt /> CodeSandbox
+              </a>
+            ) : null}
           </div>
         </DocTitle>
       </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
-import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { defineConfig } from 'vite'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 export default defineConfig({
   build: {
@@ -9,8 +9,8 @@ export default defineConfig({
     // Put the Sentry vite plugin after all other plugins
     sentryVitePlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: "tanstack",
-      project: "tanstack-com",
+      org: 'tanstack',
+      project: 'tanstack-com',
     }),
   ],
-});
+})


### PR DESCRIPTION
Opting-out of providing codesanbox urls for Router.

CSB repros are practically impossible to make changes to and test alternatives **AND** they make you need to pray to a deity to actually get the packages to upgrade to latest.