### PR TITLE
feat: directly serve library document markdown

### DIFF
--- a/.tanstack-start/server-routes/routeTree.gen.ts
+++ b/.tanstack-start/server-routes/routeTree.gen.ts
@@ -19,40 +19,114 @@ import {
   createServerFileRoute,
 } from '@tanstack/react-start/server'
 
+import { ServerRoute as LibraryIdVersionDocsChar123Char125DotmdRouteImport } from './../../src/routes/$libraryId/$version.docs.{$}[.]md'
+import { ServerRoute as LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRouteImport } from './../../src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md'
+
 // Create/Update Routes
 
 const rootRoute = createServerRoute()
 
+const LibraryIdVersionDocsChar123Char125DotmdRoute =
+  LibraryIdVersionDocsChar123Char125DotmdRouteImport.update({
+    id: '/$libraryId/$version/docs/{$}.md',
+    path: '/$libraryId/$version/docs/{$}.md',
+    getParentRoute: () => rootRoute,
+  } as any)
+
+const LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute =
+  LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRouteImport.update({
+    id: '/$libraryId/$version/docs/framework/$framework/{$}.md',
+    path: '/$libraryId/$version/docs/framework/$framework/{$}.md',
+    getParentRoute: () => rootRoute,
+  } as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-start/server' {
-  interface FileRoutesByPath {}
+  interface FileRoutesByPath {
+    '/$libraryId/$version/docs/{$}.md': {
+      id: '/$libraryId/$version/docs/{$}.md'
+      path: '/$libraryId/$version/docs/{$}.md'
+      fullPath: '/$libraryId/$version/docs/{$}.md'
+      preLoaderRoute: typeof LibraryIdVersionDocsChar123Char125DotmdRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/$libraryId/$version/docs/framework/$framework/{$}.md': {
+      id: '/$libraryId/$version/docs/framework/$framework/{$}.md'
+      path: '/$libraryId/$version/docs/framework/$framework/{$}.md'
+      fullPath: '/$libraryId/$version/docs/framework/$framework/{$}.md'
+      preLoaderRoute: typeof LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRouteImport
+      parentRoute: typeof rootRoute
+    }
+  }
 }
 
 // Add type-safety to the createFileRoute function across the route tree
 
+declare module './../../src/routes/$libraryId/$version.docs.{$}[.]md' {
+  const createServerFileRoute: CreateServerFileRoute<
+    FileRoutesByPath['/$libraryId/$version/docs/{$}.md']['parentRoute'],
+    FileRoutesByPath['/$libraryId/$version/docs/{$}.md']['id'],
+    FileRoutesByPath['/$libraryId/$version/docs/{$}.md']['path'],
+    FileRoutesByPath['/$libraryId/$version/docs/{$}.md']['fullPath'],
+    unknown
+  >
+}
+declare module './../../src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md' {
+  const createServerFileRoute: CreateServerFileRoute<
+    FileRoutesByPath['/$libraryId/$version/docs/framework/$framework/{$}.md']['parentRoute'],
+    FileRoutesByPath['/$libraryId/$version/docs/framework/$framework/{$}.md']['id'],
+    FileRoutesByPath['/$libraryId/$version/docs/framework/$framework/{$}.md']['path'],
+    FileRoutesByPath['/$libraryId/$version/docs/framework/$framework/{$}.md']['fullPath'],
+    unknown
+  >
+}
+
 // Create and export the route tree
 
-export interface FileRoutesByFullPath {}
+export interface FileRoutesByFullPath {
+  '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
+  '/$libraryId/$version/docs/framework/$framework/{$}.md': typeof LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute
+}
 
-export interface FileRoutesByTo {}
+export interface FileRoutesByTo {
+  '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
+  '/$libraryId/$version/docs/framework/$framework/{$}.md': typeof LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute
+}
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
+  '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
+  '/$libraryId/$version/docs/framework/$framework/{$}.md': typeof LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: never
+  fullPaths:
+    | '/$libraryId/$version/docs/{$}.md'
+    | '/$libraryId/$version/docs/framework/$framework/{$}.md'
   fileRoutesByTo: FileRoutesByTo
-  to: never
-  id: '__root__'
+  to:
+    | '/$libraryId/$version/docs/{$}.md'
+    | '/$libraryId/$version/docs/framework/$framework/{$}.md'
+  id:
+    | '__root__'
+    | '/$libraryId/$version/docs/{$}.md'
+    | '/$libraryId/$version/docs/framework/$framework/{$}.md'
   fileRoutesById: FileRoutesById
 }
 
-export interface RootRouteChildren {}
+export interface RootRouteChildren {
+  LibraryIdVersionDocsChar123Char125DotmdRoute: typeof LibraryIdVersionDocsChar123Char125DotmdRoute
+  LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute: typeof LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute
+}
 
