### PR TITLE
fix: scroll to a markdown heading is hidden when navigating on mobile

### DIFF
--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -23,7 +23,10 @@ const CustomHeading = ({
 }) => {
   if (id) {
     return (
-      <a href={`#${id}`} className={`anchor-heading`}>
+      <a
+        href={`#${id}`}
+        className={`anchor-heading [&>*]:scroll-my-[5rem] [&>*]:lg:scroll-my-4`}
+      >
         <Comp id={id} {...props} />
       </a>
     )


### PR DESCRIPTION
On mobile, if you click a link to a heading within the markdown content, the heading with its content is hidden behind the mobile navbar.

To test, using a mobile phone (or more realistically the browser devtool) go to: https://tanstack.com/router/latest/docs/framework/react/start/api-routes, and click on the "Defining an API Route" link in the topics at the start of the page.

See the heading is hidden behind the navbar.
<img width="390" alt="image" src="https://github.com/user-attachments/assets/04bd52c0-b043-404b-957c-65073c68e61d">


With this fix, it is no longer hidden.
<img width="392" alt="image" src="https://github.com/user-attachments/assets/9b1dddbb-c042-4bda-b7fb-8364527ad8fe">
