### PR TITLE
fix: counters in the homepage no longer disappear on first load

### DIFF
--- a/src/routes/_libraries/index.tsx
+++ b/src/routes/_libraries/index.tsx
@@ -1,4 +1,6 @@
 import { Await, Link, MatchRoute, getRouteApi } from '@tanstack/react-router'
+import { convexQuery } from '@convex-dev/react-query'
+import { api } from 'convex/_generated/api'
 import { twMerge } from 'tailwind-merge'
 import { CgSpinner } from 'react-icons/cg'
 import { Footer } from '~/components/Footer'
@@ -39,7 +41,20 @@ const courses = [
 ]
 
 export const Route = createFileRoute({
-  loader: () => {
+  loader: async ({ context: { queryClient } }) => {
+    const githubQuery = queryClient.ensureQueryData(
+      convexQuery(api.stats.getGithubOwner, {
+        owner: 'tanstack',
+      })
+    )
+    const npmQuery = queryClient.ensureQueryData(
+      convexQuery(api.stats.getNpmOrg, {
+        name: 'tanstack',
+      })
+    )
+
+    await Promise.all([githubQuery, npmQuery])
+
     return {
       randomNumber: Math.random(),
     }


### PR DESCRIPTION
We still have the counters in the homepage disappearing for a second right after the first load. No errors are thrown but the component still suspends and our fallback is an empty component.

Preloading the data will prevent the component from suspending right after mount.

While waiting for the current behaviour to be fixed upstream (see https://github.com/erquhart/convex-oss-stats/issues/7 and https://github.com/get-convex/convex-react-query/issues/22) this could be a nice temporary fix