### PR TITLE
fix: raw links

### DIFF
--- a/src/libraries/start.tsx
+++ b/src/libraries/start.tsx
@@ -31,6 +31,7 @@ export const startProject = {
   textColor: 'text-cyan-600',
   embedEditor: 'codesandbox',
   frameworks: ['react', 'solid'],
+  defaultDocs: 'framework/react/overview',
   scarfId: 'b6e2134f-e805-401d-95c3-2a7765d49a3d',
   showNetlifyUrl: true,
   // hide stackblitz until they support Async Local Storage

--- a/src/routes/$libraryId/$version.docs.index.tsx
+++ b/src/routes/$libraryId/$version.docs.index.tsx
@@ -7,11 +7,9 @@ export const Route = createFileRoute({
     const library = getLibrary(libraryId)
 
     throw redirect({
-      // to: `/$libraryId/$version/docs/${library.defaultDocs || 'overview'}`,
-      to: '/$libraryId/$version/docs/$',
+      from: '/$libraryId/$version/docs',
+      to: './$',
       params: {
-        libraryId,
-        version: ctx.params.version,
         _splat: 'defaultDocs' in library ? library.defaultDocs : 'overview',
       },
     })

--- a/src/routes/_libraries/config.$version.index.tsx
+++ b/src/routes/_libraries/config.$version.index.tsx
@@ -51,7 +51,9 @@ export default function FormVersionIndex() {
             for publishing and maintaining high-quality JavaScript packages
           </h2>
           <Link
-            to="./docs/"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`py-2 px-4 bg-gray-500 text-white rounded uppercase font-extrabold`}
           >
             Get Started
@@ -139,7 +141,9 @@ export default function FormVersionIndex() {
           </div>
           <div>
             <Link
-              to="./docs/"
+              from="/$libraryId/$version"
+              to="./docs"
+              params={{ libraryId: library.id }}
               className={`inline-block py-2 px-4 bg-gray-500 text-white rounded uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/db.$version.index.tsx
+++ b/src/routes/_libraries/db.$version.index.tsx
@@ -62,8 +62,9 @@ export default function DBVersionIndex() {
             and&nbsp;blazing fast 🔥
           </p>
           <Link
-            to="/$libraryId/$version/docs"
-            params={{ libraryId: library.id, version }}
+            from={'/$libraryId/$version'}
+            params={{ libraryId: library.id }}
+            to={'./docs'}
             className={`py-2 px-4 bg-orange-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started &raquo;
@@ -188,8 +189,9 @@ export default function DBVersionIndex() {
           </div>
           <div>
             <Link
-              to="/$libraryId/$version/docs"
-              params={{ libraryId: library.id, version }}
+              from={'/$libraryId/$version'}
+              params={{ libraryId: library.id }}
+              to={'./docs'}
               className={`inline-block py-2 px-4 bg-stone-700 rounded text-white uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/db.$version.index.tsx
+++ b/src/routes/_libraries/db.$version.index.tsx
@@ -67,7 +67,7 @@ export default function DBVersionIndex() {
             to={'./docs'}
             className={`py-2 px-4 bg-orange-500 rounded text-white uppercase font-extrabold`}
           >
-            Get Started &raquo;
+            Get Started
           </Link>
         </div>
         <LibraryFeatureHighlights
@@ -192,7 +192,7 @@ export default function DBVersionIndex() {
               from={'/$libraryId/$version'}
               params={{ libraryId: library.id }}
               to={'./docs'}
-              className={`inline-block py-2 px-4 bg-stone-700 rounded text-white uppercase font-extrabold`}
+              className={`py-2 px-4 bg-orange-500 rounded text-white uppercase font-extrabold`}
             >
               Get Started!
             </Link>

--- a/src/routes/_libraries/devtools.$version.index.tsx
+++ b/src/routes/_libraries/devtools.$version.index.tsx
@@ -71,7 +71,9 @@ export default function DevtoolsVersionIndex() {
             designed to work with any framework.
           </p>
           <Link
-            to="./docs/"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`py-2 px-4 bg-slate-500 hover:bg-slate-600 text-white rounded uppercase font-extrabold transition-colors`}
           >
             Get Started
@@ -161,7 +163,9 @@ export default function DevtoolsVersionIndex() {
           </div>
           <div>
             <Link
-              to="./docs/"
+              from="/$libraryId/$version"
+              to="./docs"
+              params={{ libraryId: library.id }}
               className={`inline-block py-2 px-4 bg-slate-500 hover:bg-slate-600 text-white rounded uppercase font-extrabold transition-colors`}
             >
               Get Started!

--- a/src/routes/_libraries/form.$version.index.tsx
+++ b/src/routes/_libraries/form.$version.index.tsx
@@ -75,8 +75,9 @@ export default function FormVersionIndex() {
             you need to build forms fast with peace of mind.
           </p>
           <Link
-            to="/$libraryId/$version/docs"
-            params={{ libraryId: library.id, version }}
+            from={'/$libraryId/$version'}
+            params={{ libraryId: library.id }}
+            to={'./docs'}
             className={`py-2 px-4 bg-yellow-400 text-black rounded uppercase font-extrabold`}
           >
             Get Started
@@ -230,8 +231,9 @@ export default function FormVersionIndex() {
           </div>
           <div>
             <Link
-              to="/$libraryId/$version/docs"
-              params={{ libraryId: library.id, version }}
+              from={'/$libraryId/$version'}
+              params={{ libraryId: library.id }}
+              to={'./docs'}
               className={`inline-block py-2 px-4 bg-yellow-500 rounded text-black uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/maintainers.tsx
+++ b/src/routes/_libraries/maintainers.tsx
@@ -40,6 +40,7 @@ const librarySchema = z.enum([
   'config',
   'react-charts',
   'create-tsrouter-app',
+  'devtools',
 ])
 
 const viewModeSchema = z.enum(['compact', 'full', 'row'])

--- a/src/routes/_libraries/pacer.$version.index.tsx
+++ b/src/routes/_libraries/pacer.$version.index.tsx
@@ -216,7 +216,7 @@ export default function PacerVersionIndex() {
               from={'/$libraryId/$version'}
               params={{ libraryId: library.id }}
               to={'./docs'}
-              className={`inline-block py-2 px-4 bg-stone-700 rounded text-white uppercase font-extrabold`}
+              className={`py-2 px-4 bg-lime-600 hover:bg-lime-700 text-white rounded uppercase font-extrabold transition-colors`}
             >
               Get Started!
             </Link>

--- a/src/routes/_libraries/pacer.$version.index.tsx
+++ b/src/routes/_libraries/pacer.$version.index.tsx
@@ -78,8 +78,9 @@ export default function PacerVersionIndex() {
             for reactive state management.
           </p>
           <Link
-            to="/$libraryId/$version/docs"
-            params={{ libraryId: library.id, version }}
+            from={'/$libraryId/$version'}
+            params={{ libraryId: library.id }}
+            to={'./docs'}
             className={`py-2 px-4 bg-lime-600 hover:bg-lime-700 text-white rounded uppercase font-extrabold transition-colors`}
           >
             Get Started
@@ -212,8 +213,9 @@ export default function PacerVersionIndex() {
           </div>
           <div>
             <Link
-              to="/$libraryId/$version/docs"
-              params={{ libraryId: library.id, version }}
+              from={'/$libraryId/$version'}
+              params={{ libraryId: library.id }}
+              to={'./docs'}
               className={`inline-block py-2 px-4 bg-stone-700 rounded text-white uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/query.$version.index.tsx
+++ b/src/routes/_libraries/query.$version.index.tsx
@@ -78,7 +78,9 @@ export default function VersionIndex() {
             </p>
             <div className="space-y-4">
               <Link
-                to="./docs/"
+                from={'/$libraryId/$version'}
+                params={{ libraryId: library.id }}
+                to={'./docs'}
                 className={`py-2 px-4 bg-red-500 rounded text-white uppercase font-extrabold`}
               >
                 Read the Docs
@@ -339,7 +341,9 @@ export default function VersionIndex() {
             </div>
             <div>
               <Link
-                to="./docs/"
+                from={'/$libraryId/$version'}
+                params={{ libraryId: library.id }}
+                to={'./docs'}
                 className={`inline-block py-2 px-4 bg-red-500 rounded text-white uppercase font-extrabold`}
               >
                 Read the Docs!

--- a/src/routes/_libraries/ranger.$version.index.tsx
+++ b/src/routes/_libraries/ranger.$version.index.tsx
@@ -66,7 +66,9 @@ export default function VersionIndex() {
             React.
           </p>
           <Link
-            to="./docs/overview"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`py-2 px-4 bg-pink-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started
@@ -153,7 +155,9 @@ export default function VersionIndex() {
           </div>
           <div>
             <Link
-              to="./docs/overview"
+              from="/$libraryId/$version"
+              to="./docs"
+              params={{ libraryId: library.id }}
               className={`inline-block py-2 px-4 bg-pink-500 rounded text-white uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/route.tsx
+++ b/src/routes/_libraries/route.tsx
@@ -275,7 +275,7 @@ function LibrariesLayout() {
         <div className="flex items-center gap-3 px-2 py-1 rounded-lg">
           <UserButton />
           <Link
-            to="/account"
+            to="/account/$"
             className="flex-1 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
           >
             My Account

--- a/src/routes/_libraries/router.$version.index.tsx
+++ b/src/routes/_libraries/router.$version.index.tsx
@@ -65,7 +65,9 @@ function RouterVersionIndex() {
           revalidate caching and first-class search-param APIs.
         </p>
         <Link
-          to="./docs/framework/react/overview"
+          from="/$libraryId/$version"
+          to="./docs"
+          params={{ libraryId: library.id }}
           className={`py-2 px-4 bg-emerald-500 rounded text-white uppercase font-extrabold`}
         >
           Get Started
@@ -263,7 +265,9 @@ function RouterVersionIndex() {
         </div>
         <div>
           <Link
-            to="./docs/framework/react/overview"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`inline-block py-2 px-4 bg-emerald-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started!

--- a/src/routes/_libraries/start.$version.index.tsx
+++ b/src/routes/_libraries/start.$version.index.tsx
@@ -84,13 +84,21 @@ export default function VersionIndex() {
         </p>
         <div className="flex justify-center gap-4 flex-wrap">
           <Link
-            to="./docs/framework/react/quick-start#impatient"
+            from={'/$libraryId/$version'}
+            to={'./docs/framework/$framework/$'}
+            params={{
+              libraryId: library.id,
+              framework: 'react',
+              _splat: 'quick-start#impatient',
+            }}
             className={`py-2 px-4 bg-transparent text-cyan-600 dark:text-cyan-400 border-2 border-cyan-500 dark:border-cyan-600 rounded uppercase font-extrabold`}
           >
             Try it in 60 seconds
           </Link>
           <Link
-            to="./docs/framework/react/overview"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`py-2 px-4 bg-cyan-500 dark:bg-cyan-600 rounded text-white uppercase font-extrabold flex items-center`}
           >
             Get Started
@@ -114,13 +122,21 @@ export default function VersionIndex() {
         </div>
         <div className="grid items-center gap-2 justify-center grid-cols-1 sm:grid-cols-2 w-[600px] max-w-full mx-auto">
           <Link
-            to="/start/latest/docs/framework/react/examples/start-basic"
+            from={'/$libraryId/$version'}
+            to="./docs/framework/$framework/examples/$"
+            params={{
+              libraryId: library.id,
+              framework: 'react',
+              _splat: 'start-basic',
+            }}
             className="flex items-center gap-2 py-2 px-4 bg-cyan-900 rounded text-white uppercase font-extrabold"
           >
             <VscPreview className="min-w-4" /> See an Example
           </Link>
           <Link
-            to="/start/latest/docs/framework/react/overview"
+            from={'/$libraryId/$version'}
+            to="./docs"
+            params={{ libraryId: library.id }}
             className="flex items-center gap-2 py-2 px-4 bg-cyan-800 rounded text-white uppercase font-extrabold"
           >
             <FaBook className="min-w-4" /> Try the BETA
@@ -452,7 +468,9 @@ export default function VersionIndex() {
         </div>
         <div>
           <Link
-            to="/start/latest/docs/framework/react/overview"
+            from="/$libraryId/$version"
+            to={'./docs'}
+            params={{ libraryId: library.id }}
             className={`inline-block py-2 px-4 bg-cyan-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started!

--- a/src/routes/_libraries/start.$version.index.tsx
+++ b/src/routes/_libraries/start.$version.index.tsx
@@ -89,8 +89,9 @@ export default function VersionIndex() {
             params={{
               libraryId: library.id,
               framework: 'react',
-              _splat: 'quick-start#impatient',
+              _splat: 'quick-start',
             }}
+            hash={'impatient'}
             className={`py-2 px-4 bg-transparent text-cyan-600 dark:text-cyan-400 border-2 border-cyan-500 dark:border-cyan-600 rounded uppercase font-extrabold`}
           >
             Try it in 60 seconds

--- a/src/routes/_libraries/store.$version.index.tsx
+++ b/src/routes/_libraries/store.$version.index.tsx
@@ -64,7 +64,9 @@ export default function StoreVersionIndex() {
             Store.
           </p>
           <Link
-            to="./docs/"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`py-2 px-4 bg-stone-600 text-white rounded uppercase font-extrabold`}
           >
             Get Started
@@ -194,7 +196,9 @@ export default function StoreVersionIndex() {
           </div>
           <div>
             <Link
-              to="./docs/"
+              from="/$libraryId/$version"
+              to="./docs"
+              params={{ libraryId: library.id }}
               className={`inline-block py-2 px-4 bg-stone-700 rounded text-white uppercase font-extrabold`}
             >
               Get Started!

--- a/src/routes/_libraries/table.$version.index.tsx
+++ b/src/routes/_libraries/table.$version.index.tsx
@@ -71,7 +71,9 @@ export default function TableVersionIndex() {
           markup and styles.
         </p>
         <Link
-          to="./docs/introduction/"
+          from={'/$libraryId/$version'}
+          to={'./docs'}
+          params={{ libraryId: library.id }}
           className={`py-2 px-4 bg-blue-500 rounded text-white uppercase font-extrabold`}
         >
           Get Started
@@ -308,12 +310,9 @@ export default function TableVersionIndex() {
         </div>
         <div>
           <Link
-            to="/$libraryId/$version/docs/$"
-            params={{
-              libraryId: 'table',
-              version,
-              _splat: 'introduction',
-            }}
+            from={'/$libraryId/$version'}
+            to={'./docs/$'}
+            params={{ libraryId: library.id }}
             className={`inline-block py-2 px-4 bg-teal-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started!

--- a/src/routes/_libraries/virtual.$version.index.tsx
+++ b/src/routes/_libraries/virtual.$version.index.tsx
@@ -69,7 +69,9 @@ export default function RouteComp() {
           while retaining 100% control over markup and styles.
         </p>
         <Link
-          to="./docs/introduction"
+          from="/$libraryId/$version"
+          to="./docs"
+          params={{ libraryId: library.id }}
           className={`py-2 px-4 bg-purple-500 rounded text-white uppercase font-extrabold`}
         >
           Get Started
@@ -276,7 +278,9 @@ export default function RouteComp() {
         </div>
         <div>
           <Link
-            to="./docs/introduction"
+            from="/$libraryId/$version"
+            to="./docs"
+            params={{ libraryId: library.id }}
             className={`inline-block py-2 px-4 bg-purple-500 rounded text-white uppercase font-extrabold`}
           >
             Get Started!


### PR DESCRIPTION
All the "get started" links are plain strings, not really typesafe in a tanstack style. This PR addresses it.

Also relative navigation does not infers the `libraryId` on pages where the param is defined, this might be material for an issue on Router though.

---

There are 101 typescript errors and 56 eslint warnings in the repo, I might take on this crusade step by step and get rid of them.