### PR TITLE
fix: line height for descender letters on library title pages

### DIFF
--- a/app/routes/_libraries.config.$version.index.tsx
+++ b/app/routes/_libraries.config.$version.index.tsx
@@ -86,7 +86,7 @@ export default function FormVersionIndex() {
   //   setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   // }, [])
 
-  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${configProject.colorFrom} ${configProject.colorTo}`
+  const gradientText = `inline-block leading-snug text-transparent bg-clip-text bg-gradient-to-r ${configProject.colorFrom} ${configProject.colorTo}`
 
   return (
     <>

--- a/app/routes/_libraries.query.$version.index.tsx
+++ b/app/routes/_libraries.query.$version.index.tsx
@@ -96,7 +96,7 @@ export default function VersionIndex() {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
 
-  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${queryProject.colorFrom} ${queryProject.colorTo}`
+  const gradientText = `inline-block leading-snug text-transparent bg-clip-text bg-gradient-to-r ${queryProject.colorFrom} ${queryProject.colorTo}`
 
   return (
     <div className="flex flex-1 flex-col min-h-0 relative overflow-x-hidden">
@@ -303,6 +303,7 @@ export default function VersionIndex() {
                   href="https://query.gg?s=tanstack"
                   target="_blank"
                   className={`inline-block py-2 px-4 bg-red-500 rounded text-white uppercase font-extrabold`}
+                  rel="noreferrer"
                 >
                   Get the course
                 </a>

--- a/app/routes/_libraries.ranger.$version.index.tsx
+++ b/app/routes/_libraries.ranger.$version.index.tsx
@@ -93,7 +93,7 @@ export default function VersionIndex() {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches)
   }, [])
 
-  const gradientText = `inline-block text-transparent bg-clip-text bg-gradient-to-r ${rangerProject.colorFrom} ${rangerProject.colorTo}`
+  const gradientText = `inline-block leading-snug text-transparent bg-clip-text bg-gradient-to-r ${rangerProject.colorFrom} ${rangerProject.colorTo}`
 
   return (
     <>


### PR DESCRIPTION
PR for issue #289 

Fixing the line height on the library title pages that contain descender letters. (Query, Ranger, Config)

From:
![image](https://github.com/user-attachments/assets/4bbb0642-83ca-4cb9-9ef6-ce21e17fe061)

To:
![image](https://github.com/user-attachments/assets/b8e24f72-e978-4c1e-95f0-3a8b32861cac)
