### PR TITLE
fix: add scroll-padding to accommodate for the sticky header height

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -48,7 +48,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     const updateContainerHeight = () => {
       if (containerRef.current) {
         const height = containerRef.current.offsetHeight
-        document.body.style.setProperty('--navbar-height', `${height}px`)
+        document.documentElement.style.setProperty('--navbar-height', `${height}px`)
       }
     }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -224,7 +224,7 @@ function HtmlWrapper({ children }: { children: React.ReactNode }) {
         ) : null}
         <GamScripts />
       </head>
-      <body style={{ '--navbar-height': '48px' } as any}>
+      <body>
         <ToastProvider>
           <BackgroundGradient />
           <React.Suspense fallback={null}>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -53,6 +53,11 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  :root {
+    --navbar-height: 50px;
+    scroll-padding-top: var(--navbar-height);
+  }
 }
 
 button {


### PR DESCRIPTION
Adds `scroll-padding-top` to accommodate for sticky header.

Otherwise all anchor links are scrolled too far and user would not see the header that was linked to as it's behind the header.


https://github.com/user-attachments/assets/bacb976e-1edc-4252-822b-92cb26c2074b

