### PR TITLE
Fix K in "Tanstack" overflowing using padding

### DIFF
--- a/app/routes/_libraries/index.tsx
+++ b/app/routes/_libraries/index.tsx
@@ -109,7 +109,7 @@ function Index() {
                 className={`
             inline-block text-transparent bg-clip-text bg-gradient-to-r ${gradient}
             underline decoration-4 md:decoration-8 underline-offset-[.5rem] md:underline-offset-[1rem] decoration-gray-200 dark:decoration-gray-800
-            mb-2 uppercase [letter-spacing:-.05em]
+            mb-2 uppercase [letter-spacing:-.05em] pr-1.5
             `}
               >
                 TanStack


### PR DESCRIPTION
The letter K on the landing page overflows, causing the end to be cut off. I've added some padding on the right to give it space to show the last bit of the K.
It seems to be the letter-spacing causing the overflow.

Before:
![image](https://github.com/user-attachments/assets/7c9e4eb7-ba32-4580-8f9f-f3167bc77871)

After:
![image](https://github.com/user-attachments/assets/b1eac4c5-3b56-4005-b382-f6fd96b15ed0)
