### PR TITLE
style: improve text alignment

### DIFF
--- a/app/routes/_libraries/start.$version.index.tsx
+++ b/app/routes/_libraries/start.$version.index.tsx
@@ -189,7 +189,7 @@ export default function VersionIndex() {
               }}
             />
           </div>
-          <div className="flex flex-col gap-4 text-center">
+          <div className="flex flex-col gap-4">
             <h3 className="uppercase text-xl font-black">
               Enterprise-Grade Routing
             </h3>
@@ -218,7 +218,7 @@ export default function VersionIndex() {
               />
             </div>
           </div>
-          <div className="flex flex-col gap-4 text-center">
+          <div className="flex flex-col gap-4">
             <h3 className="uppercase text-xl font-black">
               SSR, Streaming and Server RPCs
             </h3>
@@ -243,7 +243,7 @@ export default function VersionIndex() {
               }}
             />
           </div>
-          <div className="flex flex-col gap-4 text-center">
+          <div className="flex flex-col gap-4">
             <h3 className="uppercase text-xl font-black">
               Client-Side First, 100% Server Capable
             </h3>
@@ -272,7 +272,7 @@ export default function VersionIndex() {
               }}
             />
           </div>
-          <div className="flex flex-col gap-4 text-center">
+          <div className="flex flex-col gap-4">
             <h3 className="uppercase text-xl font-black">
               Deploy Anywhere with Vinxi & Vite
             </h3>


### PR DESCRIPTION
Currently, the text in the following columns is centered.
https://tanstack.com/start/latest

**Before:**
![before](https://github.com/user-attachments/assets/608144eb-b47d-4cec-976b-9548c6a5dbc7)

It becomes hard to read if centered text has more than ~3 lines.
Remove center alignment to improve text readability.

**After:**
![after](https://github.com/user-attachments/assets/76be024b-4c39-4fa8-909c-ad687130a9d8)