### PR TITLE
feat: support rewriting a doc's image source to the current branch

### DIFF
--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -133,13 +133,7 @@ function replaceSections(
   return result
 }
 
-function replaceImageBranchRef(
-  text: string,
-  owner: string,
-  repo: string,
-  ref: string
-) {
-  const repoPair = `${owner}/${repo}`
+function replaceImageBranchRef(text: string, repoPair: string, ref: string) {
   const possibleOrigins = [
     // HTTPS versions
     'https://raw.githubusercontent.com/',
@@ -258,7 +252,7 @@ export async function fetchRepoFile(
               text = replaceContent(text, originFrontmatter)
               text = replaceSections(text, originFrontmatter)
             }
-            text = replaceImageBranchRef(text, owner, repo, ref)
+            text = replaceImageBranchRef(text, repoPair, ref)
             return Promise.resolve(text)
           }
           // If file has a ref to another file, cache current front-matter and load referenced file

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -185,7 +185,7 @@ function replaceProjectImageBranch(
     return newSrc
   }
 
-  // find all instances of markdown image syntax
+  // find all instances of markdown inline images
   const markdownInlineImageRegex = /\!(\[([^\]]+)\]\(([^)]+)\))/g
   const inlineMarkdownImageMatches = text.matchAll(markdownInlineImageRegex)
   for (const match of inlineMarkdownImageMatches) {
@@ -195,7 +195,7 @@ function replaceProjectImageBranch(
     text = text.replace(fullInlineMatch, replacement)
   }
 
-  // find all instances of markdown image html tag
+  // find all instances of markdown html images
   const markdownImageHtmlTagRegex = /<img[^>]+>/g
   const htmlImageTagMatches = text.matchAll(markdownImageHtmlTagRegex)
   for (const match of htmlImageTagMatches) {

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -169,7 +169,8 @@ function replaceImageBranchRef(text: string, repoPair: string, ref: string) {
 
     // Only replace the branch ref if it is present and only immediately after the repo pair
     // It should NOT be replaced if it is further down the path.
-    // If the ref is "main" and the src is "https://github.com/TanStack/router/beta/docs/assets/beta.png"
+
+    // Example: If the ref is "main" and the src is "https://github.com/TanStack/router/beta/docs/assets/beta.png"
     // then the replaced src should be "https://github.com/TanStack/router/main/docs/assets/beta.png"
 
     const branchIndex = repoIndex + repoPair.length + 1

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -199,29 +199,43 @@ function replaceProjectImageBranch(
   const markdownInlineImageRegex = /\!(\[([^\]]+)\]\(([^)]+)\))/g
   const inlineMarkdownImageMatches = text.matchAll(markdownInlineImageRegex)
   for (const match of inlineMarkdownImageMatches) {
-    const [fullInlineMatch, _, alt, src] = match
+    const [fullMatch, _, __, src] = match
     const newSrc = handleReplaceImageSrc(src)
-    const replacement = `![${alt}](${newSrc})`
-    text = text.replace(fullInlineMatch, replacement)
+
+    // No need to replace the src if it is the same as the original
+    if (newSrc === src) {
+      continue
+    }
+
+    const replacement = fullMatch.replace(src, newSrc)
+    text = text.replace(fullMatch, replacement)
   }
 
   // find all instances of markdown html images
   const markdownImageHtmlTagRegex = /<img[^>]+>/g
   const htmlImageTagMatches = text.matchAll(markdownImageHtmlTagRegex)
   for (const match of htmlImageTagMatches) {
-    const [fullImageTagMatch] = match
+    const [fullMatch] = match
 
-    // can have single or double quotes
+    // Match the src attribute on the img tag
+    // The src could be wrapped with single or double quotes
     const src =
-      fullImageTagMatch.match(/src='([^']+)'/)?.[1] ||
-      fullImageTagMatch.match(/src="([^"]+)"/)?.[1]
+      fullMatch.match(/src='([^']+)'/)?.[1] ||
+      fullMatch.match(/src="([^"]+)"/)?.[1]
+
     if (!src) {
       continue
     }
 
     const newSrc = handleReplaceImageSrc(src)
-    const replacement = fullImageTagMatch.replace(src, newSrc)
-    text = text.replace(fullImageTagMatch, replacement)
+
+    // No need to replace the src if it is the same as the original
+    if (newSrc === src) {
+      continue
+    }
+
+    const replacement = fullMatch.replace(src, newSrc)
+    text = text.replace(fullMatch, replacement)
   }
 
   return text

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -166,7 +166,13 @@ function replaceProjectImageBranch(
       return src
     }
 
