### PR TITLE
fix: correct spelling of 'GitHub' in project labels in side menu

### DIFF
--- a/src/libraries/ai.tsx
+++ b/src/libraries/ai.tsx
@@ -38,7 +38,7 @@ export const aiProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/config.tsx
+++ b/src/libraries/config.tsx
@@ -35,7 +35,7 @@ export const configProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/db.tsx
+++ b/src/libraries/db.tsx
@@ -38,7 +38,7 @@ export const dbProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/devtools.tsx
+++ b/src/libraries/devtools.tsx
@@ -36,7 +36,7 @@ export const devtoolsProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/form.tsx
+++ b/src/libraries/form.tsx
@@ -41,7 +41,7 @@ export const formProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/pacer.tsx
+++ b/src/libraries/pacer.tsx
@@ -47,7 +47,7 @@ export const pacerProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/ranger.tsx
+++ b/src/libraries/ranger.tsx
@@ -46,7 +46,7 @@ export const rangerProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/store.tsx
+++ b/src/libraries/store.tsx
@@ -41,7 +41,7 @@ export const storeProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/table.tsx
+++ b/src/libraries/table.tsx
@@ -63,7 +63,7 @@ export const tableProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],

--- a/src/libraries/virtual.tsx
+++ b/src/libraries/virtual.tsx
@@ -43,7 +43,7 @@ export const virtualProject = {
     },
     {
       icon: <GithubIcon />,
-      label: 'Github',
+      label: 'GitHub',
       to: `https://github.com/${repo}`,
     },
   ],


### PR DESCRIPTION
The "Github" and "GitHub" appearing in the side menu have been unified to "GitHub".

<img width="244" height="222" alt="image" src="https://github.com/user-attachments/assets/4c66c828-c8f5-4877-a249-d4ba5a021b28" /><img width="246" height="240" alt="image" src="https://github.com/user-attachments/assets/b49ca851-7419-4855-a086-049c3e6bd859" />
