### PR TITLE
Fix GitHub link on tanstack start repo

### DIFF
--- a/src/libraries/start.tsx
+++ b/src/libraries/start.tsx
@@ -4,7 +4,7 @@ import { redirect } from '@tanstack/react-router'
 import { GithubIcon } from '~/components/icons/GithubIcon'
 import { YinYangIcon } from '~/components/icons/YinYangIcon'
 
-const repo = 'tanstack/router'
+const repo = 'tanstack/start'
 
 const textStyles = 'text-cyan-600 dark:text-cyan-500'
 


### PR DESCRIPTION
Currently the "Stars on GitHub" link on the [TanStack Start homepage](https://tanstack.com/start/latest) links to [TanStack Router GitHub](https://github.com/tanstack/router)

This is due to incorrect data `'tanstack/router'` in `src/libraries/start.tsx`

This PR updates the variable to `'tanstack/start'`