### PR TITLE
Fix: display correct NPM download count for TanStack Config

### DIFF
--- a/convex/stats.ts
+++ b/convex/stats.ts
@@ -29,7 +29,7 @@ export const getStats = query({
             ? args.library.frameworks.map(
                 (framework) => `@tanstack/${framework}-${args.library?.id}`
               )
-            : [`@tanstack/${args.library.id}`] // For libraries like @tanstack/config
+            : [`@tanstack/${args.library.id}`]
         )
       : await ossStats.getNpmOrg(ctx, 'tanstack')
     return {


### PR DESCRIPTION
Fix: Display correct NPM download count for TanStack Config

Previously, the NPM download count for TanStack Config was showing as NaN. This was due to the `frameworks` array being empty in `src/libraries/config.tsx`. The `getNpmPackages` function in `convex/stats.ts` was attempting to construct package names using a framework prefix (e.g., `@tanstack/{framework}-config`), which resulted in an empty list of package names when `frameworks` was empty.

This fix modifies the `getNpmPackages` logic to handle libraries like TanStack Config, which do not have framework-prefixed package names. If a library's `frameworks` array is empty, it now correctly uses `@tanstack/{library.id}` as the package name for fetching NPM download statistics.

<img width="1183" height="805" alt="image" src="https://github.com/user-attachments/assets/72f580ea-cc15-4d3b-8223-8dbb409792b4" />
