### PR TITLE
Reorder partners list

### DIFF
--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -631,11 +631,11 @@ export const partners: Partner[] = [
   netlify,
   neon,
   convex,
+  electric,
   sentry,
   unkey,
   uiDev,
   nozzle,
-  electric,
   vercel,
   speakeasy,
 ] as any


### PR DESCRIPTION
Reorder `electric` in the partners list to be after `convex` and before `sentry`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f680804-441c-4019-92ce-95a2a6822207">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f680804-441c-4019-92ce-95a2a6822207">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

