### PR TITLE
Remove serialization FAQ and add detailed caching example

### DIFF
--- a/src/blog/composite-components.md
+++ b/src/blog/composite-components.md
@@ -193,15 +193,15 @@ For dependencies beyond route params, use `loaderDeps` to include search params 
 export const Route = createFileRoute('/posts/$postId')({
   loaderDeps: ({ search }) => ({
     tab: search.tab,
-    sort: search.sort
+    sort: search.sort,
   }),
   loader: async ({ params, deps }) => ({
     Post: await getPost({
       data: {
         postId: params.postId,
         tab: deps.tab,
-        sort: deps.sort
-      }
+        sort: deps.sort,
+      },
     }),
   }),
   component: PostPage,


### PR DESCRIPTION
- Removed the FAQ about serialization support (unnecessary discussion)
- Expanded the caching section with a detailed example showing how
  query keys with route params trigger automatic cache invalidation
- Added clear navigation flow example demonstrating cache hits/misses