### PR TITLE
fix: docs content container should take up available height

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -539,7 +539,7 @@ export function DocsLayout({
       {largeMenu}
       <div
         className={twMerge(
-          `max-w-full min-w-0 min-h-0 flex relative justify-center w-full`,
+          `max-w-full min-w-0 min-h-0 flex relative justify-center w-full flex-1`,
           !isExample && 'mx-auto w-[900px]'
         )}
       >

--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -539,7 +539,7 @@ export function DocsLayout({
       {largeMenu}
       <div
         className={twMerge(
-          `max-w-full min-w-0 min-h-0 flex relative justify-center w-full flex-1`,
+          `max-w-full min-w-0 flex relative justify-center w-full min-h-[88dvh] lg:min-h-0`,
           !isExample && 'mx-auto w-[900px]'
         )}
       >


### PR DESCRIPTION
Fixes #262 

Test URL: https://tanstack.com/query/latest/docs/framework/react/examples/simple
Before:
<img width="414" alt="image" src="https://github.com/user-attachments/assets/088ed6b5-3af7-4545-b464-d3de8254204a">

After:
<img width="410" alt="image" src="https://github.com/user-attachments/assets/87bd4df7-1b5e-4311-8f1f-bf0a3feb047a">
