### PR TITLE
fix: showing NaN for Npm Downloads in the tanstack/config page

### DIFF
--- a/src/components/OpenSourceStats.tsx
+++ b/src/components/OpenSourceStats.tsx
@@ -58,7 +58,8 @@ const NpmDownloadCounter = ({
   npmData: Parameters<typeof useNpmDownloadCounter>[0]
 }) => {
   const { count, intervalMs } = useNpmDownloadCounter(npmData)
-  if (!Number.isFinite(count)) { // this returns true for NaN, Infinty / -Infinty, null, undefined
+  if (!Number.isFinite(count)) {
+    // this returns true for NaN, Infinty / -Infinty, null, undefined
     return '-'
   }
   return <StableCounter value={count} intervalMs={intervalMs} />


### PR DESCRIPTION
Handle non-finite values for npm download count.