### PR TITLE
Update 418 and 423 error replacement

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
         const replacements = [
           // replace `throw Error(p(418))` with `console.error(p(418))`
           ['throw Error(p(418))', 'console.error(p(418))'],
+          ['Error(p(418))', 'console.error(p(418))'],
+          ['throw Error(n(418))', 'console.error(n(418))'],
+          ['Error(n(418))', 'console.error(n(418))'],
+          ['throw Error(p(423))', 'console.error(p(423))'],
+          ['throw Error(n(423))', 'console.error(n(423))'],
+          ['Error(n(423))', 'console.error(n(423))'],
           // replace `throw new Error('Hydration failed` with `console.error('Hydration failed')`
           [
             `throw new Error('Hydration failed`,


### PR DESCRIPTION
In one of the new React minified versions, they changed `p(418)` to `n(418)`.

This change still allow `p(418)` backward compatibility as forward compatibility with the new React version which introduces the `n` function.

This change also introduces a replacement for 423 errors as they can also crash the runtime and malform the webpage.