### PR TITLE
fix: remove the unused bottom padding on the side navigation on `<DocsLayout>`

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -522,7 +522,7 @@ export function DocsLayout({
           onSelect={versionConfig.onSelect}
         />
       </div>
-      <div className="flex-1 flex flex-col gap-4 px-4 whitespace-nowrap overflow-y-auto text-base pb-[300px]">
+      <div className="flex-1 flex flex-col gap-4 px-4 whitespace-nowrap overflow-y-auto text-base pb-8">
         {menuItems}
       </div>
     </div>


### PR DESCRIPTION
Since the Carbon block has been moved over to the right side below the Partners and Bytes blocks, we no longer need this 300px of bottom padding.

Before:
<img width="804" alt="image" src="https://github.com/user-attachments/assets/51649f14-d1ef-4aea-823c-88e5e8407f7e">

After:
<img width="814" alt="image" src="https://github.com/user-attachments/assets/3de5563e-acfe-4d3e-968c-ab36783b61cc">
