### PR TITLE
chore: github action to auto update tanstack dependencies

### DIFF
--- a/.github/workflows/update-tanstack-deps.yaml
+++ b/.github/workflows/update-tanstack-deps.yaml
@@ -1,0 +1,61 @@
+name: Update TanStack Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run weekly on Sundays at 10:00 AM UTC
+    - cron: '0 10 * * 0'
+
+jobs:
+  update-deps:
+    name: Update TanStack Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install Packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Update TanStack Dependencies
+        run: pnpm up "@tanstack/*" --latest
+
+      - name: Check for Changes
+        id: git-check
+        run: |
+          git status --porcelain .
+          if [[ -z $(git status --porcelain .) ]]; then
+            echo "No changes detected"
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected"
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Lint
+        if: steps.git-check.outputs.changes == 'true'
+        run: pnpm lint
+
+      - name: Run Build
+        if: steps.git-check.outputs.changes == 'true'
+        run: pnpm build
+
+      - name: Commit and Push Changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "chore: update @tanstack/* dependencies"
+          git push


### PR DESCRIPTION
Fixes https://github.com/TanStack/tanstack.com/issues/472

This PR was 100% AI generated by Claude Sonnet 4, based on the following prompt:

We need a github action workflow that updates `@tanstack/*` libraries
- easy to run
  - on `workflow_dispatch`
  - on `cron` schedule
- checkout this repo
- install `pnpm`
- run `pnpm up "@tanstack/*" --latest`
- if the `git status --porcelain .` is clean, stop here
- install node
- run pnpm lint
- run pnpm build
- if everything passes commit changes to main