### PR TITLE
feat: use content collections for the blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ yarn.lock
 dist
 .vscode/
 .env.local
+
+# Content Collections generated files
+.content-collections
+

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { defineConfig } from '@tanstack/start/config'
-import contentCollections from "@content-collections/vinxi";
+import contentCollections from '@content-collections/vite'
 import tsConfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
@@ -10,7 +10,6 @@ export default defineConfig({
   vite: {
     plugins: [
       tsConfigPaths(),
-      contentCollections(),
       (() => {
         const replacements = [
           // replace `throw Error(p(418))` with `console.error(p(418))`
@@ -47,6 +46,7 @@ export default defineConfig({
             org: 'tanstack',
             project: 'tanstack-com',
           }),
+          contentCollections(),
         ],
       },
     },

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,5 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { defineConfig } from '@tanstack/start/config'
+import contentCollections from "@content-collections/vinxi";
 import tsConfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
@@ -9,6 +10,7 @@ export default defineConfig({
   vite: {
     plugins: [
       tsConfigPaths(),
+      contentCollections(),
       (() => {
         const replacements = [
           // replace `throw Error(p(418))` with `console.error(p(418))`

--- a/app/blog/ag-grid-partnership.md
+++ b/app/blog/ag-grid-partnership.md
@@ -1,6 +1,6 @@
 ---
 title: TanStack Table + Ag-Grid Partnership
-published: 6/17/2022
+published: 2022-06-17
 authors:
   - Tanner Linsley
   - Niall Crosby

--- a/app/blog/announcing-tanstack-form-v1.md
+++ b/app/blog/announcing-tanstack-form-v1.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing TanStack Form v1
-published: 03/03/2025
+published: 2025-03-03
 authors:
   - Corbin Crutchley
 ---

--- a/app/blog/announcing-tanstack-query-v4.md
+++ b/app/blog/announcing-tanstack-query-v4.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing TanStack Query v4
-published: 7/14/2022
+published: 2022-07-14
 authors:
   - Dominik Dorfmeister
 ---

--- a/app/blog/announcing-tanstack-query-v5.md
+++ b/app/blog/announcing-tanstack-query-v5.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing TanStack Query v5
-published: 10/17/2023
+published: 2023-10-17
 authors:
   - Dominik Dorfmeister
 ---

--- a/app/blog/netlify-partnership.md
+++ b/app/blog/netlify-partnership.md
@@ -1,6 +1,6 @@
 ---
 title: TanStack + Netlify Partnership
-published: 3/18/2025
+published: 2025-03-18
 authors:
   - Tanner Linsley
 ---

--- a/app/blog/tanstack-router-typescript-performance.md
+++ b/app/blog/tanstack-router-typescript-performance.md
@@ -1,6 +1,6 @@
 ---
 title: A milestone for TypeScript Performance in TanStack Router
-published: 09/17/2024
+published: 2024-09-17
 authors:
   - Christopher Horobin
 ---

--- a/app/blog/why-tanstack-start-and-router.md
+++ b/app/blog/why-tanstack-start-and-router.md
@@ -1,6 +1,6 @@
 ---
 title: Why choose TanStack Start and Router?
-published: 12/03/2024
+published: 2024-12-03
 authors:
   - Tanner Linsley
 ---

--- a/app/blog/why-tanstack-start-is-ditching-adapters.md
+++ b/app/blog/why-tanstack-start-is-ditching-adapters.md
@@ -1,6 +1,6 @@
 ---
 title: Why TanStack Start is Ditching Adapters
-published: 11/22/2024
+published: 2024-11-22
 authors:
   - Tanner Linsley
 ---

--- a/app/routes/_libraries/blog.$.tsx
+++ b/app/routes/_libraries/blog.$.tsx
@@ -1,6 +1,4 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router'
-import { extractFrontMatter, fetchRepoFile } from '~/utils/documents.server'
-import removeMarkdown from 'remove-markdown'
 import { seo } from '~/utils/seo'
 import { Doc } from '~/components/Doc'
 import { PostNotFound } from './blog'
@@ -11,6 +9,7 @@ import { z } from 'zod'
 import { FaArrowLeft } from 'react-icons/fa'
 import { DocContainer } from '~/components/DocContainer'
 import { setHeaders } from 'vinxi/http'
+import { allPosts } from 'content-collections'
 
 const fetchBlogPost = createServerFn({ method: 'GET' })
   .validator(z.string().optional())
@@ -21,14 +20,11 @@ const fetchBlogPost = createServerFn({ method: 'GET' })
 
     const filePath = `app/blog/${docsPath}.md`
 
-    const file = await fetchRepoFile('tanstack/tanstack.com', 'main', filePath)
+    const post = allPosts.find((post) => post.slug === docsPath)
 
-    if (!file) {
+    if (!post) {
       throw notFound()
     }
-
-    const frontMatter = extractFrontMatter(file)
-    const description = removeMarkdown(frontMatter.excerpt ?? '')
 
     setHeaders({
       'cache-control': 'public, max-age=0, must-revalidate',
@@ -37,11 +33,11 @@ const fetchBlogPost = createServerFn({ method: 'GET' })
     })
 
     return {
-      title: frontMatter.data.title,
-      description,
-      published: frontMatter.data.published,
-      content: frontMatter.content,
-      authors: (frontMatter.data.authors ?? []) as Array<string>,
+      title: post.title,
+      description: post.excerpt,
+      published: post.published,
+      content: post.content,
+      authors: post.authors,
       filePath,
     }
   })

--- a/app/routes/_libraries/blog.index.tsx
+++ b/app/routes/_libraries/blog.index.tsx
@@ -18,9 +18,19 @@ const fetchFrontMatters = createServerFn({ method: 'GET' }).handler(
       'Netlify-Vary': 'query=payload',
     })
 
-    return allPosts.sort((a, b) => {
-      return new Date(b.published).getTime() - new Date(a.published).getTime()
-    })
+    return allPosts
+      .sort((a, b) => {
+        return new Date(b.published).getTime() - new Date(a.published).getTime()
+      })
+      .map((post) => {
+        return {
+          slug: post.slug,
+          title: post.title,
+          published: post.published,
+          excerpt: post.excerpt,
+          authors: post.authors,
+        }
+      })
 
     // return json(frontMatters, {
     //   headers: {

--- a/app/routes/_libraries/blog.index.tsx
+++ b/app/routes/_libraries/blog.index.tsx
@@ -7,23 +7,24 @@ import { format } from 'date-fns'
 import { Footer } from '~/components/Footer'
 import { PostNotFound } from './blog'
 import { createServerFn } from '@tanstack/start'
-import { allPosts } from "content-collections";
+import { allPosts } from 'content-collections'
 import { setHeaders } from 'vinxi/http'
 
 const fetchFrontMatters = createServerFn({ method: 'GET' }).handler(
   async () => {
     setHeaders({
       'cache-control': 'public, max-age=0, must-revalidate',
-      'cdn-cache-control':
-        'max-age=300, stale-while-revalidate=300, durable',
+      'cdn-cache-control': 'max-age=300, stale-while-revalidate=300, durable',
       'Netlify-Vary': 'query=payload',
     })
 
-    return allPosts.map(post => {
-      return post;
-    }).sort((a, b) => {
-      return new Date(b.published).getTime() -  new Date(a.published).getTime()
-    })
+    return allPosts
+      .map((post) => {
+        return post
+      })
+      .sort((a, b) => {
+        return new Date(b.published).getTime() - new Date(a.published).getTime()
+      })
 
     // return json(frontMatters, {
     //   headers: {
@@ -59,7 +60,7 @@ function BlogIndex() {
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-4">
           {frontMatters.map(
-            ({ _meta: {path}, title, published, excerpt, authors = [] }) => {
+            ({ _meta: { path }, title, published, excerpt, authors = [] }) => {
               return (
                 <Link
                   key={path}

--- a/app/routes/_libraries/blog.index.tsx
+++ b/app/routes/_libraries/blog.index.tsx
@@ -64,7 +64,8 @@ function BlogIndex() {
               return (
                 <Link
                   key={path}
-                  to={`${path}`}
+                  to="/blog/$"
+                  params={{ _splat: path }}
                   className={`flex flex-col gap-4 justify-between
                   border-2 border-transparent rounded-lg p-4 md:p-8
                   transition-all bg-white/100 dark:bg-gray-800

--- a/app/routes/_libraries/blog.index.tsx
+++ b/app/routes/_libraries/blog.index.tsx
@@ -18,13 +18,9 @@ const fetchFrontMatters = createServerFn({ method: 'GET' }).handler(
       'Netlify-Vary': 'query=payload',
     })
 
-    return allPosts
-      .map((post) => {
-        return post
-      })
-      .sort((a, b) => {
-        return new Date(b.published).getTime() - new Date(a.published).getTime()
-      })
+    return allPosts.sort((a, b) => {
+      return new Date(b.published).getTime() - new Date(a.published).getTime()
+    })
 
     // return json(frontMatters, {
     //   headers: {
@@ -59,51 +55,49 @@ function BlogIndex() {
           <div className="h-6" />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 2xl:grid-cols-3 gap-4">
-          {frontMatters.map(
-            ({ _meta: { path }, title, published, excerpt, authors = [] }) => {
-              return (
-                <Link
-                  key={path}
-                  to="/blog/$"
-                  params={{ _splat: path }}
-                  className={`flex flex-col gap-4 justify-between
+          {frontMatters.map(({ slug, title, published, excerpt, authors }) => {
+            return (
+              <Link
+                key={slug}
+                to="/blog/$"
+                params={{ _splat: slug }}
+                className={`flex flex-col gap-4 justify-between
                   border-2 border-transparent rounded-lg p-4 md:p-8
                   transition-all bg-white/100 dark:bg-gray-800
                   shadow-xl dark:shadow-lg dark:shadow-blue-500/30
                   hover:border-blue-500
               `}
-                >
-                  <div>
-                    <div className={`text-lg font-extrabold`}>{title}</div>
-                    <div className={`text-xs italic font-light mt-1`}>
-                      <p>
-                        by {formatAuthors(authors)}
-                        {published ? (
-                          <time
-                            dateTime={published}
-                            title={format(new Date(published), 'MMM dd, yyyy')}
-                          >
-                            {' '}
-                            on {format(new Date(published), 'MMM dd, yyyy')}
-                          </time>
-                        ) : null}
-                      </p>
-                    </div>
-                    <div
-                      className={`text-sm mt-4 text-black dark:text-white leading-7`}
-                    >
-                      <Markdown rawContent={excerpt || ''} />
-                    </div>
+              >
+                <div>
+                  <div className={`text-lg font-extrabold`}>{title}</div>
+                  <div className={`text-xs italic font-light mt-1`}>
+                    <p>
+                      by {formatAuthors(authors)}
+                      {published ? (
+                        <time
+                          dateTime={published}
+                          title={format(new Date(published), 'MMM dd, yyyy')}
+                        >
+                          {' '}
+                          on {format(new Date(published), 'MMM dd, yyyy')}
+                        </time>
+                      ) : null}
+                    </p>
                   </div>
-                  <div>
-                    <div className="text-blue-500 uppercase font-black text-sm">
-                      Read More
-                    </div>
+                  <div
+                    className={`text-sm mt-4 text-black dark:text-white leading-7`}
+                  >
+                    <Markdown rawContent={excerpt || ''} />
                   </div>
-                </Link>
-              )
-            }
-          )}
+                </div>
+                <div>
+                  <div className="text-blue-500 uppercase font-black text-sm">
+                    Read More
+                  </div>
+                </div>
+              </Link>
+            )
+          })}
         </div>
         <div className="h-24" />
       </div>

--- a/app/utils/blog.ts
+++ b/app/utils/blog.ts
@@ -1,32 +1,3 @@
-export function getPostList() {
-  return [
-    {
-      id: 'announcing-tanstack-form-v1',
-    },
-    {
-      id: 'announcing-tanstack-query-v5',
-    },
-    {
-      id: 'announcing-tanstack-query-v4',
-    },
-    {
-      id: 'ag-grid-partnership',
-    },
-    {
-      id: 'tanstack-router-typescript-performance',
-    },
-    {
-      id: 'why-tanstack-start-is-ditching-adapters',
-    },
-    {
-      id: 'why-tanstack-start-and-router',
-    },
-    {
-      id: 'netlify-partnership',
-    },
-  ]
-}
-
 export function formatAuthors(authors: Array<string>) {
   if (!authors.length) {
     return 'TanStack'

--- a/app/utils/blog.ts
+++ b/app/utils/blog.ts
@@ -1,15 +1,12 @@
+const joiner = new Intl.ListFormat('en-US', {
+  style: 'long',
+  type: 'conjunction',
+})
+
 export function formatAuthors(authors: Array<string>) {
   if (!authors.length) {
     return 'TanStack'
   }
 
-  if (authors.length === 1) {
-    return authors[0]
-  }
-
-  if (authors.length === 2) {
-    return authors.join(' and ')
-  }
-
-  return authors.slice(0, -1).join(', ') + ', and ' + authors.slice(-1)
+  return joiner.format(authors)
 }

--- a/app/utils/blog.ts
+++ b/app/utils/blog.ts
@@ -1,4 +1,4 @@
-const joiner = new Intl.ListFormat('en-US', {
+const listJoiner = new Intl.ListFormat('en-US', {
   style: 'long',
   type: 'conjunction',
 })
@@ -8,5 +8,5 @@ export function formatAuthors(authors: Array<string>) {
     return 'TanStack'
   }
 
-  return joiner.format(authors)
+  return listJoiner.format(authors)
 }

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -1,0 +1,24 @@
+import { defineCollection, defineConfig } from "@content-collections/core";
+import { extractFrontMatter } from '~/utils/documents.server'
+
+const posts = defineCollection({
+  name: "posts",
+  directory: "app/blog",
+  include: "**/*.md",
+  transform: ({ content, ...rest }) => {
+    return {
+      ...rest,
+      ...extractFrontMatter(content),
+    }
+  },
+  schema: (z) => ({
+    title: z.string(),
+    published: z.string().date(),
+    authors: z.string().array()
+  }),
+
+});
+
+export default defineConfig({
+  collections: [posts],
+});

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -3,19 +3,22 @@ import { extractFrontMatter } from '~/utils/documents.server'
 
 const posts = defineCollection({
   name: 'posts',
-  directory: 'app/blog',
-  include: '**/*.md',
-  transform: ({ content, ...rest }) => {
-    return {
-      ...rest,
-      ...extractFrontMatter(content),
-    }
-  },
+  directory: './app/blog',
+  include: '*.md',
   schema: (z) => ({
     title: z.string(),
     published: z.string().date(),
     authors: z.string().array(),
   }),
+  transform: ({ content, ...post }) => {
+    const frontMatter = extractFrontMatter(content)
+    return {
+      ...post,
+      slug: post._meta.path,
+      excerpt: frontMatter.excerpt,
+      content,
+    }
+  },
 })
 
 export default defineConfig({

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -1,10 +1,10 @@
-import { defineCollection, defineConfig } from "@content-collections/core";
+import { defineCollection, defineConfig } from '@content-collections/core'
 import { extractFrontMatter } from '~/utils/documents.server'
 
 const posts = defineCollection({
-  name: "posts",
-  directory: "app/blog",
-  include: "**/*.md",
+  name: 'posts',
+  directory: 'app/blog',
+  include: '**/*.md',
   transform: ({ content, ...rest }) => {
     return {
       ...rest,
@@ -14,11 +14,10 @@ const posts = defineCollection({
   schema: (z) => ({
     title: z.string(),
     published: z.string().date(),
-    authors: z.string().array()
+    authors: z.string().array(),
   }),
-
-});
+})
 
 export default defineConfig({
   collections: [posts],
-});
+})

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@content-collections/core": "^0.8.2",
+    "@content-collections/vinxi": "^0.1.0",
     "@shikijs/transformers": "^1.10.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@content-collections/core": "^0.8.2",
-    "@content-collections/vinxi": "^0.1.0",
+    "@content-collections/vite": "^0.2.4",
     "@shikijs/transformers": "^1.10.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,9 @@ importers:
       '@content-collections/core':
         specifier: ^0.8.2
         version: 0.8.2(typescript@5.6.3)
-      '@content-collections/vinxi':
-        specifier: ^0.1.0
-        version: 0.1.0(@content-collections/core@0.8.2(typescript@5.6.3))
+      '@content-collections/vite':
+        specifier: ^0.2.4
+        version: 0.2.4(@content-collections/core@0.8.2(typescript@5.6.3))
       '@shikijs/transformers':
         specifier: ^1.10.3
         version: 1.10.3
@@ -1021,8 +1021,13 @@ packages:
     peerDependencies:
       typescript: ^5.0.2
 
-  '@content-collections/vinxi@0.1.0':
-    resolution: {integrity: sha512-DB80W3Rb+pBTGr+qBXSFn6llRe1YOCKjXUo5ye31lXiP8md0jA7I1/dvmxsXQAYPg5TRbNcMN+Mj7BjnNinLSg==}
+  '@content-collections/integrations@0.2.1':
+    resolution: {integrity: sha512-AyEcS2MmcOXSYt6vNmJsAiu6EBYjtNiwYGUVUmpG3llm8Gt8uiNrhIhlHyv3cuk+N8KJ2PWemLcMqtQJ+sW3bA==}
+    peerDependencies:
+      '@content-collections/core': 0.x
+
+  '@content-collections/vite@0.2.4':
+    resolution: {integrity: sha512-3+n7pUnUMyjVasZLyxoUEU9VtJigWN/REliCyvAjsm0obv+6UpHAiRrkuLhn9luKAiHw4PRcFIJefBGz4i8Uzw==}
     peerDependencies:
       '@content-collections/core': ^0.x
       vite: ^5
@@ -8030,9 +8035,14 @@ snapshots:
       yaml: 2.7.1
       zod: 3.24.1
 
-  '@content-collections/vinxi@0.1.0(@content-collections/core@0.8.2(typescript@5.6.3))':
+  '@content-collections/integrations@0.2.1(@content-collections/core@0.8.2(typescript@5.6.3))':
     dependencies:
       '@content-collections/core': 0.8.2(typescript@5.6.3)
+
+  '@content-collections/vite@0.2.4(@content-collections/core@0.8.2(typescript@5.6.3))':
+    dependencies:
+      '@content-collections/core': 0.8.2(typescript@5.6.3)
+      '@content-collections/integrations': 0.2.1(@content-collections/core@0.8.2(typescript@5.6.3))
 
   '@convex-dev/crons@0.1.5(convex@1.17.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/start':
         specifier: 1.111.1
-        version: 1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)
+        version: 1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(webpack@5.97.1)(yaml@2.7.1)
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -82,7 +82,7 @@ importers:
         version: 2.17.0(react@19.0.0)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))
+        version: 4.3.4
       airtable:
         specifier: ^0.12.2
         version: 0.12.2
@@ -166,10 +166,10 @@ importers:
         version: 1.3.3
       vinxi:
         specifier: ^0.5.3
-        version: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+        version: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       vite-tsconfig-paths:
         specifier: ^5.0.1
-        version: 5.0.1(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))
+        version: 5.0.1(typescript@5.6.3)
       zod:
         specifier: ^3.23.8
         version: 3.24.1
@@ -177,6 +177,12 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(@types/react@18.3.12)(react@19.0.0)
     devDependencies:
+      '@content-collections/core':
+        specifier: ^0.8.2
+        version: 0.8.2(typescript@5.6.3)
+      '@content-collections/vinxi':
+        specifier: ^0.1.0
+        version: 0.1.0(@content-collections/core@0.8.2(typescript@5.6.3))
       '@shikijs/transformers':
         specifier: ^1.10.3
         version: 1.10.3
@@ -1010,6 +1016,17 @@ packages:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
 
+  '@content-collections/core@0.8.2':
+    resolution: {integrity: sha512-62yVC3ne47YJ1KeCw5nk0H/G/xGBagcoWyMpVyTaCnDJhoIoTvmqBrsc+78Zk8s2Ssnb0Eo1Q4w3ZHwgL88pjg==}
+    peerDependencies:
+      typescript: ^5.0.2
+
+  '@content-collections/vinxi@0.1.0':
+    resolution: {integrity: sha512-DB80W3Rb+pBTGr+qBXSFn6llRe1YOCKjXUo5ye31lXiP8md0jA7I1/dvmxsXQAYPg5TRbNcMN+Mj7BjnNinLSg==}
+    peerDependencies:
+      '@content-collections/core': ^0.x
+      vite: ^5
+
   '@convex-dev/crons@0.1.5':
     resolution: {integrity: sha512-wQvqtWgmttq2iFkU7ObuB2vVmdywwwfY9Fl1j4FISYKypycYHu3rodZ06dkUqBlurzkC/hlYWrHirNKsFsEEUg==}
     peerDependencies:
@@ -1057,6 +1074,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.3':
+    resolution: {integrity: sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.20.2':
     resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
@@ -1077,6 +1100,12 @@ packages:
 
   '@esbuild/android-arm64@0.24.2':
     resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.3':
+    resolution: {integrity: sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1105,6 +1134,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.3':
+    resolution: {integrity: sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.20.2':
     resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
@@ -1125,6 +1160,12 @@ packages:
 
   '@esbuild/android-x64@0.24.2':
     resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.3':
+    resolution: {integrity: sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1153,6 +1194,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.3':
+    resolution: {integrity: sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.20.2':
     resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
@@ -1173,6 +1220,12 @@ packages:
 
   '@esbuild/darwin-x64@0.24.2':
     resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.3':
+    resolution: {integrity: sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1201,6 +1254,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.3':
+    resolution: {integrity: sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.20.2':
     resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
@@ -1221,6 +1280,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.24.2':
     resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.3':
+    resolution: {integrity: sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1249,6 +1314,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.3':
+    resolution: {integrity: sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.20.2':
     resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
@@ -1269,6 +1340,12 @@ packages:
 
   '@esbuild/linux-arm@0.24.2':
     resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.3':
+    resolution: {integrity: sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1297,6 +1374,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.3':
+    resolution: {integrity: sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.20.2':
     resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
@@ -1317,6 +1400,12 @@ packages:
 
   '@esbuild/linux-loong64@0.24.2':
     resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.3':
+    resolution: {integrity: sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1345,6 +1434,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.3':
+    resolution: {integrity: sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.20.2':
     resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
@@ -1365,6 +1460,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.24.2':
     resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.3':
+    resolution: {integrity: sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1393,6 +1494,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.3':
+    resolution: {integrity: sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.20.2':
     resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
@@ -1413,6 +1520,12 @@ packages:
 
   '@esbuild/linux-s390x@0.24.2':
     resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.3':
+    resolution: {integrity: sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1441,8 +1554,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.3':
+    resolution: {integrity: sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.24.2':
     resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.25.3':
+    resolution: {integrity: sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1471,6 +1596,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.3':
+    resolution: {integrity: sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.0':
     resolution: {integrity: sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==}
     engines: {node: '>=18'}
@@ -1485,6 +1616,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.24.2':
     resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.3':
+    resolution: {integrity: sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1513,6 +1650,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.3':
+    resolution: {integrity: sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.20.2':
     resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
     engines: {node: '>=12'}
@@ -1533,6 +1676,12 @@ packages:
 
   '@esbuild/sunos-x64@0.24.2':
     resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.3':
+    resolution: {integrity: sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1561,6 +1710,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.3':
+    resolution: {integrity: sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.20.2':
     resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
     engines: {node: '>=12'}
@@ -1585,6 +1740,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.3':
+    resolution: {integrity: sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.20.2':
     resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
@@ -1605,6 +1766,12 @@ packages:
 
   '@esbuild/win32-x64@0.24.2':
     resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.3':
+    resolution: {integrity: sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3350,6 +3517,10 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+
   caniuse-lite@1.0.30001692:
     resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
 
@@ -4027,6 +4198,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.25.3:
+    resolution: {integrity: sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4254,6 +4430,14 @@ packages:
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -6310,6 +6494,10 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+
   to-object-path@0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
     engines: {node: '>=0.10.0'}
@@ -6808,6 +6996,11 @@ packages:
 
   yaml@2.4.0:
     resolution: {integrity: sha512-j9iR8g+/t0lArF4V6NE/QCfT+CO7iLqrXAHZbJdo+LfjqP1vR8Fg5bSiaq6Q2lOD1AUEVrEVIgABvBFYojJVYQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.7.1:
+    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -7822,6 +8015,25 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
+  '@content-collections/core@0.8.2(typescript@5.6.3)':
+    dependencies:
+      '@parcel/watcher': 2.4.1
+      camelcase: 8.0.0
+      esbuild: 0.25.3
+      gray-matter: 4.0.3
+      p-limit: 6.2.0
+      picomatch: 4.0.2
+      pluralize: 8.0.0
+      serialize-javascript: 6.0.2
+      tinyglobby: 0.2.13
+      typescript: 5.6.3
+      yaml: 2.7.1
+      zod: 3.24.1
+
+  '@content-collections/vinxi@0.1.0(@content-collections/core@0.8.2(typescript@5.6.3))':
+    dependencies:
+      '@content-collections/core': 0.8.2(typescript@5.6.3)
+
   '@convex-dev/crons@0.1.5(convex@1.17.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       convex: 1.17.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -7875,6 +8087,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.24.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.3':
+    optional: true
+
   '@esbuild/android-arm64@0.20.2':
     optional: true
 
@@ -7885,6 +8100,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.3':
     optional: true
 
   '@esbuild/android-arm@0.20.2':
@@ -7899,6 +8117,9 @@ snapshots:
   '@esbuild/android-arm@0.24.2':
     optional: true
 
+  '@esbuild/android-arm@0.25.3':
+    optional: true
+
   '@esbuild/android-x64@0.20.2':
     optional: true
 
@@ -7909,6 +8130,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.24.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.20.2':
@@ -7923,6 +8147,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.24.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.20.2':
     optional: true
 
@@ -7933,6 +8160,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.24.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.20.2':
@@ -7947,6 +8177,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.24.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.20.2':
     optional: true
 
@@ -7957,6 +8190,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.3':
     optional: true
 
   '@esbuild/linux-arm64@0.20.2':
@@ -7971,6 +8207,9 @@ snapshots:
   '@esbuild/linux-arm64@0.24.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.3':
+    optional: true
+
   '@esbuild/linux-arm@0.20.2':
     optional: true
 
@@ -7981,6 +8220,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.24.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.3':
     optional: true
 
   '@esbuild/linux-ia32@0.20.2':
@@ -7995,6 +8237,9 @@ snapshots:
   '@esbuild/linux-ia32@0.24.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.20.2':
     optional: true
 
@@ -8005,6 +8250,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.20.2':
@@ -8019,6 +8267,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.24.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.20.2':
     optional: true
 
@@ -8029,6 +8280,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.20.2':
@@ -8043,6 +8297,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.24.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.20.2':
     optional: true
 
@@ -8053,6 +8310,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.24.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.3':
     optional: true
 
   '@esbuild/linux-x64@0.20.2':
@@ -8067,7 +8327,13 @@ snapshots:
   '@esbuild/linux-x64@0.24.2':
     optional: true
 
+  '@esbuild/linux-x64@0.25.3':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.3':
     optional: true
 
   '@esbuild/netbsd-x64@0.20.2':
@@ -8082,6 +8348,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.24.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.3':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.0':
     optional: true
 
@@ -8089,6 +8358,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.20.2':
@@ -8103,6 +8375,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.20.2':
     optional: true
 
@@ -8113,6 +8388,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.3':
     optional: true
 
   '@esbuild/win32-arm64@0.20.2':
@@ -8127,6 +8405,9 @@ snapshots:
   '@esbuild/win32-arm64@0.24.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.20.2':
     optional: true
 
@@ -8139,6 +8420,9 @@ snapshots:
   '@esbuild/win32-ia32@0.24.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.3':
+    optional: true
+
   '@esbuild/win32-x64@0.20.2':
     optional: true
 
@@ -8149,6 +8433,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.24.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -9086,7 +9373,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@tanstack/router-plugin@1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)':
+  '@tanstack/router-plugin@1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -9106,7 +9393,6 @@ snapshots:
       zod: 3.24.1
     optionalDependencies:
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
       webpack: 5.97.1
     transitivePeerDependencies:
       - supports-color
@@ -9139,11 +9425,11 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@tanstack/start-api-routes@1.110.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-api-routes@1.110.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/router-core': 1.108.0
-      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9187,7 +9473,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-client@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-client@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-cross-context': 1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9196,7 +9482,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9238,22 +9524,21 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-config@1.109.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)':
+  '@tanstack/start-config@1.109.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(webpack@5.97.1)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/router-generator': 1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@tanstack/router-plugin': 1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)
+      '@tanstack/router-plugin': 1.109.2(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(webpack@5.97.1)
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
       '@tanstack/start-plugin': 1.107.0
-      '@tanstack/start-server-functions-handler': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@vitejs/plugin-react': 4.3.4(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))
+      '@tanstack/start-server-functions-handler': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@vitejs/plugin-react': 4.3.4
       import-meta-resolve: 4.1.0
       nitropack: 2.10.4(typescript@5.6.3)
       ofetch: 1.4.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
+      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       zod: 3.24.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9319,11 +9604,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/start-router-manifest@1.111.0(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-router-manifest@1.111.0(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/router-core': 1.108.0
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      vinxi: 0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9365,10 +9650,10 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-client@1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-server-functions-client@1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
-      '@tanstack/start-server-functions-fetcher': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-server-functions-fetcher': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9413,10 +9698,10 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-fetcher@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-server-functions-fetcher@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -9460,11 +9745,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-handler@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-server-functions-handler@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tiny-invariant: 1.3.3
@@ -9517,12 +9802,12 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@tanstack/start-server-functions-ssr@1.110.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-server-functions-ssr@1.110.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
-      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server-functions-fetcher': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server-functions-fetcher': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9568,11 +9853,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)':
+  '@tanstack/start-server@1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-cross-context': 1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       h3: 1.13.0
       isbot: 5.1.22
       jsesc: 3.1.0
@@ -9620,20 +9905,19 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start@1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)':
+  '@tanstack/start@1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(webpack@5.97.1)(yaml@2.7.1)':
     dependencies:
-      '@tanstack/start-api-routes': 1.110.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-config': 1.109.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))(webpack@5.97.1)
-      '@tanstack/start-router-manifest': 1.111.0(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server-functions-client': 1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
-      '@tanstack/start-server-functions-handler': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-api-routes': 1.110.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-client': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-config': 1.109.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(webpack@5.97.1)(yaml@2.7.1)
+      '@tanstack/start-router-manifest': 1.111.0(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server-functions-client': 1.111.1(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
+      '@tanstack/start-server-functions-handler': 1.109.2(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       '@tanstack/start-server-functions-server': 1.110.1(babel-plugin-macros@3.1.0)
-      '@tanstack/start-server-functions-ssr': 1.110.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)
+      '@tanstack/start-server-functions-ssr': 1.110.2(@types/node@22.12.0)(babel-plugin-macros@3.1.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10122,14 +10406,13 @@ snapshots:
       prop-types: 15.8.1
       react: 19.0.0
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2))':
+  '@vitejs/plugin-react@4.3.4':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10741,6 +11024,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   camelcase@7.0.1: {}
+
+  camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001692: {}
 
@@ -11514,6 +11799,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
 
+  esbuild@0.25.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.3
+      '@esbuild/android-arm': 0.25.3
+      '@esbuild/android-arm64': 0.25.3
+      '@esbuild/android-x64': 0.25.3
+      '@esbuild/darwin-arm64': 0.25.3
+      '@esbuild/darwin-x64': 0.25.3
+      '@esbuild/freebsd-arm64': 0.25.3
+      '@esbuild/freebsd-x64': 0.25.3
+      '@esbuild/linux-arm': 0.25.3
+      '@esbuild/linux-arm64': 0.25.3
+      '@esbuild/linux-ia32': 0.25.3
+      '@esbuild/linux-loong64': 0.25.3
+      '@esbuild/linux-mips64el': 0.25.3
+      '@esbuild/linux-ppc64': 0.25.3
+      '@esbuild/linux-riscv64': 0.25.3
+      '@esbuild/linux-s390x': 0.25.3
+      '@esbuild/linux-x64': 0.25.3
+      '@esbuild/netbsd-arm64': 0.25.3
+      '@esbuild/netbsd-x64': 0.25.3
+      '@esbuild/openbsd-arm64': 0.25.3
+      '@esbuild/openbsd-x64': 0.25.3
+      '@esbuild/sunos-x64': 0.25.3
+      '@esbuild/win32-arm64': 0.25.3
+      '@esbuild/win32-ia32': 0.25.3
+      '@esbuild/win32-x64': 0.25.3
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -11825,6 +12138,10 @@ snapshots:
       reusify: 1.0.4
 
   fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -14028,6 +14345,11 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinyglobby@0.2.13:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   to-object-path@0.3.0:
     dependencies:
       kind-of: 3.2.2
@@ -14343,7 +14665,7 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vinxi@0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3):
+  vinxi@0.5.3(@types/node@22.12.0)(db0@0.2.1)(ioredis@5.4.1)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.1):
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -14377,7 +14699,7 @@ snapshots:
       unctx: 2.4.1
       unenv: 1.10.0
       unstorage: 1.14.4(db0@0.2.1)(ioredis@5.4.1)
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
+      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.1)
       zod: 3.24.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14420,18 +14742,16 @@ snapshots:
       - xml2js
       - yaml
 
-  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)):
+  vite-tsconfig-paths@5.0.1(typescript@5.6.3):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.6.3)
-    optionalDependencies:
-      vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2):
+  vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
@@ -14442,6 +14762,7 @@ snapshots:
       jiti: 2.4.2
       terser: 5.37.0
       tsx: 4.19.2
+      yaml: 2.7.1
 
   vue@3.5.13(typescript@5.6.3):
     dependencies:
@@ -14601,6 +14922,8 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.4.0: {}
+
+  yaml@2.7.1: {}
 
   yargs-parser@21.1.1: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./app/*"]
+      "~/*": ["./app/*"],
+      "content-collections": ["./.content-collections/generated"]
     },
     "types": ["vite/client"],
     "noEmit": true


### PR DESCRIPTION
Based on [this X post](https://x.com/tannerlinsley/status/1918026872765727027), I've added [Content Collections](https://www.content-collections.dev/docs/quickstart/tanstack-start) to the blog page of [tanstack.com](https://tanstack.com/blog).

To summarize the change:
- Added Content Collections plugin to Vite
- Added Content Collections generated files to `.gitignore`
- Adjusted all `published` fields for articles to `YYYY-MM-DD`
- Adjusted `fetchFrontMatters` server function
- Removed `getPostList` utility function as, per my understanding, we don't need it anymore

Happy to hear feedback, as this is my small and first open-source contribution, and I've been really nervous before committing (had to fix stuff and force-push 4 times into my branch before opening PR).