### PR TITLE
fix(codesandbox): open ./src instead of ./app on launch for start

### DIFF
--- a/app/utils/sandbox.ts
+++ b/app/utils/sandbox.ts
@@ -5,7 +5,7 @@ export const getInitialSandboxFileName = (
   libraryId?: string
 ) => {
   if (libraryId === 'start') {
-    return 'app/routes/__root.tsx'
+    return 'src/routes/__root.tsx'
   }
 
   const dir = 'src'


### PR DESCRIPTION
when opening the start examples, it says it can't find

`./app/routes/__root.tsx`

<img width="536" alt="Screenshot 2025-03-10 at 18 20 07" src="https://github.com/user-attachments/assets/0d0a69e8-b997-44b6-ac0e-933c1d5dd00a" />


The error can be repro'd here:
- https://tanstack.com/start/latest/docs/framework/react/examples/start-basic


It's correct the file is missing. It was moved to:

`./src/routes/__root.tsx`

... as part of:
- https://github.com/TanStack/router/pull/3712

