### PR TITLE
Fix: mobile responsiveness issues on TanStack DB documentation page

### DIFF
--- a/src/routes/_libraries/db.$version.index.tsx
+++ b/src/routes/_libraries/db.$version.index.tsx
@@ -56,7 +56,7 @@ export default function DBVersionIndex() {
             <h3 className="text-3xl text-center mx-auto leading-tight font-extrabold tracking-tight sm:text-4xl lg:leading-none mt-2">
               Blazing fast apps 🔥
             </h3>
-            <p className="mt-6 text-xl w-3xl mx-auto leading-7 opacity-75 max-w-[500px] lg:max-w-[800px]">
+            <p className="mt-6 text-xl mx-auto leading-7 opacity-75 max-w-[90vw] sm:max-w-[500px] lg:max-w-[800px]">
               Built on a{' '}
               <a
                 href="https://github.com/electric-sql/d2ts"
@@ -70,7 +70,7 @@ export default function DBVersionIndex() {
               apps.
             </p>
           </div>
-          <div className="grid grid-flow-row grid-cols-2 gap-x-10 lg:gap-x-12 gap-y-4 mx-auto max-w-[500px] lg:max-w-[650px]">
+          <div className="grid grid-flow-row grid-cols-1 sm:grid-cols-2 gap-x-4 sm:gap-x-10 lg:gap-x-12 gap-y-4 mx-auto max-w-[90vw] sm:max-w-[500px] lg:max-w-[650px]">
             <div>
               <h4 className="text-xl my-2">🔥 Blazing fast query engine</h4>
               <p>For sub-millisecond live queries.</p>


### PR DESCRIPTION
**Fixes #505**

This PR addresses an issue where the TanStack DB documentation layout overflowed horizontally on mobile devices.


### Problem
The TanStack DB documentation page was not responsive on mobile devices, causing horizontal overflow and unwanted scrolling on small viewports.

### Changes Made
- **Fixed paragraph width constraints**: Replaced fixed `w-3xl` class with responsive `max-w-[90vw] sm:max-w-[500px] lg:max-w-[800px]` to prevent text overflow on mobile
- **Improved grid layout**: Changed grid from `grid-cols-2` to `grid-cols-1 sm:grid-cols-2` to stack items vertically on mobile
- **Enhanced spacing**: Updated gap classes to `gap-x-4 sm:gap-x-10 lg:gap-x-12` for better mobile spacing
- **Added responsive container width**: Applied `max-w-[90vw] sm:max-w-[500px] lg:max-w-[650px]` to the grid container

### Testing
- ✅ Tested with Chrome DevTools mobile simulation
- ✅ Confirmed no horizontal scrolling on mobile viewports
- ✅ Maintained desktop layout integrity

The page now properly adapts to small viewports while preserving the existing desktop experience.