### PR TITLE
Fix mobile overflow in DB overview page

### DIFF
--- a/src/routes/_libraries/db.$version.index.tsx
+++ b/src/routes/_libraries/db.$version.index.tsx
@@ -50,7 +50,7 @@ export default function DBVersionIndex() {
             <h3 className="text-3xl text-center mx-auto leading-tight font-extrabold tracking-tight sm:text-4xl lg:leading-none mt-2">
               Blazing fast apps 🔥
             </h3>
-            <p className="mt-6 text-xl w-3xl mx-auto leading-7 opacity-75 max-w-[500px] lg:max-w-[800px]">
+            <p className="mt-6 text-xl w-full md:w-3xl mx-auto leading-7 opacity-75 max-w-[500px] lg:max-w-[800px]">
               Built on a{' '}
               <a
                 href="https://github.com/electric-sql/d2ts"
@@ -64,7 +64,7 @@ export default function DBVersionIndex() {
               apps.
             </p>
           </div>
-          <div className="grid grid-flow-row grid-cols-2 gap-x-10 lg:gap-x-12 gap-y-4 mx-auto max-w-[500px] lg:max-w-[650px]">
+          <div className="grid grid-flow-row grid-cols-2 gap-x-8 md:gap-x-10 lg:gap-x-12 gap-y-4 mx-auto max-w-[500px] lg:max-w-[650px]">
             <div>
               <h4 className="text-xl my-2">🔥 Blazing fast query engine</h4>
               <p>For sub-millisecond live queries.</p>
@@ -85,7 +85,7 @@ export default function DBVersionIndex() {
         </div>
         <PartnersSection
           libraryId="db"
-          gridClassName="w-[500px] max-w-full mx-auto"
+          gridClassName="md:w-[500px] max-w-full mx-auto"
         />
         <div className="h-8" />
         <PartnershipCallout libraryName="DB" />


### PR DESCRIPTION
This PR adds a simple fix to prevent mobile overflow in the DB overview page using full widths instead of fixed widths.
This was tested in Chrome with iPhone 12 Pro screen (390px)

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/a02e5178-7e88-4c7f-b46c-d4fac5a6a5e1" alt="Before 1" width="300"/> | <img src="https://github.com/user-attachments/assets/29ac94eb-c217-4045-95d6-45b8f571a8cc" alt="After 1" width="300"/> |
| <img src="https://github.com/user-attachments/assets/3905bbb8-ff40-48c3-ba60-089a52268582" alt="Before 2" width="300"/> | <img src="https://github.com/user-attachments/assets/64f62d50-131f-4325-ba32-e602dc78d309" alt="After 2" width="300"/> |