-const rootRouteChildren: RootRouteChildren = {}
+const rootRouteChildren: RootRouteChildren = {
+  LibraryIdVersionDocsChar123Char125DotmdRoute:
+    LibraryIdVersionDocsChar123Char125DotmdRoute,
+  LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute:
+    LibraryIdVersionDocsFrameworkFrameworkChar123Char125DotmdRoute,
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
@@ -63,7 +137,16 @@ export const routeTree = rootRoute
   "routes": {
     "__root__": {
       "filePath": "__root.tsx",
-      "children": []
+      "children": [
+        "/$libraryId/$version/docs/{$}.md",
+        "/$libraryId/$version/docs/framework/$framework/{$}.md"
+      ]
+    },
+    "/$libraryId/$version/docs/{$}.md": {
+      "filePath": "$libraryId/$version.docs.{$}[.]md.tsx"
+    },
+    "/$libraryId/$version/docs/framework/$framework/{$}.md": {
+      "filePath": "$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx"
     }
   }
 }

--- a/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
@@ -24,6 +24,8 @@ export const ServerRoute = createServerFileRoute().methods({
       headers: {
         'Content-Type': 'text/markdown',
         'Content-Disposition': `inline; filename="${filename}.md"`,
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Cdn-Cache-Control': 'max-age=300, stale-while-revalidate=300, durable',
       },
     })
   },

--- a/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
@@ -1,0 +1,5 @@
+export const ServerRoute = createServerFileRoute().methods({
+  GET: async ({ request }) => {
+    return new Response('Foo bar')
+  },
+})

--- a/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.{$}[.]md.tsx
@@ -1,5 +1,30 @@
+import { getBranch, getLibrary } from '~/libraries'
+import { loadDocs } from '~/utils/docs'
+
 export const ServerRoute = createServerFileRoute().methods({
-  GET: async ({ request }) => {
-    return new Response('Foo bar')
+  GET: async ({ request, params }) => {
+    const url = new URL(request.url)
+
+    const { libraryId, version, framework, _splat: docsPath } = params
+    const library = getLibrary(libraryId)
+    const root = library.docsRoot || 'docs'
+
+    const doc = await loadDocs({
+      repo: library.repo,
+      branch: getBranch(library, version),
+      docsPath: `${root}/framework/${framework}/${docsPath}`,
+      currentPath: url.pathname,
+      redirectPath: `/${library.id}/${version}/docs/overview`,
+    })
+
+    const markdownContent = `# ${doc.title}\n${doc.content}`
+    const filename = (docsPath || 'file').split('/').join('-')
+
+    return new Response(markdownContent, {
+      headers: {
+        'Content-Type': 'text/markdown',
+        'Content-Disposition': `inline; filename="${filename}.md"`,
+      },
+    })
   },
 })

--- a/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
@@ -24,6 +24,8 @@ export const ServerRoute = createServerFileRoute().methods({
       headers: {
         'Content-Type': 'text/markdown',
         'Content-Disposition': `inline; filename="${filename}.md"`,
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'Cdn-Cache-Control': 'max-age=300, stale-while-revalidate=300, durable',
       },
     })
   },

--- a/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
@@ -1,5 +1,30 @@
+import { getBranch, getLibrary } from '~/libraries'
+import { loadDocs } from '~/utils/docs'
+
 export const ServerRoute = createServerFileRoute().methods({
-  GET: async ({ request }) => {
-    return new Response('Foo bar')
+  GET: async ({ request, params }) => {
+    const url = new URL(request.url)
+
+    const { libraryId, version, _splat: docsPath } = params
+    const library = getLibrary(libraryId)
+    const root = library.docsRoot || 'docs'
+
+    const doc = await loadDocs({
+      repo: library.repo,
+      branch: getBranch(library, version),
+      docsPath: `${root}/${docsPath}`,
+      currentPath: url.pathname,
+      redirectPath: `/${library.id}/${version}/docs/overview`,
+    })
+
+    const markdownContent = `# ${doc.title}\n${doc.content}`
+    const filename = (docsPath || 'file').split('/').join('-')
+
+    return new Response(markdownContent, {
+      headers: {
+        'Content-Type': 'text/markdown',
+        'Content-Disposition': `inline; filename="${filename}.md"`,
+      },
+    })
   },
 })

--- a/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
+++ b/src/routes/$libraryId/$version.docs.{$}[.]md.tsx
@@ -1,0 +1,5 @@
+export const ServerRoute = createServerFileRoute().methods({
+  GET: async ({ request }) => {
+    return new Response('Foo bar')
+  },
+})


### PR DESCRIPTION
Redo of #396 with the new changes available using the features in the TanStack Start Alpha channel.

---

Updated description from #396.

> This is a POC PR that lets the user to access the markdown documentation pages by adding `.md` to the end of the path.
> 
> - `/form/latest/docs/framework/react/guides/basic-concepts.md` serves the markdown version of the documentation page.
> 
> ### Why is it useful?
> 
> This feature is useful for using the documentation with LLMs, and was inspired by `vite`:
> 
> > For every page you can get the original markdown by replacing the .html extension with .md - e.g.:
> > 
> > [https://vite.dev/guide/rolldown](https://t.co/JqWavTbqzT)
> > (Posted by [Evan You](https://x.com/youyuxi/status/1918139674662715774))
> 
> This feature would let the user to pass the documentation pages as context to the LLM-s they use for specific versions of tanstack libs, which would make sure that they always get the right information, even if there were breaking changes between versions.