### PR TITLE
fix: use absolute url for og:image tag

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -40,7 +40,7 @@ export const Route = createRootRouteWithContext<{
     ...seo({
       title: 'TanStack | High Quality Open-Source Software for Web Developers',
       description: `Headless, type-safe, powerful utilities for complex workflows like Data Management, Data Visualization, Charts, Tables, and UI Components.`,
-      image: ogImage,
+      image: `https://tanstack.com${ogImage}`,
       keywords:
         'tanstack,react,reactjs,react query,react table,open source,open source software,oss,software',
     }),

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -40,7 +40,7 @@ export const Route = createRootRouteWithContext<{
     ...seo({
       title: 'TanStack | High Quality Open-Source Software for Web Developers',
       description: `Headless, type-safe, powerful utilities for complex workflows like Data Management, Data Visualization, Charts, Tables, and UI Components.`,
-      image: `https://tanstack.com${ogImage}`,
+      image: `https://${(import.meta as any).env.VITE_VERCEL_URL}${ogImage}`,
       keywords:
         'tanstack,react,reactjs,react query,react table,open source,open source software,oss,software',
     }),

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -40,7 +40,7 @@ export const Route = createRootRouteWithContext<{
     ...seo({
       title: 'TanStack | High Quality Open-Source Software for Web Developers',
       description: `Headless, type-safe, powerful utilities for complex workflows like Data Management, Data Visualization, Charts, Tables, and UI Components.`,
-      image: `https://${(import.meta as any).env.VITE_VERCEL_URL}${ogImage}`,
+      image: `https://tanstack.com${ogImage}`,
       keywords:
         'tanstack,react,reactjs,react query,react table,open source,open source software,oss,software',
     }),

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -17,14 +17,14 @@ export const seo = ({
     { name: 'twitter:description', content: description },
     { name: 'twitter:creator', content: '@tannerlinsley' },
     { name: 'twitter:site', content: '@tannerlinsley' },
-    { name: 'og:type', content: 'website' },
-    { name: 'og:title', content: title },
-    { name: 'og:description', content: description },
+    { property: 'og:type', content: 'website' },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
     ...(image
       ? [
           { name: 'twitter:image', content: image },
           { name: 'twitter:card', content: 'summary_large_image' },
-          { name: 'og:image', content: image },
+          { property: 'og:image', content: image },
         ]
       : []),
   ]


### PR DESCRIPTION
Sharing https://tanstack.com/ in social networks (like linkedin) does not properly show the og:image in the preview.

<details><summary>See images</summary>
<p>

![image](https://github.com/user-attachments/assets/63529430-dc19-4c0b-9633-fb71fd07ba21)

<img width="570" alt="image" src="https://github.com/user-attachments/assets/e63501cc-d4dd-487d-b8f1-c13c4f0279c2">

</p>
</details> 

Our current value is `/_build/assets/og-pGgYlhyc.png` but it seems [only absolute urls are valid](https://stackoverflow.com/a/9858694).

I'm not sure this works as I cannot reliably test it locally but I'd probably give it a try.
I think other pages may be affected but let's do it step by step (or if anyone has a better solution is welcome!)