### PR TITLE
chore: stats layout mobile update

### DIFF
--- a/app/routes/_libraries/index.tsx
+++ b/app/routes/_libraries/index.tsx
@@ -131,7 +131,7 @@ const OssStats = () => {
 
   return (
     <div>
-      <div className="p-8 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-8 items-center justify-center place-items-center bg-white/50 dark:bg-gray-700/30 dark:shadow-none rounded-xl shadow-xl">
+      <div className="p-8 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-8 items-center justify-center xl:place-items-center bg-white/50 dark:bg-gray-700/30 dark:shadow-none rounded-xl shadow-xl">
         <a
           href="https://www.npmjs.com/org/tanstack"
           target="_blank"


### PR DESCRIPTION
layout on mobile for stats is odd

current:
<img width="1074" alt="Screenshot 2024-12-11 at 9 20 44 PM" src="https://github.com/user-attachments/assets/1ae460db-bfb9-4e26-a1b1-82b94defd3a5" />
<img width="742" alt="Screenshot 2024-12-11 at 9 20 50 PM" src="https://github.com/user-attachments/assets/ab156d7c-32c0-4425-a0f1-d58359cc037b" />
<img width="730" alt="Screenshot 2024-12-11 at 9 20 59 PM" src="https://github.com/user-attachments/assets/1a332da1-b84f-44f9-b064-b2c25629da2b" />


updated:
<img width="1128" alt="Screenshot 2024-12-11 at 9 17 26 PM" src="https://github.com/user-attachments/assets/1d3ecab5-d17c-410b-85c7-7679a7b92f8e" />
<img width="843" alt="Screenshot 2024-12-11 at 9 17 10 PM" src="https://github.com/user-attachments/assets/4faf3af8-2ae3-4694-ba1f-180ae9f41465" />
<img width="620" alt="Screenshot 2024-12-11 at 9 17 19 PM" src="https://github.com/user-attachments/assets/7d66695d-9215-42e4-bfb8-16930e8642e0" />
