### PR TITLE
fix: angular examples

### DIFF
--- a/app/routes/_libraries.form.$version.index.tsx
+++ b/app/routes/_libraries.form.$version.index.tsx
@@ -391,7 +391,7 @@ export default function FormVersionIndex() {
               formProject.repo
             }/tree/${branch}/examples/${framework}/simple?embed=1&theme=${
               isDark ? 'dark' : 'light'
-            }`}
+            }&preset=node`}
             title={`tanstack//${framework}-form: simple`}
             sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
             className="shadow-2xl max-h-[800px]"

--- a/app/routes/_libraries.query.$version.index.tsx
+++ b/app/routes/_libraries.query.$version.index.tsx
@@ -536,7 +536,7 @@ export default function VersionIndex() {
                   queryProject.repo
                 }/tree/${branch}/examples/${framework}/simple?embed=1&theme=${
                   isDark ? 'dark' : 'light'
-                }`}
+                }&preset=node`}
                 title={`tannerlinsley/${framework}-query: basic`}
                 sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
                 className="shadow-2xl"

--- a/app/routes/_libraries.table.$version.index.tsx
+++ b/app/routes/_libraries.table.$version.index.tsx
@@ -453,7 +453,7 @@ export default function TableVersionIndex() {
             tableProject.repo
           }/tree/${branch}/examples/${framework}/basic?embed=1&theme=${
             isDark ? 'dark' : 'light'
-          }&file=${sandboxFirstFileName}`}
+          }&preset=node&file=${sandboxFirstFileName}`}
           title="tannerlinsley/react-table: basic"
           sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
           className="shadow-2xl"


### PR DESCRIPTION
The Angular examples for
- Query
- Form
- Table

show errors and do not run because StackBlitz is not configured to always use Webcontainers. For Angular StackBlitz will then default to their [legacy EngineBlock technology](https://github.com/stackblitz/core/issues/2957) which does not work for recent Angular versions.

This PR adds a parameter to make sure Webcontainers is used instead.