### PR TITLE
fix: use the correct URL when the user clicks "Edit on Github"

### DIFF
--- a/app/components/Doc.tsx
+++ b/app/components/Doc.tsx
@@ -125,7 +125,7 @@ export function Doc({
           <div className="w-full h-px bg-gray-500 opacity-30" />
           <div className="py-4 opacity-70">
             <a
-              href={`https://github.com/${repo}/tree/${branch}/${filePath}`}
+              href={`https://github.com/${repo}/edit/${branch}/${filePath}`}
               className="flex items-center gap-2"
             >
               <FaEdit /> Edit on GitHub


### PR DESCRIPTION
This has to do with the "Edit on GitHub" link that we place at the moment of our markdown documents.

Previously, this link took the user to "view" the markdown document on GitHub.

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/ddda2ef3-4b66-480f-b0b6-c3ca63b63c4d" />

With this change, the new link takes the user to a view designed by GitHub to encourage more native flows towards making edits.

If the user already has write-access on GitHub (which they most likely won't), then they can start making changes.

<img width="1689" alt="image" src="https://github.com/user-attachments/assets/66faff1e-ed4d-487a-a7e4-570173080c8c" />

If not, the user will be asked to fork the repository, before they can begin making changes and opening a pull request (which they'd have to do anyways).

<img width="1692" alt="image" src="https://github.com/user-attachments/assets/a5ba2c4e-898a-4653-94cb-ae5280d084dd" />
