### PR TITLE
fix: load selected path on code explorer

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -104,10 +104,10 @@ export function CodeBlock({
 
   const [codeElement, setCodeElement] = React.useState(
     <>
-      <pre ref={ref} className={`shiki github-light`}>
+      <pre ref={ref} className={`shiki github-light h-full`}>
         <code>{code}</code>
       </pre>
-      <pre className={`shiki tokyo-night bg-gray-900 text-gray-400`}>
+      <pre className={`shiki tokyo-night h-full bg-gray-900 text-gray-400`}>
         <code>{code}</code>
       </pre>
     </>


### PR DESCRIPTION
## Before

The example page loads the repo default file in SSR, then the client looks for a `path` search param to load the specified page (if defined).
Navigating to an url with a specified path leads to an empty small div being shown while the `path` file is loaded client side (look in network tab for `fetchFile_createServerFn`)
Example: https://tanstack.com/start/latest/docs/framework/react/examples/start-basic?path=examples%2Freact%2Fstart-basic%2Fsrc%2Froutes%2Fposts.%24postId.tsx

## After

The `path` search param is read directly into the loader, hence the right file is loaded during SSR and delivered immediately to the client. No client fetch required.
If no `path` is specified, falls back to the usual behaviour.

## Video


https://github.com/user-attachments/assets/6f5f6577-2d34-4430-8cef-39936b551850

---

Note: Moving `head` below `loader` also fixed `Route.useLoaderData()` types