### PR TITLE
fix: only init OramaSearchBox when component mounts

### DIFF
--- a/app/components/DocsLayout.tsx
+++ b/app/components/DocsLayout.tsx
@@ -348,6 +348,12 @@ export function DocsLayout({
 
   const [showBytes, setShowBytes] = useLocalStorage('showBytes', true)
 
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
   const menuItems = menuConfig.map((group, i) => {
     const WrapperComp = group.collapsible ? 'details' : 'div'
     const LabelComp = group.collapsible ? 'summary' : 'div'
@@ -538,18 +544,20 @@ export function DocsLayout({
       className={`min-h-screen flex flex-col lg:flex-row w-full transition-all duration-300`}
     >
       <div className="fixed z-50">
-        <OramaSearchBox
-          {...searchBoxParams}
-          searchParams={{
-            threshold: 0,
-            where: {
-              category: {
-                eq: capitalize(libraryId!) as string,
-              },
-            } as any,
-          }}
-          facetProperty={undefined}
-        />
+        {mounted && (
+          <OramaSearchBox
+            {...searchBoxParams}
+            searchParams={{
+              threshold: 0,
+              where: {
+                category: {
+                  eq: capitalize(libraryId!) as string,
+                },
+              } as any,
+            }}
+            facetProperty={undefined}
+          />
+        )}
       </div>
       {smallMenu}
       {largeMenu}
@@ -632,6 +640,7 @@ export function DocsLayout({
                         href={partner.href}
                         target="_blank"
                         className="px-4 flex items-center justify-center cursor-pointer"
+                        rel="noreferrer"
                       >
                         <div className="mx-auto max-w-[150px]">
                           <img


### PR DESCRIPTION
This pr fixes some console errors due to the OramaSearchBox not being correctly initialized only when the parent component finished mounting.

<img width="904" alt="image" src="https://github.com/user-attachments/assets/b3c4921a-f4b5-4fa3-b234-80338e1b479d">
<img width="415" alt="image" src="https://github.com/user-attachments/assets/48bb201c-120e-4c73-8878-425117cb6922">

NB. the `rel="noreferrer"` change is an eslint automatic change