-    // Only replace the branch ref if it is present and only immediately after the repo pair
+    // If the branch ref is the same as the target ref, return the src as is
+    const refIndex = srcLowered.indexOf(ref.toLowerCase())
+    if (refIndex !== -1 && refIndex === repoIndex + repoPair.length + 1) {
+      return src
+    }
+
+    // We should only replace the branch ref if it is present and only immediately after the repo pair
     // It should NOT be replaced if it is further down the path.
 
     // Example: If the ref is "main" and the src is "https://github.com/TanStack/router/beta/docs/assets/beta.png"

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -133,28 +133,27 @@ function replaceSections(
   return result
 }
 
-function replaceImageBranchRef(text: string, repoPair: string, ref: string) {
-  const possibleOrigins = [
-    // HTTPS versions
-    'https://raw.githubusercontent.com/',
-    // HTTP versions
-    'http://raw.githubusercontent.com/',
-  ]
-
+function replaceProjectImageBranch(
+  text: string,
+  repoPair: string,
+  ref: string
+) {
   const handleReplaceImageSrc = (src: string): string => {
     const srcLowered = src.toLowerCase()
+    const isHttps = srcLowered.startsWith('https://')
 
-    let possibleOrigin
+    const testOrigin = isHttps
+      ? 'https://raw.githubusercontent.com/'
+      : 'http://raw.githubusercontent.com/'
 
-    for (const origin of possibleOrigins) {
-      if (srcLowered.startsWith(origin)) {
-        possibleOrigin = origin
-        break
-      }
+    let validSrcOrigin: string | undefined
+
+    if (srcLowered.startsWith(testOrigin)) {
+      validSrcOrigin = testOrigin
     }
 
     // If the image src does not start with a known origin, return the src as is
-    if (!possibleOrigin) {
+    if (!validSrcOrigin) {
       return src
     }
 
@@ -162,7 +161,7 @@ function replaceImageBranchRef(text: string, repoPair: string, ref: string) {
     const repoIndex = srcLowered.indexOf(repoPair.toLowerCase())
     if (
       repoIndex === -1 ||
-      src.indexOf(possibleOrigin) + possibleOrigin.length !== repoIndex
+      src.indexOf(validSrcOrigin) + validSrcOrigin.length !== repoIndex
     ) {
       return src
     }
@@ -253,7 +252,7 @@ export async function fetchRepoFile(
               text = replaceContent(text, originFrontmatter)
               text = replaceSections(text, originFrontmatter)
             }
-            text = replaceImageBranchRef(text, repoPair, ref)
+            text = replaceProjectImageBranch(text, repoPair, ref)
             return Promise.resolve(text)
           }
           // If file has a ref to another file, cache current front-matter and load referenced file

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -133,6 +133,16 @@ function replaceSections(
   return result
 }
 
+/**
+ * Perform image src replacement in text for given repo pair and ref.
+ * - Find all instances of markdown inline images
+ * - Find all instances of markdown html images
+ * - Replace image src's for given repo pair and ref if matched
+ * @param text Markdown file content
+ * @param repoPair Repo pair e.g. "TanStack/router"
+ * @param ref Branch ref e.g. "main"
+ * @returns Markdown file content with replaced image src's for given repo pair and ref
+ */
 function replaceProjectImageBranch(
   text: string,
   repoPair: string,


### PR DESCRIPTION
> [!IMPORTANT]
> This change should have zero impact on the current status of the docs, instead it should make it easier for us to manage images in the future.

From this discussion with Tanner: https://discord.com/channels/719702312431386674/1252133993172697098

Right now, when any of the TanStack projects move to a new major version, we keep all the content of the previous major versions in their own branches. Since we generally have a "main" branch, old branches (v1, v2, ...), and future branches (alpha, beta, ...), this creates a problem when we need to show images in the markdown content in the respective projects.

Currently, when including an image source like `https://github.com/TanStack/router/main/docs/assets/beta.png` it gets rendered from markdown "as-is" regardless of which branch the doc is in. This creates a problem where this image's source would need to remain "as-is" without ANY changes to its name or content till the end of time since it'd have possible effects on the docs for the older branches. Should you decide to make a change to the image source (filename or content) in a documentation markdown file, it'd need massive amounts of coordination since changes would need to be made to all of the previous versions as well.

With this change, it'd lock the image source's branch to whatever the current reference branch is provided the source is the same project's repo.

When the project is "router" and the current branch is "alpha", with the image pointing at "main", it'll be rewritten to point at "alpha":

```
input: https://github.com/TanStack/router/main/docs/assets/main.png
output: https://github.com/TanStack/router/alpha/docs/assets/main.png
```

When the project is "router" and the current branch is "alpha", an image from **"Table"** will be returned as-is.

```
input: https://github.com/TanStack/table/main/docs/assets/main.png
output: https://github.com/TanStack/table/main/docs/assets/main.png
```
