### PR TITLE
Search Icons

### DIFF
--- a/src/components/SearchButton.tsx
+++ b/src/components/SearchButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Command, Search } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 import { useSearchContext } from '~/contexts/SearchContext'
+import { usePlatform } from '~/hooks/usePlatform'
 
 interface SearchButtonProps {
   className?: string
@@ -10,6 +11,7 @@ interface SearchButtonProps {
 
 export function SearchButton({ className }: SearchButtonProps) {
   const { openSearch } = useSearchContext()
+  const platform = usePlatform();
 
   return (
     <button
@@ -23,7 +25,7 @@ export function SearchButton({ className }: SearchButtonProps) {
         <Search size={18} /> Search...
       </div>
       <div className="flex items-center bg-white/50 dark:bg-gray-500/50 rounded-md px-2 py-1 gap-1 font-bold text-xs whitespace-nowrap">
-        <Command size={12} /> + K
+        {platform?.toLowerCase()?.includes("mac") ? <Command size={12} /> : "Ctrl"} + K
       </div>
     </button>
   )

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,0 +1,6 @@
+export function usePlatform() {
+  if (typeof navigator === "undefined") {
+    return;
+  }
+  return navigator.platform;
+}


### PR DESCRIPTION
Automatically changes the icon of the search bar between `cmd` and `ctrl` based on the user agent.

I was struggling to test due to no `DATABASE_URL` environment variable being set, but I could not find anywhere what it needed to be.