### PR TITLE
fix(code-explorer): resolving starting path when not available

### DIFF
--- a/app/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
+++ b/app/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
@@ -71,6 +71,10 @@ export const Route = createFileRoute(
     const library = getLibrary(params.libraryId)
     const branch = getBranch(library, params.version)
     const examplePath = [params.framework, params._splat].join('/')
+
+    // Used to determine the starting file name for the explorer
+    // i.e. app.tsx, main.tsx, src/routes/__root.tsx, etc.
+    // This value is not absolutely guaranteed to be available, so further resolution may be necessary
     const explorerCandidateStartingFileName = getInitialExplorerFileName(
       params.framework as Framework,
       params.libraryId
@@ -84,7 +88,8 @@ export const Route = createFileRoute(
       repoDirApiContentsQueryOptions(library.repo, branch, repoStartingDirPath)
     )
 
-    // Determine the starting file path for the explorer and the file to be fetched
+    // Using the fetched contents, get the actual starting file-path for the explorer
+    // The `explorerCandidateStartingFileName` is used for matching, but the actual file-path may differ
     const repoStartingFilePath = determineStartingFilePath(
       githubContents,
       explorerCandidateStartingFileName,
@@ -92,7 +97,8 @@ export const Route = createFileRoute(
       params.libraryId
     )
 
-    // Fetching and Caching the file content for the starting file path
+    // Now that we've resolved the starting file path, we can
+    // fetching and caching the file content for the starting file path
     await queryClient.ensureQueryData(
       fileQueryOptions(library.repo, branch, repoStartingFilePath)
     )

--- a/app/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
+++ b/app/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
@@ -12,8 +12,7 @@ import { Framework, getBranch, getLibrary } from '~/libraries'
 import { fetchFile, fetchRepoDirectoryContents } from '~/utils/docs'
 import {
   getFrameworkStartFileName,
-  getInitialExplorerDirectory,
-  getInitialSandboxFileName,
+  getInitialExplorerFileName,
 } from '~/utils/sandbox'
 import { seo } from '~/utils/seo'
 import { capitalize, slugToTitle } from '~/utils/utils'
@@ -43,7 +42,7 @@ const repoDirApiContentsQueryOptions = (
       fetchRepoDirectoryContents({
         data: { repo, branch, startingPath },
       }),
-    staleTime: Infinity,
+    staleTime: Infinity, // We can cache this forever. A refresh can invalidate the cache if necessary.
   })
 
 export const Route = createFileRoute(
@@ -72,35 +71,35 @@ export const Route = createFileRoute(
     const library = getLibrary(params.libraryId)
     const branch = getBranch(library, params.version)
     const examplePath = [params.framework, params._splat].join('/')
-    const explorerFirstDirectory = getInitialExplorerDirectory(params.libraryId)
-    const explorerFirstFileName = getInitialSandboxFileName(
+    const explorerCandidateStartingFileName = getInitialExplorerFileName(
       params.framework as Framework,
       params.libraryId
     )
 
-    // Used for fetching the file content of the initial file
-    const explorerStartingFilePath = `examples/${examplePath}/${explorerFirstFileName}`
+    // Used to tell the github contents api where to start looking for files in the target repository
+    const repoStartingDirPath = `examples/${examplePath}`
 
-    // Used to indicate from where should the directory tree start.
-    // i.e. from `examples/react/quickstart` or `examples/react/quickstart/src`
-    const explorerDirectoryStartingPath = `examples/${examplePath}${explorerFirstDirectory}`
+    // Fetching and Caching the contents of the target directory
+    const githubContents = await queryClient.ensureQueryData(
+      repoDirApiContentsQueryOptions(library.repo, branch, repoStartingDirPath)
+    )
 
-    await Promise.allSettled([
-      queryClient.ensureQueryData(
-        fileQueryOptions(library.repo, branch, explorerStartingFilePath)
-      ),
-      queryClient.ensureQueryData(
-        repoDirApiContentsQueryOptions(
-          library.repo,
-          branch,
-          explorerDirectoryStartingPath
-        )
-      ),
-    ])
+    // Determine the starting file path for the explorer and the file to be fetched
+    const repoStartingFilePath = determineStartingFilePath(
+      githubContents,
+      explorerCandidateStartingFileName,
+      params.framework as Framework,
+      params.libraryId
+    )
+
+    // Fetching and Caching the file content for the starting file path
+    await queryClient.ensureQueryData(
+      fileQueryOptions(library.repo, branch, repoStartingFilePath)
+    )
 
     return {
-      explorerDirectoryStartingPath,
-      explorerStartingFilePath,
+      repoStartingDirPath,
+      repoStartingFilePath,
     }
   },
   staleTime: 1000 * 60 * 5, // 5 minutes
@@ -114,8 +113,7 @@ function RouteComponent() {
 function PageComponent() {
   // Not sure why this inferred type is not working
   // @ts-expect-error
-  const { explorerDirectoryStartingPath, explorerStartingFilePath } =
-    Route.useLoaderData()
+  const { repoStartingDirPath, repoStartingFilePath } = Route.useLoaderData()
 
   const navigate = Route.useNavigate()
   const queryClient = useQueryClient()
@@ -125,24 +123,13 @@ function PageComponent() {
 
   const examplePath = [framework, _splat].join('/')
 
-  const mainExampleFile = getInitialSandboxFileName(
+  const mainExampleFile = getInitialExplorerFileName(
     framework as Framework,
     libraryId
   )
 
   const { data: githubContents } = useSuspenseQuery(
-    repoDirApiContentsQueryOptions(
-      library.repo,
-      branch,
-      explorerDirectoryStartingPath
-    )
-  )
-
-  const startingFilePath = determineStartingFilePath(
-    githubContents,
-    explorerStartingFilePath,
-    framework as Framework,
-    libraryId
+    repoDirApiContentsQueryOptions(library.repo, branch, repoStartingDirPath)
   )
 
   const [isDark, setIsDark] = React.useState(true)
@@ -170,7 +157,7 @@ function PageComponent() {
 
   const currentPath = Route.useSearch({
     select: (s) => {
-      return s.path || startingFilePath || explorerStartingFilePath
+      return s.path || repoStartingFilePath
     },
   })
 
@@ -313,15 +300,9 @@ function determineStartingFilePath(
 
   const preferenceFiles = new Set([
     getFrameworkStartFileName(framework, libraryId),
-    'page.tsx',
-    'page.ts',
-    'App.tsx',
-    'App.ts',
-    'main.tsx',
-    'main.ts',
-    'index.tsx',
-    'index.ts',
-    'action.ts',
+    ...['App', 'main', 'index', 'page', 'action']
+      .map((name) => [`${name}.tsx`, `${name}.ts`, `${name}.js`, `${name}.jsx`])
+      .flat(),
     'README.md',
   ])
 

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -387,8 +387,7 @@ export function fetchApiContents(
     ttl: isDev ? 1 : 1 * 60 * 1000, // 5 minute
     fn: () => {
       return isDev
-        ? // ? fetchApiContentsFs(repoPair, startingPath)
-          fetchApiContentsRemote(repoPair, branch, startingPath)
+        ? fetchApiContentsFs(repoPair, startingPath)
         : fetchApiContentsRemote(repoPair, branch, startingPath)
     },
   })

--- a/app/utils/documents.server.ts
+++ b/app/utils/documents.server.ts
@@ -387,7 +387,8 @@ export function fetchApiContents(
     ttl: isDev ? 1 : 1 * 60 * 1000, // 5 minute
     fn: () => {
       return isDev
-        ? fetchApiContentsFs(repoPair, startingPath)
+        ? // ? fetchApiContentsFs(repoPair, startingPath)
+          fetchApiContentsRemote(repoPair, branch, startingPath)
         : fetchApiContentsRemote(repoPair, branch, startingPath)
     },
   })
@@ -496,7 +497,7 @@ async function fetchApiContentsRemote(
     },
   }
   const res = await fetch(
-    `https://api.github.com/repos/${repo}/contents/${startingPath}?=${branch}`,
+    `https://api.github.com/repos/${repo}/contents/${startingPath}?ref=${branch}`,
     fetchOptions
   )
 

--- a/app/utils/sandbox.ts
+++ b/app/utils/sandbox.ts
@@ -38,10 +38,13 @@ export function getFrameworkStartFileName(
   return `${file}.${ext}` as const
 }
 
-export const getInitialExplorerDirectory = (libraryId: string) => {
-  if (['start', 'router'].includes(libraryId)) {
-    return ''
+export const getInitialExplorerFileName = (
+  framework: Framework,
+  libraryId?: string
+) => {
+  if (libraryId && ['start', 'router'].includes(libraryId)) {
+    return 'src/routes/__root.tsx'
   }
 
-  return '/src'
+  return getFrameworkStartFileName(framework, libraryId)
 }


### PR DESCRIPTION
Fixes an issue with the code-explorer dying when it couldn't resolve to child directories within the `examplePath`.

For example, when trying to start fetching the contents for `examples/react/pagination/src`, where the leaf `/src` directory did not exist, the whole application would simply fail.

To fix this, the contents will always be fetched from the contents API from the base of the `examplePath` (i.e. `examples/react/pagination`). From there on, once the contents have been fetched, the logic in `determineStartingFilePath` will resolve it to the correct starting file-path to have correct file opened in the explorer.

This results in a UI change, where the contents of the file-tree will differ from the existing implementation.

> [!IMPORTANT]
> The default opened/"starting file" will remain the same for users.

Old:
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/16fd1746-e8de-4402-b5dd-345793ea2be6" />

New: 
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/d9286edb-246e-4bf7-8e2b-93abcde306a0" />
