### PR TITLE
fix(docs): #9958 TanStack/query make theme toggle keyboard accessible 

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -5,19 +5,17 @@ import { useTheme } from './ThemeProvider'
 export function ThemeToggle() {
   const { toggleMode } = useTheme()
 
-  const handleToggleMode = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-  ) => {
-    e.preventDefault()
-    e.stopPropagation()
-    toggleMode()
-  }
-
   return (
-    <div
-      onClick={handleToggleMode}
+    <button
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        toggleMode()
+      }}
+      aria-label="Toggle color theme"
       className={`bg-gray-500/10 dark:bg-gray-500/30 rounded-lg flex items-center justify-between
         hover:bg-gray-500/20 dark:hover:bg-gray-500/40
+        focus:ring-2 focus:ring-offset-2 focus:ring-gray-500/50 dark:focus:ring-gray-400/50
         cursor-pointer transition-all duration-300 ease-in-out text-xs font-black`}
     >
       <div className="flex-1 flex items-center justify-between p-2 gap-1">
@@ -29,6 +27,6 @@ export function ThemeToggle() {
           Auto
         </div>
       </div>
-    </div>
+    </button>
   )
 }


### PR DESCRIPTION
Fixes TanStack/tanstack.com#606
The theme toggle in the docs header was not reachable via keyboard navigation, causing it to be skipped in the tab order and violating WCAG 2.4.3. This change renders the toggle as a semantic button, adds an accessible label, and ensures a visible focus indicator. Verified Tab and Shift+Tab navigation on the docs site.