### PR TITLE
Refactor ad disable preference storage

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -31,6 +31,7 @@ const schema = defineSchema({
     capabilities: v.array(
       v.union(...validCapabilities.map((cap) => v.literal(cap)))
     ),
+    adsDisabled: v.optional(v.boolean()),
   }),
 })
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -81,22 +81,6 @@ async function requireCapability(ctx: QueryCtx, capability: Capability) {
   return { currentUser }
 }
 
-// Get current user's ad preference
-export const getUserAdPreference = query({
-  args: {},
-  handler: async (ctx) => {
-    const currentUser = await getCurrentUserConvex(ctx)
-    if (!currentUser) {
-      throw new Error('Not authenticated')
-    }
-
-    return {
-      adsDisabled: currentUser.adsDisabled ?? false,
-      canDisableAds: currentUser.capabilities.includes('disableAds'),
-    }
-  },
-})
-
 // Toggle ad preference (only for users with disableAds capability)
 export const toggleAdPreference = mutation({
   args: {},

--- a/src/hooks/useAdPreference.ts
+++ b/src/hooks/useAdPreference.ts
@@ -1,0 +1,57 @@
+import { convexQuery, useConvexMutation } from '@convex-dev/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from 'convex/_generated/api'
+
+export function useAdPreferenceQuery() {
+  return useQuery(convexQuery(api.users.getUserAdPreference, {}))
+}
+
+export function useToggleAdPreference() {
+  const queryClient = useQueryClient()
+  
+  return useConvexMutation(api.users.toggleAdPreference, {
+    onSuccess: () => {
+      // Invalidate and refetch ad preference query
+      queryClient.invalidateQueries({
+        queryKey: ['convex', api.users.getUserAdPreference, {}],
+      })
+      // Also invalidate current user query since it might contain ad preferences
+      queryClient.invalidateQueries({
+        queryKey: ['convex', api.auth.getCurrentUser, {}],
+      })
+    },
+  })
+}
+
+export function useSetAdPreference() {
+  const queryClient = useQueryClient()
+  
+  return useConvexMutation(api.users.setAdPreference, {
+    onSuccess: () => {
+      // Invalidate and refetch ad preference query
+      queryClient.invalidateQueries({
+        queryKey: ['convex', api.users.getUserAdPreference, {}],
+      })
+      // Also invalidate current user query
+      queryClient.invalidateQueries({
+        queryKey: ['convex', api.auth.getCurrentUser, {}],
+      })
+    },
+  })
+}
+
+// Legacy hook for backward compatibility - replace the useAdsPreference function
+export function useAdsPreference() {
+  const adPreferenceQuery = useAdPreferenceQuery()
+  
+  if (adPreferenceQuery.isLoading || !adPreferenceQuery.data) {
+    return { adsEnabled: true } // Default to showing ads while loading
+  }
+  
+  const { adsDisabled, canDisableAds } = adPreferenceQuery.data
+  
+  // Ads are enabled if user can't disable them OR if they haven't disabled them
+  const adsEnabled = !canDisableAds || !adsDisabled
+  
+  return { adsEnabled }
+}

--- a/src/hooks/useAdPreference.ts
+++ b/src/hooks/useAdPreference.ts
@@ -1,21 +1,14 @@
-import { convexQuery, useConvexMutation } from '@convex-dev/react-query'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useConvexMutation } from '@convex-dev/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { api } from 'convex/_generated/api'
-
-export function useAdPreferenceQuery() {
-  return useQuery(convexQuery(api.users.getUserAdPreference, {}))
-}
+import { useCurrentUserQuery } from './useCurrentUser'
 
 export function useToggleAdPreference() {
   const queryClient = useQueryClient()
   
   return useConvexMutation(api.users.toggleAdPreference, {
     onSuccess: () => {
-      // Invalidate and refetch ad preference query
-      queryClient.invalidateQueries({
-        queryKey: ['convex', api.users.getUserAdPreference, {}],
-      })
-      // Also invalidate current user query since it might contain ad preferences
+      // Invalidate current user query to refresh the ad preference
       queryClient.invalidateQueries({
         queryKey: ['convex', api.auth.getCurrentUser, {}],
       })
@@ -28,11 +21,7 @@ export function useSetAdPreference() {
   
   return useConvexMutation(api.users.setAdPreference, {
     onSuccess: () => {
-      // Invalidate and refetch ad preference query
-      queryClient.invalidateQueries({
-        queryKey: ['convex', api.users.getUserAdPreference, {}],
-      })
-      // Also invalidate current user query
+      // Invalidate current user query to refresh the ad preference
       queryClient.invalidateQueries({
         queryKey: ['convex', api.auth.getCurrentUser, {}],
       })
@@ -40,15 +29,17 @@ export function useSetAdPreference() {
   })
 }
 
-// Legacy hook for backward compatibility - replace the useAdsPreference function
+// Legacy hook for backward compatibility - now uses current user query
 export function useAdsPreference() {
-  const adPreferenceQuery = useAdPreferenceQuery()
+  const userQuery = useCurrentUserQuery()
   
-  if (adPreferenceQuery.isLoading || !adPreferenceQuery.data) {
-    return { adsEnabled: true } // Default to showing ads while loading
+  if (userQuery.isLoading || !userQuery.data) {
+    return { adsEnabled: true } // Default to showing ads while loading or not authenticated
   }
   
-  const { adsDisabled, canDisableAds } = adPreferenceQuery.data
+  const user = userQuery.data
+  const adsDisabled = user.adsDisabled ?? false
+  const canDisableAds = user.capabilities.includes('disableAds')
   
   // Ads are enabled if user can't disable them OR if they haven't disabled them
   const adsEnabled = !canDisableAds || !adsDisabled

--- a/src/hooks/useAdPreference.ts
+++ b/src/hooks/useAdPreference.ts
@@ -1,48 +1,19 @@
-import { useConvexMutation } from '@convex-dev/react-query'
-import { useQueryClient } from '@tanstack/react-query'
-import { api } from 'convex/_generated/api'
 import { useCurrentUserQuery } from './useCurrentUser'
-
-export function useToggleAdPreference() {
-  const queryClient = useQueryClient()
-  
-  return useConvexMutation(api.users.toggleAdPreference, {
-    onSuccess: () => {
-      // Invalidate current user query to refresh the ad preference
-      queryClient.invalidateQueries({
-        queryKey: ['convex', api.auth.getCurrentUser, {}],
-      })
-    },
-  })
-}
-
-export function useSetAdPreference() {
-  const queryClient = useQueryClient()
-  
-  return useConvexMutation(api.users.setAdPreference, {
-    onSuccess: () => {
-      // Invalidate current user query to refresh the ad preference
-      queryClient.invalidateQueries({
-        queryKey: ['convex', api.auth.getCurrentUser, {}],
-      })
-    },
-  })
-}
 
 // Legacy hook for backward compatibility - now uses current user query
 export function useAdsPreference() {
   const userQuery = useCurrentUserQuery()
-  
+
   if (userQuery.isLoading || !userQuery.data) {
     return { adsEnabled: true } // Default to showing ads while loading or not authenticated
   }
-  
+
   const user = userQuery.data
   const adsDisabled = user.adsDisabled ?? false
   const canDisableAds = user.capabilities.includes('disableAds')
-  
+
   // Ads are enabled if user can't disable them OR if they haven't disabled them
   const adsEnabled = !canDisableAds || !adsDisabled
-  
+
   return { adsEnabled }
 }

--- a/src/routes/_libraries/account.tsx
+++ b/src/routes/_libraries/account.tsx
@@ -1,4 +1,4 @@
-import { useUserSettingsStore } from '~/stores/userSettings'
+import { useAdPreferenceQuery, useToggleAdPreference } from '~/hooks/useAdPreference'
 import { FaSignOutAlt } from 'react-icons/fa'
 import { Authenticated, Unauthenticated } from 'convex/react'
 import { Link, redirect } from '@tanstack/react-router'
@@ -11,10 +11,17 @@ export const Route = createFileRoute({
 
 function UserSettings() {
   const userQuery = useCurrentUserQuery()
-  const adsDisabled = useUserSettingsStore((s) => s.settings.adsDisabled)
-  const toggleAds = useUserSettingsStore((s) => s.toggleAds)
-
-  const canDisableAds = userQuery.data?.capabilities.includes('disableAds')
+  // Replace local storage-based state with Convex-based queries
+  const adPreferenceQuery = useAdPreferenceQuery()
+  const toggleAdPreferenceMutation = useToggleAdPreference()
+  
+  // Get values from the new queries
+  const adsDisabled = adPreferenceQuery.data?.adsDisabled ?? false
+  const canDisableAds = adPreferenceQuery.data?.canDisableAds ?? false
+  
+  const handleToggleAds = () => {
+    toggleAdPreferenceMutation.mutate()
+  }
 
   const signOut = async () => {
     await authClient.signOut()
@@ -53,8 +60,8 @@ function UserSettings() {
                     type="checkbox"
                     className="h-4 w-4 accent-blue-600 my-1"
                     checked={adsDisabled}
-                    onChange={toggleAds}
-                    disabled={userQuery.isLoading}
+                    onChange={handleToggleAds}
+                    disabled={adPreferenceQuery.isLoading || toggleAdPreferenceMutation.isPending}
                     aria-label="Disable Ads"
                   />
                   <div>

--- a/src/routes/_libraries/account.tsx
+++ b/src/routes/_libraries/account.tsx
@@ -1,4 +1,4 @@
-import { useAdPreferenceQuery, useToggleAdPreference } from '~/hooks/useAdPreference'
+import { useToggleAdPreference } from '~/hooks/useAdPreference'
 import { FaSignOutAlt } from 'react-icons/fa'
 import { Authenticated, Unauthenticated } from 'convex/react'
 import { Link, redirect } from '@tanstack/react-router'
@@ -11,13 +11,12 @@ export const Route = createFileRoute({
 
 function UserSettings() {
   const userQuery = useCurrentUserQuery()
-  // Replace local storage-based state with Convex-based queries
-  const adPreferenceQuery = useAdPreferenceQuery()
+  // Use current user query directly instead of separate ad preference query
   const toggleAdPreferenceMutation = useToggleAdPreference()
   
-  // Get values from the new queries
-  const adsDisabled = adPreferenceQuery.data?.adsDisabled ?? false
-  const canDisableAds = adPreferenceQuery.data?.canDisableAds ?? false
+  // Get values directly from the current user data
+  const adsDisabled = userQuery.data?.adsDisabled ?? false
+  const canDisableAds = userQuery.data?.capabilities.includes('disableAds') ?? false
   
   const handleToggleAds = () => {
     toggleAdPreferenceMutation.mutate()
@@ -61,7 +60,7 @@ function UserSettings() {
                     className="h-4 w-4 accent-blue-600 my-1"
                     checked={adsDisabled}
                     onChange={handleToggleAds}
-                    disabled={adPreferenceQuery.isLoading || toggleAdPreferenceMutation.isPending}
+                    disabled={userQuery.isLoading || toggleAdPreferenceMutation.isPending}
                     aria-label="Disable Ads"
                   />
                   <div>

--- a/src/stores/userSettings.ts
+++ b/src/stores/userSettings.ts
@@ -1,55 +1,32 @@
 import { create } from 'zustand'
-import { persist, createJSONStorage } from 'zustand/middleware'
-import { useCurrentUserQuery } from '~/hooks/useCurrentUser'
+// Remove persist and createJSONStorage imports since we no longer use localStorage
+// import { persist, createJSONStorage } from 'zustand/middleware'
+// Remove the useCurrentUserQuery import since we'll use the new hook
+// import { useCurrentUserQuery } from '~/hooks/useCurrentUser'
+
+// Update the export to use the new hook
+export { useAdsPreference } from '~/hooks/useAdPreference'
 
 export type UserSettings = {
-  adsDisabled: boolean
+  // Remove adsDisabled since it's now handled by Convex
+  // Other settings can be added here in the future
 }
 
 type UserSettingsState = {
   settings: UserSettings
   hasHydrated: boolean
   setHasHydrated: (value: boolean) => void
-  toggleAds: () => void
+  // Remove toggleAds since it's now handled by the new hooks
 }
 
-export const useUserSettingsStore = create<UserSettingsState>()(
-  persist(
-    (set, get) => ({
-      settings: {
-        adsDisabled: false,
-      },
-      hasHydrated: false,
-      setHasHydrated: (value) => set({ hasHydrated: value }),
-      toggleAds: () =>
-        set({
-          settings: {
-            ...get().settings,
-            adsDisabled: !get().settings.adsDisabled,
-          },
-        }),
-    }),
-    {
-      name: 'user_settings_v1',
-      storage: createJSONStorage(() => localStorage),
-      onRehydrateStorage: () => (state, error) => {
-        if (!state || error) return
-        state.setHasHydrated(true)
-      },
-      partialize: (state) => ({ settings: state.settings }),
-    }
-  )
-)
+export const useUserSettingsStore = create<UserSettingsState>()((set, get) => ({
+  settings: {
+    // Remove adsDisabled initialization
+  },
+  hasHydrated: true, // No need for hydration since we're not using persistence
+  setHasHydrated: (value) => set({ hasHydrated: value }),
+  // Remove toggleAds function
+}))
 
-export function useAdsPreference() {
-  const userQuery = useCurrentUserQuery()
-  const { settings } = useUserSettingsStore((s) => ({
-    settings: s.settings,
-  }))
-
-  const adsEnabled = userQuery.data
-    ? userQuery.data.capabilities.includes('disableAds') &&
-      !settings.adsDisabled
-    : true
-  return { adsEnabled }
-}
+// Remove the persist wrapper and localStorage configuration
+// The useAdsPreference function is now exported from useAdPreference.ts


### PR DESCRIPTION
Move ad preference state from local storage to Convex user Meta object, enforcing capability-based access.

---
<a href="https://cursor.com/background-agent?bcId=bc-5979252c-bcb5-4e3a-8e05-f770f395fd5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5979252c-bcb5-4e3a-8e05-f770f395fd5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

