### PR TITLE
Fix: remove padding on the right sidebar so it doesn't get cut off

### DIFF
--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -605,7 +605,7 @@ export function DocsLayout({
         sm:top-[var(--navbar-height)]
         "
         >
-          <div className="sm:sticky sm:top-[var(--navbar-height)] ml-auto flex flex-wrap flex-row justify-center sm:flex-col gap-4 pl-4 pb-4">
+          <div className="sm:sticky sm:top-[var(--navbar-height)] ml-auto flex flex-wrap flex-row justify-center sm:flex-col gap-4 pb-4">
             <div className="flex flex-wrap items-stretch border-l border-gray-500/20 rounded-bl-lg overflow-hidden -mr-px">
               <div className="w-full flex gap-2 justify-between border-b border-gray-500/20 px-3 py-2">
                 <Link


### PR DESCRIPTION
### Problem:
The right sidebar with the partner info was being cut off in my browser:
<img width="1440" height="729" alt="image" src="https://github.com/user-attachments/assets/72c6b19b-2295-4a3d-b459-c6ccf9f6b010" />

### Fix:
- removed the left padding so that it wouldn't be overflowing

<img width="1440" height="706" alt="image" src="https://github.com/user-attachments/assets/4d8bd3a8-2fc1-48c7-93e4-0ee1fcf3e41f" />

### Testing:
- [x] checked that this fix works on multiple window sizes including mobile
- [x] checked that this fix works in multiple browsers (chrome, safari, firefox)
