### PR TITLE
Upgrade to Start RC - Fix Relative Routing

### DIFF
--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -222,6 +222,7 @@ export function DocsLayout({
                   </a>
                 ) : (
                   <Link
+                    from='/$libraryId/$version/docs'
                     to={child.to}
                     params
                     onClick={() => {


### PR DESCRIPTION
based on changes merged with router 1.131.28 relative routing is always relative to current location unless a from is specified then its relative to the from. This brings this in line with the change