### PR TITLE
fix: interactive sandbox card not filling the whole card contents

### DIFF
--- a/app/components/InteractiveSandbox.tsx
+++ b/app/components/InteractiveSandbox.tsx
@@ -28,7 +28,7 @@ export function InteractiveSandbox({
         src={embedEditor === 'codesandbox' ? codeSandboxUrl : stackBlitzUrl}
         title={`${libraryName} | ${examplePath}`}
         sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-        className="w-full h-full min-h-[80dvh] overflow-hidden lg:rounded-lg shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
+        className="w-full h-full min-h-[80dvh] overflow-hidden shadow-xl shadow-gray-700/20 bg-white dark:bg-black"
       />
     </div>
   )


### PR DESCRIPTION
You can notice how it's not taking all the remaining space due to `lg:rounded-lg` being there unnecessarily
![image](https://github.com/user-attachments/assets/6823a7ec-152e-4f34-9c46-df6ac7068ee8)
Here is it with the removal. 
![image](https://github.com/user-attachments/assets/4b75e4bb-4db5-4c43-a102-4cef5099b85d)

Though you can also see the bottom clips off due to `min-h-[80dvh]`, which happend before this. I just don't know if it's intentional or not.