### PR TITLE
fix(ui): resolve mobile responsive issue with overflowing container on the homepage

### DIFF
--- a/src/components/LandingPageGad.tsx
+++ b/src/components/LandingPageGad.tsx
@@ -11,7 +11,7 @@ export default function LandingPageGad() {
             <GamFooter />
             <div
               className="text-xs bg-gray-500 bg-opacity-10 py-2 px-4 rounded text-gray-600 dark:text-gray-300
-                dark:bg-opacity-20 self-center text-center w-[500px] max-w-full space-y-2"
+                dark:bg-opacity-20 self-center text-center max-w-[500px] space-y-2"
             >
               <div>
                 <span className="font-medium italic">


### PR DESCRIPTION
## Problem
A container element on the homepage was breaking the responsive layout on mobile views (width < 768px). Its `width` property was causing it to extend beyond the viewport, creating a horizontal scrollbar and degrading the user experience.

## Solution
- I have used `max-w-[500px]` instead of `w-[500px] max-w-full`

## Impact
This fix restores the intended responsive design on all mobile devices, ensuring a seamless and scrollbar-free experience for users.

Before:

<img width="493" height="878" alt="Screenshot_20250822_225435" src="https://github.com/user-attachments/assets/22d9cc12-74dd-43dd-ae3e-d69cce42940d" />


After:

<img width="489" height="887" alt="Screenshot_20250822_225855" src="https://github.com/user-attachments/assets/e16a9c11-1c9c-43e5-a09d-885d9bc6549f" />


