### PR TITLE
Updated Copy Markdown component for success and fallback toast notification

### DIFF
--- a/src/components/CopyMarkdownButton.tsx
+++ b/src/components/CopyMarkdownButton.tsx
@@ -54,48 +54,52 @@ export function CopyMarkdownButton({
       const cached = cache.get(url)
 
       if (cached) {
-        navigator.clipboard.writeText(cached)
-        notify(
-          <div>
-            <div className="font-medium">Copied markdown</div>
-            <div className="text-gray-500 dark:text-gray-400 text-xs">
-              Source content copied from cache
+        navigator.clipboard.writeText(cached).then(() => {
+          notify(
+            <div>
+              <div className="font-medium">Copied markdown</div>
+              <div className="text-gray-500 dark:text-gray-400 text-xs">
+                Source content copied from cache
+              </div>
             </div>
-          </div>
-        )
+          )
+        })
       } else {
         fetch(url)
-          .then((response) => response.text())
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error('Fetch failed')
+            }
+            return response.text()
+          })
           .then((content) => {
             cache.set(url, content)
-            return navigator.clipboard.writeText(content)
-          })
-          .then(() => {
-            notify(
-              <div>
-                <div className="font-medium">Copied markdown</div>
-                <div className="text-gray-500 dark:text-gray-400 text-xs">
-                  Source content copied from GitHub
+            return navigator.clipboard.writeText(content).then(() => {
+              notify(
+                <div>
+                  <div className="font-medium">Copied markdown</div>
+                  <div className="text-gray-500 dark:text-gray-400 text-xs">
+                    Source content copied from GitHub
+                  </div>
                 </div>
-              </div>
-            )
+              )
+            })
           })
           .catch(() => {
             // fallback: try to copy current page content if available
             const pageContent =
               document.querySelector('.styled-markdown-content')?.textContent ||
               ''
-            return navigator.clipboard.writeText(pageContent)
-          })
-          .then(() => {
-            notify(
-              <div>
-                <div className="font-medium">Copied markdown</div>
-                <div className="text-gray-500 dark:text-gray-400 text-xs">
-                  Fallback: copied rendered page content
+            navigator.clipboard.writeText(pageContent).then(() => {
+              notify(
+                <div>
+                  <div className="font-medium">Copied markdown</div>
+                  <div className="text-gray-500 dark:text-gray-400 text-xs">
+                    Fallback: copied rendered page content
+                  </div>
                 </div>
-              </div>
-            )
+              )
+            })
           })
       }
     })


### PR DESCRIPTION
This will fix this [issue](https://github.com/TanStack/tanstack.com/issues/514).

To fix this, I've separated the success and fallback logic more clearly, ensuring the fallback toast only triggers when the fetch fails and the fallback content is actually copied.

<img width="1440" height="826" alt="Screenshot 2025-10-21 at 6 45 29 PM" src="https://github.com/user-attachments/assets/91bac328-2a71-4224-8839-e62a576a200c" />
