### PR TITLE
fix: keep the empty space besides headings out of the clickable area

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -94,7 +94,7 @@
 
   .anchor-heading {
     text-decoration: none !important;
-    display: block;
+    display: inline;
   }
 
   .anchor-heading > *:after {


### PR DESCRIPTION
In the tanstack docs, each heading is a clickable anchor, but the clickable area also spans the whole width of the content area. An accidental click on this empty white space causes the heading and contents to suddenly yank to the top.

This PR limits the clickable area to just the heading text.