### PR TITLE
Inline or remove script

### DIFF
--- a/src/blog/npm-stats-the-right-way.md
+++ b/src/blog/npm-stats-the-right-way.md
@@ -312,22 +312,6 @@ The NPM download counts API is powerful, but it has sharp edges. Understanding t
 
 ---
 
-## Try It Yourself
-
-I've included the experiment script in our repo at [`scripts/npm-point-vs-range-experiment.js`](https://github.com/TanStack/tanstack.com/blob/main/scripts/npm-point-vs-range-experiment.js).
-
-Run it yourself:
-
-```bash
-node scripts/npm-point-vs-range-experiment.js
-```
-
-Test your favorite packages. See where the 18-month wall hits. Watch the numbers stop growing when you go too far back.
-
-It's a sobering reminder that even simple APIs have complex behavior once you dig in.
-
----
-
 ## Why This Matters to TanStack
 
 We care about this because **transparency matters**. When we show download stats, we want them to be accurate. When we talk about growth, we want it to be real.


### PR DESCRIPTION
Remove the 'Try It Yourself' section from the npm stats blog post because the referenced experiment script does not exist.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9bba56e-d492-4aa3-b7e5-c1ea89abc68b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9bba56e-d492-4aa3-b7e5-c1ea89abc68b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

