### PR TITLE
Serve markdown to LLMs via Accept header

### DIFF
--- a/src/routes/$libraryId/$version.docs.framework.$framework.$.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.$.tsx
@@ -1,31 +1,13 @@
 import { seo } from '~/utils/seo'
 import { Doc } from '~/components/Doc'
-import { loadDocs } from '~/utils/docs'
+import {
+  loadDocs,
+  prefersMarkdown,
+  createMarkdownResponse,
+} from '~/utils/docs'
 import { getBranch, getLibrary } from '~/libraries'
 import { capitalize } from '~/utils/utils'
 import { DocContainer } from '~/components/DocContainer'
-
-// Helper function to check if the Accept header prefers markdown
-function prefersMarkdown(acceptHeader: string | null): boolean {
-  if (!acceptHeader) return false
-
-  const accepts = acceptHeader.split(',').map(type => {
-    const [mediaType, ...params] = type.trim().split(';')
-    const quality = params.find(p => p.trim().startsWith('q='))
-    const q = quality ? parseFloat(quality.split('=')[1]) : 1.0
-    return { mediaType: mediaType.toLowerCase(), q }
-  })
-
-  const markdownQ = accepts.find(a =>
-    a.mediaType === 'text/markdown' || a.mediaType === 'text/plain'
-  )?.q || 0
-
-  const htmlQ = accepts.find(a =>
-    a.mediaType === 'text/html' || a.mediaType === '*/*'
-  )?.q || 0
-
-  return markdownQ > 0 && markdownQ > htmlQ
-}
 
 export const ServerRoute = createServerFileRoute().methods({
   GET: async ({ request, params }) => {
@@ -45,16 +27,7 @@ export const ServerRoute = createServerFileRoute().methods({
         redirectPath: `/${library.id}/${version}/docs/overview`,
       })
 
-      const markdownContent = `# ${doc.title}\n${doc.content}`
-
-      return new Response(markdownContent, {
-        headers: {
-          'Content-Type': 'text/markdown; charset=utf-8',
-          'Cache-Control': 'public, max-age=0, must-revalidate',
-          'Cdn-Cache-Control': 'max-age=300, stale-while-revalidate=300, durable',
-          'Vary': 'Accept',
-        },
-      })
+      return createMarkdownResponse(doc.title, doc.content)
     }
   },
 })


### PR DESCRIPTION
## Summary

This PR adds content negotiation to documentation routes to serve markdown when AI coding agents and LLMs request it via the Accept header.

Like the brother of Jared who saw things more clearly through simplicity, LLMs can process markdown much more efficiently than HTML - reducing token usage by ~10x.

## Changes

- Added `prefersMarkdown()` helper function to parse Accept headers with quality values
- Added `ServerRoute` handlers to both doc routes:
  - `$libraryId/$version.docs.$.tsx`
  - `$libraryId/$version.docs.framework.$framework.$.tsx`
- Returns raw markdown when `Accept: text/markdown` or `Accept: text/plain` is preferred over HTML
- Added `Vary: Accept` header to ensure proper caching of both formats

## How it works

When a request comes in with an Accept header like:
```
Accept: text/markdown, text/html;q=0.9
```

The server will return markdown content instead of rendering the HTML page. This allows tools like Claude Code, Cursor, and other AI agents to fetch cleaner, more parseable documentation.

## Testing

Test with:
```bash
curl -H "Accept: text/markdown" https://tanstack.com/router/latest/docs/overview
```

Should return raw markdown instead of HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)