### PR TITLE
add static counter fallback

### DIFF
--- a/app/components/OpenSourceStats.tsx
+++ b/app/components/OpenSourceStats.tsx
@@ -80,7 +80,11 @@ export default function OssStats() {
           <FaDownload className="text-2xl group-hover:text-emerald-500 transition-colors duration-200" />
           <div>
             <div className="text-2xl font-bold opacity-80 relative group-hover:text-emerald-500 transition-colors duration-200">
-              <NpmDownloadCounter npmData={npm} />
+              {/* Uncomment for live counter */}
+              {/*<NpmDownloadCounter npmData={npm} />*/}
+
+              {/* Uncomment for static counter */}
+              <StableCounter value={1688523620} />
             </div>
             <div className="text-sm opacity-50 font-medium italic group-hover:text-emerald-500 transition-colors duration-200">
               NPM Downloads


### PR DESCRIPTION
Npm is showing 0 downloads today for every package - I don't know if or how this might impact the counter. Merge this if there are problems, it'll just show a static hardcoded number that's relatively accurate (as of this PR opening).

Setting to draft as it may not be needed, but it's ready to merge.