### PR TITLE
fix: correct backdrop-blur typo in Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -158,7 +158,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   const navbar = (
     <div
       className={twMerge(
-        'w-full p-2 fixed top-0 z-[100] bg-white/70 dark:bg-black/70 backdrop-br-lg shadow-xl shadow-black/3',
+        'w-full p-2 fixed top-0 z-[100] bg-white/70 dark:bg-black/70 backdrop-blur-lg shadow-xl shadow-black/3',
         'flex items-center justify-between gap-4',
         'dark:border-b border-gray-500/20',
       )}


### PR DESCRIPTION
Closes #586.

| Before | After |
|--------|--------|
| <img width="316" height="857" alt="image" src="https://github.com/user-attachments/assets/bd58a8dc-7e0f-4c5e-8910-dae1a10068c7" /> | <img width="307" height="857" alt="image" src="https://github.com/user-attachments/assets/16fee4c1-f0ca-4147-82a2-33080a1057a4" /> |
| <img width="352" height="763" alt="image" src="https://github.com/user-attachments/assets/b2718753-84ac-40ea-bfe9-69992c7f58e4" /> | <img width="352" height="764" alt="image" src="https://github.com/user-attachments/assets/eba2a667-92a0-492b-ab24-f23a2a5f5ad9" /> | 