### PR TITLE
Adjust electrics logo size to match partners

### DIFF
--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -548,24 +548,20 @@ const electric = (() => {
     libraries: ['db'] as const,
     sidebarImgLight: electricLightSvg,
     sidebarImgDark: electricDarkSvg,
-    sidebarImgClass: 'py-4 scale-[1]',
+    sidebarImgClass: 'py-4 scale-[1.1]',
     status: 'active' as const,
     href,
     homepageImg: (
       <div className="w-full h-full flex items-center justify-center px-4 py-6">
         <img
           src={electricLightSvg}
-          alt="Unkey"
-          className="w-[180px] max-w-full dark:hidden"
-          width="180"
-          height="77"
+          alt="Electric"
+          className="w-[240px] max-w-full dark:hidden"
         />
         <img
           src={electricDarkSvg}
-          alt="Unkey"
-          className="w-[180px] max-w-full hidden dark:block"
-          width="180"
-          height="77"
+          alt="Electric"
+          className="w-[240px] max-w-full hidden dark:block"
         />
       </div>
     ),


### PR DESCRIPTION
Adjust Electric's logo size and alt text to match other partners.

---
<a href="https://cursor.com/background-agent?bcId=bc-697c8059-007b-4597-a0b5-d5b3230ecdd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-697c8059-007b-4597-a0b5-d5b3230ecdd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

