### PR TITLE
Feat: Add Cursor Deeplink in Copy Page Dropdown

### DIFF
--- a/src/components/CopyPageDropdown.tsx
+++ b/src/components/CopyPageDropdown.tsx
@@ -272,7 +272,7 @@ export function CopyPageDropdown({
                 )}
                 onSelect={item.onSelect}
               >
-                <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-gray-500 dark:text-gray-400">
+                <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-gray-700 dark:text-gray-400">
                   <item.icon className="w-4 h-4" />
                 </div>
                 <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Feature

Add Cursor deeplink in Copy Page Dropdown option

## Changes

- Add Cursor icon
- Minor: increase icon visibility in light mode

## Screenshot

### In TanStack page

<img width="513" height="423" alt="image" src="https://github.com/user-attachments/assets/a4295625-bb52-40e2-9c4e-5d55e5d978ef" />

### In Cursor

<img width="816" height="398" alt="image" src="https://github.com/user-attachments/assets/38774d18-2d23-4412-bfb4-85b64f243156" />

<img width="524" height="303" alt="image" src="https://github.com/user-attachments/assets/4cbd8497-5caa-4083-8320-002e193185cd" />

Close #612 
