### PR TITLE
fix: change doc footer from block to flex

### DIFF
--- a/src/components/Doc.tsx
+++ b/src/components/Doc.tsx
@@ -170,7 +170,7 @@ export function Doc({
           </div>
           <div className="h-12" />
           <div className="w-full h-px bg-gray-500 opacity-30" />
-          <div className="py-4 opacity-70">
+          <div className="flex py-4 opacity-70">
             <a
               href={`https://github.com/${repo}/edit/${branch}/${filePath}`}
               className="flex items-center gap-2"


### PR DESCRIPTION
fixes issue where the "edit on github" link stretches across the entire width. noticed this when i got redirected randomly to github when i was navigating the docs.

before:
<img width="639" height="272" alt="Screenshot 2025-10-04 at 21 56 45" src="https://github.com/user-attachments/assets/9a7dcf94-a91b-4c37-a795-650019a7e80a" />

after:
<img width="609" height="250" alt="Screenshot 2025-10-04 at 21 58 04" src="https://github.com/user-attachments/assets/b6f4e9cc-e83f-45e0-97b8-2e4aa85d5b81" />
