### PR TITLE
fix: headings collapsing when there is no content to separate them

### DIFF
--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -21,7 +21,7 @@ export function Doc({
       <div className="h-4" />
       <div className="h-px bg-gray-500 opacity-20" />
       <div className="h-4" />
-      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none grid">
+      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none md:grid">
         <Markdown code={content} />
       </div>
       <div className="h-12" />

--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -21,7 +21,7 @@ export function Doc({
       <div className="h-4" />
       <div className="h-px bg-gray-500 opacity-20" />
       <div className="h-4" />
-      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none md:grid">
+      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none">
         <Markdown code={content} />
       </div>
       <div className="h-12" />

--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -21,7 +21,7 @@ export function Doc({
       <div className="h-4" />
       <div className="h-px bg-gray-500 opacity-20" />
       <div className="h-4" />
-      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none">
+      <div className="prose prose-gray prose-sm dark:prose-invert max-w-none grid">
         <Markdown code={content} />
       </div>
       <div className="h-12" />

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -89,6 +89,7 @@
 
   .anchor-heading {
     text-decoration: none !important;
+    display: block;
   }
 
   .anchor-heading > *:after {


### PR DESCRIPTION
Currently, all headings extracted from the markdown files are wrapped in anchor tags.

Since anchor tags have a display property of `inline`, when there are adjacent headings and no content to separate them, it causes the headings to collapse onto one another into a single line. See the screenshot below.

<img width="1430" alt="Screenshot 2024-06-17 at 20 29 05" src="https://github.com/TanStack/tanstack.com/assets/33615041/2dc41979-b63e-4d6c-bb69-b8bf94f6c006">

The easiest fix for this, without having to use specific CSS selectors, is to set the `display: grid;` on the outer block containing the markdown content. This fixes the bug and restores order to world 🙌🏼. See the screenshot below.

<img width="1429" alt="Screenshot 2024-06-17 at 21 53 39" src="https://github.com/TanStack/tanstack.com/assets/33615041/a0bd077e-913e-48e4-8a10-48d1210d1cfa">
