### PR TITLE
Stats: Fix auto-animate npm package name

### DIFF
--- a/src/routes/stats/npm/-comparisons.ts
+++ b/src/routes/stats/npm/-comparisons.ts
@@ -340,7 +340,7 @@ export function getPopularComparisons(): z.input<
           color: '#FF1493',
         },
         {
-          packages: [{ name: 'auto-animate' }],
+          packages: [{ name: '@formkit/auto-animate' }],
           color: '#FFD700',
         },
       ],


### PR DESCRIPTION
Changed the "auto-animate" npm package name to the correct "@formkit/auto-animate" for the stats site.