### PR TITLE
update to @erquhart/convex-oss-stats@0.3.6

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[context.production]
+  command = "npx convex deploy --cmd 'pnpm run build'"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "packageManager": "pnpm@9.4.0",
   "type": "module",
   "scripts": {
-    "dev": "vinxi dev & pnpm dev:convex",
-    "dev:convex": "convex dev --tail-logs",
+    "dev": "npm-run-all --parallel dev:frontend dev:backend",
+    "dev:frontend": "vinxi dev",
+    "dev:backend": "convex dev --tail-logs",
     "build": "vinxi build",
     "start": "vinxi start",
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@convex-dev/react-query": "0.0.0-alpha.8",
     "@docsearch/css": "^3.5.2",
     "@docsearch/react": "^3.5.2",
-    "@erquhart/convex-oss-stats": "0.3.5",
+    "@erquhart/convex-oss-stats": "0.3.6",
     "@headlessui/react": "1.7.18",
     "@number-flow/react": "^0.4.1",
     "@octokit/graphql": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.5.2
         version: 3.6.0(@algolia/client-search@5.17.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
       '@erquhart/convex-oss-stats':
-        specifier: 0.3.5
-        version: 0.3.5(convex@1.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.23.8)
+        specifier: 0.3.6
+        version: 0.3.6(convex@1.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.23.8)
       '@headlessui/react':
         specifier: 1.7.18
         version: 1.7.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1096,8 +1096,8 @@ packages:
   '@emotion/weak-memoize@0.2.5':
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
 
-  '@erquhart/convex-oss-stats@0.3.5':
-    resolution: {integrity: sha512-30ptwWfbgMDwmBIYWV/FmhvVepJpgCU445tONaoc7qf5DtEkbIvh0q8q34VWU+InISk0ryhJDHDmBfLC+rtqZg==}
+  '@erquhart/convex-oss-stats@0.3.6':
+    resolution: {integrity: sha512-K+Q5PxYZURQrNHdTIqaZk3hFwGY5f98BHTGWvP09ujR1EOlmdejhtw5jo/6pZI3Ck7I1AyblkQ2nGshgBlA+7A==}
     peerDependencies:
       convex: ~1.16.5 || ~1.17.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0-0
@@ -7792,7 +7792,7 @@ snapshots:
 
   '@emotion/weak-memoize@0.2.5': {}
 
-  '@erquhart/convex-oss-stats@0.3.5(convex@1.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.23.8)':
+  '@erquhart/convex-oss-stats@0.3.6(convex@1.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.23.8)':
     dependencies:
       '@convex-dev/crons': 0.1.5(convex@1.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@octokit/graphql': 8.1.1
@@ -10812,7 +10812,7 @@ snapshots:
       eslint: 8.57.0
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -10880,7 +10880,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       eslint: 8.57.0


### PR DESCRIPTION
**This PR adds `netlify.toml` with a custom production build command for Convex.**

If you don't want this approach, I can drop it and a team member with access can update the value directly in the Netlify dashboard. The config is only currently set to override the build command for production and nothing else, but can be extended as you see fit.

In either case, the CONVEX_DEPLOY_KEY env var will need to be set in the Netlify dashboard: https://docs.convex.dev/production/hosting/netlify#deploying-to-netlify

Also fixes the dev command so both vinxi and convex can exit properly on ctrl +c.