### PR TITLE
fix(layout): doc container width not taking up all available space

### DIFF
--- a/app/components/DocContainer.tsx
+++ b/app/components/DocContainer.tsx
@@ -9,7 +9,7 @@ export function DocContainer({
     <div
       {...props}
       className={twMerge(
-        'max-w-full space-y-2 md:space-y-6 lg:space-y-8 p-2 md:p-6 lg:p-8',
+        'w-full max-w-full space-y-2 md:space-y-6 lg:space-y-8 p-2 md:p-6 lg:p-8',
         props.className
       )}
     >


### PR DESCRIPTION
I noticed on some pages the width of the page container wasn't taking up all the space. You can see this in production on the [Classes/Effects](https://tanstack.com/store/latest/docs/reference/classes/effect) page in Store. Here it is in dev locally:

![CleanShot 2025-02-22 at 08 31 03@2x](https://github.com/user-attachments/assets/d33b998a-9423-41f6-9b81-86581ea204a2)

Turns out the `DocContainer.tsx` file didn't specify its width, only its max width. Setting the width to full fixes the issue:

![CleanShot 2025-02-22 at 08 31 24@2x](https://github.com/user-attachments/assets/ca1d6e67-c982-476e-a743-f5bb07ae718d)
