### PR TITLE
update vinxi to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "shiki": "^1.4.0",
     "tailwind-merge": "^1.14.0",
     "tiny-invariant": "^1.3.3",
-    "vinxi": "^0.3.11",
+    "vinxi": "^0.4.3",
     "vite": "^5.1.4",
     "vite-tsconfig-paths": "^4.3.1",
     "zod": "^3.22.4",


### PR DESCRIPTION
This is the version of vinxi used in router/packages/start.

Updating vinxi 0.3.11 -> 0.4.3 makes it possible to run tanstack.com (and by extension tanstack/start) with `deno task dev`

The `vinxi build` command still breaks though

Related to
- https://github.com/denoland/deno/issues/24061