### PR TITLE
docs(query): typo "chek" -> "check" on query/latest

### DIFF
--- a/src/routes/_libraries/query.$version.index.tsx
+++ b/src/routes/_libraries/query.$version.index.tsx
@@ -82,7 +82,7 @@ export default function VersionIndex() {
               >
                 Read the Docs
               </Link>
-              <p>(or chek out our official course 👇)</p>
+              <p>(or check out our official course 👇)</p>
             </div>
             <QueryGGBanner />
           </div>


### PR DESCRIPTION
Fix typo in the work `chek` to `check` on the page http://localhost:3000/query/latest

From
> (or chek out our official course 👇)

To
> (or check out our official course 👇)

![query-chek](https://github.com/user-attachments/assets/0f8336cc-3c7e-4010-835d-99a110ffb67d)
