### PR TITLE
chore: Updating twitter logo to X

### DIFF
--- a/app/routes/_libraries/route.tsx
+++ b/app/routes/_libraries/route.tsx
@@ -18,7 +18,7 @@ import { Scarf } from '~/components/Scarf'
 import { searchBoxParams, searchButtonParams } from '~/components/Orama'
 import { ClientOnlySearchButton } from '~/components/ClientOnlySearchButton'
 import { ThemeToggle, useThemeStore } from '~/components/ThemeToggle'
-import { TbBrandBluesky, TbBrandTwitter } from 'react-icons/tb'
+import { TbBrandBluesky, TbBrandX } from 'react-icons/tb'
 
 export const Route = createFileRoute('/_libraries')({
   staleTime: Infinity,
@@ -205,7 +205,7 @@ function LibrariesLayout() {
           href="https://x.com/tan_stack"
           className="opacity-70 hover:opacity-100"
         >
-          <TbBrandTwitter className="text-xl" />
+          <TbBrandX className="text-xl" />
         </a>
         <a
           href="https://bsky.app/profile/tanstack.com"

--- a/app/routes/_libraries/start.$version.index.tsx
+++ b/app/routes/_libraries/start.$version.index.tsx
@@ -8,9 +8,9 @@ import {
   FaDiscord,
   FaGithub,
   FaTshirt,
-  FaTwitter,
   FaYinYang,
 } from 'react-icons/fa'
+import { FaXTwitter } from 'react-icons/fa6'
 import { Await, Link, getRouteApi } from '@tanstack/react-router'
 import { Carbon } from '~/components/Carbon'
 import { Footer } from '~/components/Footer'
@@ -330,7 +330,7 @@ export default function VersionIndex() {
             className={`flex items-center gap-2 py-2 px-4 bg-cyan-500 rounded text-white uppercase font-extrabold`}
             rel="noreferrer"
           >
-            <FaTwitter /> Tweet about it!
+            <FaXTwitter /> Tweet about it!
           </a>{' '}
         </div>
       </div>


### PR DESCRIPTION
Closes https://github.com/TanStack/tanstack.com/issues/281

- Updated all twitter logo references for `react-icons` to X.


<img width="324" alt="Screenshot 2024-12-24 at 7 30 28 PM" src="https://github.com/user-attachments/assets/0cb23b4a-20d3-4123-a97a-f86edeaa1792" />
