### PR TITLE
feat: add mobile version of the "table of contents"

### DIFF
--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -7,6 +7,7 @@ import { DocTitle } from '~/components/DocTitle'
 import { Markdown } from '~/components/Markdown'
 import { Toc } from './Toc'
 import { twMerge } from 'tailwind-merge'
+import { TocMobile } from './TocMobile'
 
 type DocProps = {
   title: string
@@ -89,55 +90,59 @@ export function Doc({
   }, [])
 
   return (
-    <div
-      className={twMerge(
-        'w-full flex bg-white/70 dark:bg-black/40 mx-auto rounded-xl max-w-[936px]',
-        isTocVisible && 'max-w-full'
-      )}
-    >
+    <React.Fragment>
+      {shouldRenderToc ? <TocMobile headings={headings} /> : null}
       <div
         className={twMerge(
-          'flex overflow-auto flex-col w-full p-4 lg:p-6',
-          isTocVisible && '!pr-0'
+          'w-full flex bg-white/70 dark:bg-black/40 mx-auto rounded-xl max-w-[936px]',
+          isTocVisible && 'max-w-full',
+          shouldRenderToc && 'lg:pt-0'
         )}
       >
-        {title ? <DocTitle>{title}</DocTitle> : null}
-        <div className="h-4" />
-        <div className="h-px bg-gray-500 opacity-20" />
-        <div className="h-4" />
         <div
-          ref={markdownContainerRef}
           className={twMerge(
-            'prose prose-gray prose-sm prose-p:leading-7 dark:prose-invert max-w-none',
-            isTocVisible && 'pr-4 lg:pr-6',
-            'styled-markdown-content'
+            'flex overflow-auto flex-col w-full p-4 lg:p-6',
+            isTocVisible && '!pr-0'
           )}
         >
-          <Markdown htmlMarkup={markup} />
-        </div>
-        <div className="h-12" />
-        <div className="w-full h-px bg-gray-500 opacity-30" />
-        <div className="py-4 opacity-70">
-          <a
-            href={`https://github.com/${repo}/tree/${branch}/${filePath}`}
-            className="flex items-center gap-2"
+          {title ? <DocTitle>{title}</DocTitle> : null}
+          <div className="h-4" />
+          <div className="h-px bg-gray-500 opacity-20" />
+          <div className="h-4" />
+          <div
+            ref={markdownContainerRef}
+            className={twMerge(
+              'prose prose-gray prose-sm prose-p:leading-7 dark:prose-invert max-w-none',
+              isTocVisible && 'pr-4 lg:pr-6',
+              'styled-markdown-content'
+            )}
           >
-            <FaEdit /> Edit on GitHub
-          </a>
+            <Markdown htmlMarkup={markup} />
+          </div>
+          <div className="h-12" />
+          <div className="w-full h-px bg-gray-500 opacity-30" />
+          <div className="py-4 opacity-70">
+            <a
+              href={`https://github.com/${repo}/tree/${branch}/${filePath}`}
+              className="flex items-center gap-2"
+            >
+              <FaEdit /> Edit on GitHub
+            </a>
+          </div>
+          <div className="h-24" />
         </div>
-        <div className="h-24" />
-      </div>
 
-      {isTocVisible && (
-        <div className="border-l border-gray-500/20 max-w-52 w-full hidden 2xl:block transition-all">
-          <Toc
-            headings={headings}
-            activeHeadings={activeHeadings}
-            colorFrom={colorFrom}
-            colorTo={colorTo}
-          />
-        </div>
-      )}
-    </div>
+        {isTocVisible && (
+          <div className="border-l border-gray-500/20 max-w-52 w-full hidden 2xl:block transition-all">
+            <Toc
+              headings={headings}
+              activeHeadings={activeHeadings}
+              colorFrom={colorFrom}
+              colorTo={colorTo}
+            />
+          </div>
+        )}
+      </div>
+    </React.Fragment>
   )
 }

