### PR TITLE
feat: handle theme with localStorage

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -59,15 +59,18 @@ const themeDetectorScript = (function () {
   function themeFn() {
     try {
       const storedTheme = localStorage.getItem('theme') || 'auto'
+      const validTheme = ['light', 'dark', 'auto'].includes(storedTheme)
+        ? storedTheme
+        : 'auto'
 
-      if (storedTheme === 'auto') {
+      if (validTheme === 'auto') {
         const autoTheme = window.matchMedia('(prefers-color-scheme: dark)')
           .matches
           ? 'dark'
           : 'light'
         document.documentElement.classList.add(autoTheme, 'auto')
       } else {
-        document.documentElement.classList.add(storedTheme)
+        document.documentElement.classList.add(validTheme)
       }
     } catch (e) {
       const autoTheme = window.matchMedia('(prefers-color-scheme: dark)')

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,132 @@
+import { ScriptOnce } from '@tanstack/react-router'
+import * as React from 'react'
+import { createContext, ReactNode, useEffect, useState } from 'react'
+import { z } from 'zod'
+
+const themeModeSchema = z.enum(['light', 'dark', 'auto'])
+const resolvedThemeSchema = z.enum(['light', 'dark'])
+const themeKey = 'theme'
+
+type ThemeMode = z.infer<typeof themeModeSchema>
+type ResolvedTheme = z.infer<typeof resolvedThemeSchema>
+
+function getStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'auto'
+  try {
+    const storedTheme = localStorage.getItem(themeKey)
+    return themeModeSchema.parse(storedTheme)
+  } catch {
+    return 'auto'
+  }
+}
+
+function setStoredThemeMode(theme: ThemeMode): void {
+  if (typeof window === 'undefined') return
+  try {
+    const parsedTheme = themeModeSchema.parse(theme)
+    localStorage.setItem(themeKey, parsedTheme)
+  } catch {}
+}
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+function updateThemeClass(themeMode: ThemeMode) {
+  const root = document.documentElement
+  root.classList.remove('light', 'dark', 'auto')
+  const newTheme = themeMode === 'auto' ? getSystemTheme() : themeMode
+  root.classList.add(newTheme)
+
+  if (themeMode === 'auto') {
+    root.classList.add('auto')
+  }
+}
+
+function setupPreferredListener() {
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  const handler = () => updateThemeClass('auto')
+  mediaQuery.addEventListener('change', handler)
+  return () => mediaQuery.removeEventListener('change', handler)
+}
+
+const themeDetectorScript = (function () {
+  function themeFn() {
+    try {
+      const storedTheme = localStorage.getItem('theme') || 'auto'
+
+      if (storedTheme === 'auto') {
+        const autoTheme = window.matchMedia('(prefers-color-scheme: dark)')
+          .matches
+          ? 'dark'
+          : 'light'
+        document.documentElement.classList.add(autoTheme, 'auto')
+      } else {
+        document.documentElement.classList.add(storedTheme)
+      }
+    } catch (e) {
+      const autoTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light'
+      document.documentElement.classList.add(autoTheme, 'auto')
+    }
+  }
+  return `(${themeFn.toString()})();`
+})()
+
+type ThemeContextProps = {
+  themeMode: ThemeMode
+  resolvedTheme: ResolvedTheme
+  setTheme: (theme: ThemeMode) => void
+  toggleMode: () => void
+}
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined)
+
+type ThemeProviderProps = {
+  children: ReactNode
+}
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(getStoredThemeMode)
+
+  useEffect(() => {
+    updateThemeClass(themeMode)
+
+    if (themeMode === 'auto') {
+      return setupPreferredListener()
+    }
+  }, [themeMode])
+
+  const resolvedTheme = themeMode === 'auto' ? getSystemTheme() : themeMode
+
+  const setTheme = (newTheme: ThemeMode) => {
+    setThemeMode(newTheme)
+    setStoredThemeMode(newTheme)
+  }
+
+  const toggleMode = () => {
+    setTheme(
+      themeMode === 'light' ? 'dark' : themeMode === 'dark' ? 'auto' : 'light'
+    )
+  }
+
+  return (
+    <ThemeContext.Provider
+      value={{ themeMode, resolvedTheme, setTheme, toggleMode }}
+    >
+      <ScriptOnce children={themeDetectorScript} />
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = React.useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -55,6 +55,14 @@ const setupPreferredListener = clientOnly(() => {
   return () => mediaQuery.removeEventListener('change', handler)
 })
 
+const getNextTheme = clientOnly((current: ThemeMode): ThemeMode => {
+  const themes: ThemeMode[] =
+    getSystemTheme() === 'dark'
+      ? ['auto', 'light', 'dark']
+      : ['auto', 'dark', 'light']
+  return themes[(themes.indexOf(current) + 1) % themes.length]
+})
+
 const themeDetectorScript = (function () {
   function themeFn() {
     try {
@@ -111,9 +119,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   }
 
   const toggleMode = () => {
-    setTheme(
-      themeMode === 'light' ? 'dark' : themeMode === 'dark' ? 'auto' : 'light'
-    )
+    setTheme(getNextTheme(themeMode))
   }
 
   return (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { FaMoon, FaSun } from 'react-icons/fa'
 import { useTheme } from './ThemeProvider'
-import { twMerge } from 'tailwind-merge'
 
 export function ThemeToggle() {
   const { toggleMode } = useTheme()
@@ -17,9 +16,7 @@ export function ThemeToggle() {
   return (
     <div
       onClick={handleToggleMode}
-      className={twMerge(
-        `w-12 h-6 bg-gray-500/10 dark:bg-gray-800 rounded-full flex items-center justify-between cursor-pointer relative transition-all`
-      )}
+      className={`w-12 h-6 bg-gray-500/10 dark:bg-gray-800 rounded-full flex items-center justify-between cursor-pointer relative transition-all`}
     >
       <div className="flex-1 flex items-center justify-between px-1.5">
         <FaSun
@@ -37,7 +34,7 @@ export function ThemeToggle() {
       <div
         className="absolute w-6 h-6 rounded-full shadow-md shadow-black/20 bg-white dark:bg-gray-400 transition-all duration-300 ease-in-out
                    auto:left-1/2 auto:-translate-x-1/2 auto:scale-0 auto:opacity-0
-                   left-full -translate-x-full scale-75
+                   left-0 translate-x-full scale-75
                    dark:left-0 dark:translate-x-0 dark:scale-75"
       />
     </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -37,7 +37,7 @@ export function ThemeToggle() {
       <div
         className="absolute w-6 h-6 rounded-full shadow-md shadow-black/20 bg-white dark:bg-gray-400 transition-all duration-300 ease-in-out
                    auto:left-1/2 auto:-translate-x-1/2 auto:scale-0 auto:opacity-0
-                   light:left-full light:-translate-x-full light:scale-75 
+                   left-full -translate-x-full scale-75
                    dark:left-0 dark:translate-x-0 dark:scale-75"
       />
     </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,95 +1,84 @@
-import { createServerFn } from '@tanstack/react-start'
-import { getCookie, setCookie } from '@tanstack/react-start/server'
+import { ScriptOnce } from '@tanstack/react-router'
 import * as React from 'react'
 import { FaMoon, FaSun } from 'react-icons/fa'
 import { twMerge } from 'tailwind-merge'
-
 import { z } from 'zod'
 import { create } from 'zustand'
 
+const resolvedThemeSchema = z.enum(['light', 'dark'])
 const themeModeSchema = z.enum(['light', 'dark', 'auto'])
-const prefersModeSchema = z.enum(['light', 'dark'])
+const themeKey = 'theme'
 
 type ThemeMode = z.infer<typeof themeModeSchema>
-type PrefersMode = z.infer<typeof prefersModeSchema>
+type ResolvedTheme = z.infer<typeof resolvedThemeSchema>
 
 interface ThemeStore {
   mode: ThemeMode
-  prefers: PrefersMode
-  toggleMode: () => void
-  setPrefers: (prefers: PrefersMode) => void
+  toggleThemeMode: () => void
 }
 
-const updateThemeCookie = createServerFn({ method: 'POST' })
-  .validator(themeModeSchema)
-  .handler((ctx) => {
-    setCookie('theme', ctx.data, {
-      httpOnly: false,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      maxAge: 60 * 60 * 24 * 365 * 10,
-    })
-  })
+function getStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'auto'
+  try {
+    const storedTheme = localStorage.getItem(themeKey)
+    return resolvedThemeSchema.parse(storedTheme)
+  } catch {
+    return 'auto'
+  }
+}
 
-export const getThemeCookie = createServerFn().handler(() => {
-  return (
-    themeModeSchema.catch('auto').parse(getCookie('theme') ?? 'null') || 'auto'
-  )
-})
+function setStoredThemeMode(theme: ThemeMode): void {
+  if (typeof window === 'undefined') return
+  try {
+    const parsedTheme = themeModeSchema.parse(theme)
+    localStorage.setItem(themeKey, parsedTheme)
+  } catch {}
+}
 
-export const useThemeStore = create<ThemeStore>((set, get) => ({
-  mode: 'auto',
-  prefers: (() => {
-    if (typeof document !== 'undefined') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-    }
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
 
-    return 'light'
-  })(),
-  toggleMode: () =>
+function updateThemeClass(themeMode: ThemeMode) {
+  const root = document.documentElement
+  root.classList.remove('light', 'dark', 'auto')
+  const newTheme = themeMode === 'auto' ? getSystemTheme() : themeMode
+  root.classList.add(newTheme)
+
+  if (themeMode === 'auto') {
+    root.classList.add('auto')
+  }
+}
+
+export const useThemeStore = create<ThemeStore>((set) => ({
+  mode: getStoredThemeMode(),
+  toggleThemeMode: () =>
     set((s) => {
       const newMode =
         s.mode === 'auto' ? 'light' : s.mode === 'light' ? 'dark' : 'auto'
 
-      updateThemeClass(newMode, s.prefers)
-      updateThemeCookie({
-        data: newMode,
-      })
+      updateThemeClass(newMode)
+      setStoredThemeMode(newMode)
 
-      return {
-        mode: newMode,
-      }
+      return { mode: newMode }
     }),
-  setPrefers: (prefers) => {
-    set({ prefers })
-    updateThemeClass(get().mode, prefers)
-  },
 }))
 
 if (typeof document !== 'undefined') {
   window
     .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', (event) => {
+    .addEventListener('change', () => {
       if (useThemeStore.getState().mode === 'auto') {
+        updateThemeClass('auto')
       }
-      useThemeStore.getState().setPrefers(event.matches ? 'dark' : 'light')
     })
 }
 
-// Helper to update <body> class
-function updateThemeClass(mode: ThemeMode, prefers: PrefersMode) {
-  document.documentElement.classList.remove('dark')
-  if (mode === 'dark' || (mode === 'auto' && prefers === 'dark')) {
-    document.documentElement.classList.add('dark')
-  }
-}
-
 export function ThemeToggle() {
-  const mode = useThemeStore((s) => s.mode)
-  const toggleMode = useThemeStore((s) => s.toggleMode)
+  const toggleMode = useThemeStore((s) => s.toggleThemeMode)
 
   const handleToggleMode = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -108,35 +97,55 @@ export function ThemeToggle() {
     >
       <div className="flex-1 flex items-center justify-between px-1.5">
         <FaSun
-          className={twMerge(
-            `text-sm transition-opacity`,
-            mode !== 'auto' ? 'opacity-50' : 'opacity-0'
-          )}
+          className={`text-sm transition-opacity auto:opacity-0 opacity-50`}
         />
         <FaMoon
-          className={twMerge(
-            `text-sm transition-opacity`,
-            mode !== 'auto' ? 'opacity-50' : 'opacity-0'
-          )}
+          className={`text-sm transition-opacity auto:opacity-0 opacity-50`}
         />
         <span
-          className={twMerge(
-            `uppercase select-none font-black text-[.6rem] absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition-opacity`,
-            mode === 'auto' ? 'opacity-30 hover:opacity-50' : 'opacity-0'
-          )}
+          className={`uppercase select-none font-black text-[.6rem] absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition-opacity auto:opacity-30 auto:hover:opacity-50 opacity-0`}
         >
           Auto
         </span>
       </div>
       <div
-        className="absolute w-6 h-6 rounded-full shadow-md shadow-black/20 bg-white dark:bg-gray-400 transition-all duration-300 ease-in-out"
-        style={{
-          left: mode === 'auto' ? '50%' : mode === 'light' ? '100%' : '0%',
-          transform: `translateX(${
-            mode === 'auto' ? '-50%' : mode === 'light' ? '-100%' : '0'
-          }) scale(${mode === 'auto' ? 0 : 0.8})`,
-        }}
+        className="absolute w-6 h-6 rounded-full shadow-md shadow-black/20 bg-white dark:bg-gray-400 transition-all duration-300 ease-in-out
+                   auto:left-1/2 auto:-translate-x-1/2 auto:scale-0 auto:opacity-0
+                   light:left-full light:-translate-x-full light:scale-75 
+                   dark:left-0 dark:translate-x-0 dark:scale-75"
       />
     </div>
+  )
+}
+
+export function ThemeDetector() {
+  return (
+    <ScriptOnce
+      children={(function () {
+        function themeFn() {
+          try {
+            const storedTheme = localStorage.getItem('theme') || 'auto'
+
+            if (storedTheme === 'auto') {
+              const autoTheme = window.matchMedia(
+                '(prefers-color-scheme: dark)'
+              ).matches
+                ? 'dark'
+                : 'light'
+              document.documentElement.classList.add(autoTheme, 'auto')
+            } else {
+              document.documentElement.classList.add(storedTheme)
+            }
+          } catch (e) {
+            const autoTheme = window.matchMedia('(prefers-color-scheme: dark)')
+              .matches
+              ? 'dark'
+              : 'light'
+            document.documentElement.classList.add(autoTheme, 'auto')
+          }
+        }
+        return `(${themeFn.toString()})();`
+      })()}
+    />
   )
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as ReactDom from 'react-dom'
 import {
   Outlet,
-  ScriptOnce,
   createRootRouteWithContext,
   redirect,
   useMatches,
@@ -20,11 +19,11 @@ import { TanStackRouterDevtoolsInProd } from '@tanstack/react-router-devtools'
 import { NotFound } from '~/components/NotFound'
 import { CgSpinner } from 'react-icons/cg'
 import { DefaultCatchBoundary } from '~/components/DefaultCatchBoundary'
-import { getThemeCookie, useThemeStore } from '~/components/ThemeToggle'
 import { GamScripts } from '~/components/Gam'
 import { BackgroundAnimation } from '~/components/BackgroundAnimation'
 import { SearchProvider } from '~/contexts/SearchContext'
 import { SearchModal } from '~/components/SearchModal'
+import { ThemeDetector } from '~/components/ThemeToggle'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
@@ -127,11 +126,6 @@ export const Route = createRootRouteWithContext<{
     }
   },
   staleTime: Infinity,
-  loader: async () => {
-    return {
-      themeCookie: await getThemeCookie(),
-    }
-  },
   errorComponent: (props) => {
     return (
       <RootDocument>
@@ -169,13 +163,6 @@ function RootComponent() {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
-  const { themeCookie } = Route.useLoaderData()
-
-  React.useEffect(() => {
-    useThemeStore.setState({ mode: themeCookie })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   const matches = useMatches()
 
   const isLoading = useRouterState({
@@ -200,17 +187,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 
   const showDevtools = canShowLoading && isRouterPage
 
-  const themeClass = themeCookie === 'dark' ? 'dark' : ''
-
   return (
-    <html lang="en" className={themeClass}>
+    <html lang="en" suppressHydrationWarning>
       <head>
-        {/* If the theme is set to auto, inject a tiny script to set the proper class on html based on the user preference */}
-        {themeCookie === 'auto' ? (
-          <ScriptOnce
-            children={`window.matchMedia('(prefers-color-scheme: dark)').matches ? document.documentElement.classList.add('dark') : null`}
-          />
-        ) : null}
+        <ThemeDetector />
         <HeadContent />
         {matches.find((d) => d.staticData?.baseParent) ? (
           <base target="_parent" />

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as ReactDom from 'react-dom'
 import {
   Outlet,
   createRootRouteWithContext,
@@ -23,7 +22,7 @@ import { GamScripts } from '~/components/Gam'
 import { BackgroundAnimation } from '~/components/BackgroundAnimation'
 import { SearchProvider } from '~/contexts/SearchContext'
 import { SearchModal } from '~/components/SearchModal'
-import { ThemeDetector } from '~/components/ThemeToggle'
+import { ThemeProvider } from '~/components/ThemeProvider'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
@@ -153,11 +152,13 @@ function RootComponent() {
 
   return (
     <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
-      <SearchProvider>
-        <RootDocument>
-          <Outlet />
-        </RootDocument>
-      </SearchProvider>
+      <ThemeProvider>
+        <SearchProvider>
+          <RootDocument>
+            <Outlet />
+          </RootDocument>
+        </SearchProvider>
+      </ThemeProvider>
     </ClerkProvider>
   )
 }
@@ -190,7 +191,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <ThemeDetector />
         <HeadContent />
         {matches.find((d) => d.staticData?.baseParent) ? (
           <base target="_parent" />

--- a/src/routes/_libraries/route.tsx
+++ b/src/routes/_libraries/route.tsx
@@ -18,7 +18,7 @@ import {
 import { getSponsorsForSponsorPack } from '~/server/sponsors'
 import { libraries } from '~/libraries'
 import { Scarf } from '~/components/Scarf'
-import { ThemeToggle, useThemeStore } from '~/components/ThemeToggle'
+import { ThemeToggle } from '~/components/ThemeToggle'
 import { TbBrandBluesky, TbBrandTwitter } from 'react-icons/tb'
 import { BiSolidCheckShield } from 'react-icons/bi'
 import { SearchButton } from '~/components/SearchButton'

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,14 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    function ({ addVariant }) {
+      addVariant('light', '&:is(.light *)')
+      addVariant('dark', '&:is(.dark *)')
+      addVariant('auto', '&:is(.auto *)')
+    },
+  ],
   darkMode: 'class',
   theme: {
     extend: {


### PR DESCRIPTION
As discussed on Discord I removed the cookie logic in favor of localStorage to handle the theme (light, dark and auto)

It previously relied on zusatand, I replaced it with a react context in a separate commit, you can see both versions in this PR.
I think we should keep it simple and stay with the context but if we want to use zustand as it's already installed I can revert the second commit.