### PR TITLE
Stats: Add comparisons for docs frameworks

### DIFF
--- a/src/routes/stats/npm/-comparisons.ts
+++ b/src/routes/stats/npm/-comparisons.ts
@@ -403,5 +403,34 @@ export function getPopularComparisons(): z.input<
         },
       ],
     },
+    {
+      title: 'Documentation',
+      packageGroups: [
+        {
+          packages: [{ name: 'vitepress' }],
+          color: '#a8b1ff',
+        },
+        {
+          packages: [{ name: '@docusaurus/core' }],
+          color: '#21b091',
+        },
+        {
+          packages: [{ name: 'vocs' }],
+          color: '#0090ff',
+        },
+        {
+          packages: [{ name: '@astrojs/starlight' }],
+          color: '#f97316',
+        },
+        {
+          packages: [{ name: 'nextra' }],
+          color: '#00CED1',
+        },
+        {
+          packages: [{ name: 'fumadocs-core' }],
+          color: '#DA70D6',
+        },
+      ],
+    },
   ] as const
 }


### PR DESCRIPTION
This PR adds comparisons for **Documentation** (could also be Static Site Generators, but that may overlaps with "Frameworks").

Currently included: Vitepress, Docusaurus, Vocs, Astro Starlight, Nextra, and Fumadocs.

filling the last corner:

<img width="4610" height="1108" alt="image" src="https://github.com/user-attachments/assets/a07ec6cd-c2b3-44fe-9823-92a4121f77e4" />