--- a/app/components/DocContainer.tsx
+++ b/app/components/DocContainer.tsx
@@ -9,7 +9,7 @@ export function DocContainer({
     <div
       {...props}
       className={twMerge(
-        'w-full max-w-full space-y-2 md:space-y-6 lg:space-y-8 p-2 md:p-6 lg:p-8',
+        'w-full max-w-full p-2 md:p-6 lg:p-8',
         props.className
       )}
     >

--- a/app/components/TocMobile.tsx
+++ b/app/components/TocMobile.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Link } from '@tanstack/react-router'
+import type { HeadingData } from 'marked-gfm-heading-id'
+import { FaCaretRight, FaCaretDown } from 'react-icons/fa6'
+
+interface TocMobileProps {
+  headings: Array<HeadingData>
+}
+
+export function TocMobile({ headings }: TocMobileProps) {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  const handleToggle = (event: React.SyntheticEvent<HTMLDetailsElement>) => {
+    setIsOpen(event.currentTarget.open)
+  }
+
+  if (headings.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="lg:hidden flex -mx-2 -mt-2 md:-mx-6 md:-mt-6 pb-3 md:pb-5">
+      <details className="w-full" onToggle={handleToggle}>
+        <summary className="px-4 py-3 text-sm font-medium w-full flex content-start items-center gap-2 bg-white/50 dark:bg-black/60 backdrop-blur-lg border-b border-gray-500 border-opacity-20">
+          <span>{isOpen ? <FaCaretDown /> : <FaCaretRight />}</span>
+          <span>On this page</span>
+        </summary>
+        <div className="px-2 py-2">
+          <ul className="list-none grid gap-2">
+            {headings.map((heading) => (
+              <li
+                key={heading.id}
+                style={{
+                  paddingLeft: `${(heading.level - 1) * 1.5}rem`,
+                }}
+              >
+                <Link
+                  to="."
+                  className="text-sm"
+                  hash={heading.id}
+                  dangerouslySetInnerHTML={{ __html: heading.text }}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/app/components/TocMobile.tsx
+++ b/app/components/TocMobile.tsx
@@ -21,7 +21,10 @@ export function TocMobile({ headings }: TocMobileProps) {
   return (
     <div className="lg:hidden flex -mx-2 -mt-2 md:-mx-6 md:-mt-6 pb-3 md:pb-5">
       <details className="w-full" onToggle={handleToggle}>
-        <summary className="px-4 py-3 text-sm font-medium w-full flex content-start items-center gap-2 bg-white/50 dark:bg-black/60 backdrop-blur-lg border-b border-gray-500 border-opacity-20">
+        <summary
+          className="px-4 py-3 text-sm font-medium w-full flex content-start items-center gap-2 bg-white/50 dark:bg-black/60 backdrop-blur-lg border-b border-gray-500 border-opacity-20"
+          aria-expanded={isOpen}
+        >
           <span>{isOpen ? <FaCaretDown /> : <FaCaretRight />}</span>
           <span>On this page</span>
         </summary>
@@ -29,9 +32,9 @@ export function TocMobile({ headings }: TocMobileProps) {
           <ul className="list-none grid gap-2">
             {headings.map((heading) => (
               <li
-                key={heading.id}
+                key={`mobile-toc-${heading.id}`}
                 style={{
-                  paddingLeft: `${(heading.level - 1) * 1.5}rem`,
+                  paddingLeft: `${(heading.level - 1) * 0.7}rem`,
                 }}
               >
                 <Link
@@ -39,6 +42,7 @@ export function TocMobile({ headings }: TocMobileProps) {
                   className="text-sm"
                   hash={heading.id}
                   dangerouslySetInnerHTML={{ __html: heading.text }}
+                  aria-label={heading.text.replace(/<\/?[^>]+(>|$)/g, '')}
                 />
               </li>
             ))}

--- a/app/routes/_libraries/blog.$.tsx
+++ b/app/routes/_libraries/blog.$.tsx
@@ -82,7 +82,7 @@ ${content}`
 
   return (
     <DocContainer>
-      <div>
+      <div className="mb-2 md:mb-6 lg:mb-8">
         <Link
           from="/blog/$"
           to="/blog"


### PR DESCRIPTION
Currently, on desktop, on the right side of the page, we have a persistent table of contents section that lists all the available headings within the markdown document. This section/component was hidden on mobile as its persistent nature would work on mobile.

This change, adds a mobile-optimized version of the above component, without the sticky/persistent nature.

Before:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/399535df-3f95-46f5-aa7f-bdc0d3c4a9a9" />

After: 

<img width="399" alt="image" src="https://github.com/user-attachments/assets/f1ce331a-3410-4df0-82c1-38af9aedc2b7" />

With the section opened:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d360e233-fec8-4314-afbc-032921ac3d02" />

Also, looks surprisingly good in dark-mode as well:

<img width="402" alt="image" src="https://github.com/user-attachments/assets/1d4d9052-7170-4b13-85d3-429c04b46f14" />
