### PR TITLE
Feat: GitHub Icon on Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -149,7 +149,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   )
 
   const socialLinks = (
-    <div className="flex items-center gap-2 [&_a]:p-1.5 [&_a]:opacity-50 [&_a:hover]:opacity-100 [&_a]:transition-opacity [&_svg]:text-sm">
+    <div className="flex items-center [&_a]:p-1.5 [&_a]:opacity-50 [&_a:hover]:opacity-100 [&_a]:transition-opacity [&_svg]:text-sm">
       <a
         href={`https://github.com/${library?.repo ?? 'tanstack'}`}
         aria-label={`Follow ${library?.name ?? 'TanStack'} on GitHub`}


### PR DESCRIPTION
## Problem

Based on this [discussion](https://github.com/TanStack/tanstack.com/discussions/541), I noticed that TanStack doc doesn't include GitHub social icon in the navbar's quick links section, despite GitHub being one of the most important links.

## Changes

- Added a GitHub link to the top navbar
- Move icons' style to parent `div` & add slight gap
- Import findLibrary to dynamically set the GitHub repo URL and aria-label based on the active page/library
- Memoized `Title` and `library` lookups

## Screenshot

### Large screen

<img width="2539" height="216" alt="image" src="https://github.com/user-attachments/assets/068146a7-91d8-4c5d-806f-9c08db7e187a" />


### Small screen

<img width="2528" height="319" alt="image" src="https://github.com/user-attachments/assets/56df6799-330c-424e-a540-fc2c0e38625c" />

### On Hover

- Home page: https://github.com/tanstack
<img width="2540" height="215" alt="image" src="https://github.com/user-attachments/assets/0471f908-7a82-481c-bc4d-b152f8ebae22" />

- Tanstack Start doc page: https://github.com/tanstack/router
<img width="2539" height="188" alt="image" src="https://github.com/user-attachments/assets/a166b450-074e-46d1-945a-9275ec8182e5" />

- Tanstack Query doc page: https://github.com/tanstack/query
<img width="2539" height="194" alt="image" src="https://github.com/user-attachments/assets/347b8d06-6312-4d56-913d-ea853d52d70c" />

