### PR TITLE
feat: blog page og image

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@takumi-rs/core-*

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,6 @@
   publish = "dist/client"
 
 [functions]
+  node_bundler = "esbuild"
   directory = "netlify/functions"
+  included_files = ["node_modules/@takumi-rs/core-linux-x64-gnu/**/*.*"]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@sentry/vite-plugin": "^2.22.6",
     "@tailwindcss/typography": "^0.5.13",
     "@tailwindcss/vite": "^4.1.11",
+    "@takumi-rs/image-response": "^0.62.6",
     "@tanstack/pacer": "^0.16.4",
     "@tanstack/react-pacer": "^0.17.4",
     "@tanstack/react-query": "^5.90.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@7.1.7(@types/node@24.3.0)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@takumi-rs/image-response':
+        specifier: ^0.62.6
+        version: 0.62.6
       '@tanstack/pacer':
         specifier: ^0.16.4
         version: 0.16.4
@@ -2529,6 +2532,67 @@ packages:
     resolution: {integrity: sha512-RHYhrR3hku0MJFRV+fN2gNbDNEh3dwKvY8XJvTxCSXeMOsCRSr+uKvDWQcbizrHgjML6ZmTE5OwMrl5wKcujCw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@takumi-rs/core-darwin-arm64@0.62.6':
+    resolution: {integrity: sha512-nRz8WT7dphyhRB1QBpCJkxzpDj/0dT9xv6rAPrHK4yV9Tk01+zFW9iVgLtu8hDzLDZszmkbZzbTJ8QaZCve6Xg==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@takumi-rs/core-darwin-x64@0.62.6':
+    resolution: {integrity: sha512-uhq7dBMPP7cqsx+igXjsPFGmWlPb8wrFJNNrIzjno0Ly/X2RHn6ViZV+uE3NZsX/s3mFeOmNN1h4Mvy4k4oB2Q==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@takumi-rs/core-linux-arm64-gnu@0.62.6':
+    resolution: {integrity: sha512-tFiSTF+mkrXtzmuDUgpi2JAgumw9/okaFCMoUfKtEEPZXD6DFT65LEufmZDkHfBzKZTtqUvtM1WUc8X8Cp4oBQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@takumi-rs/core-linux-arm64-musl@0.62.6':
+    resolution: {integrity: sha512-EbgNVGMsvkYenDBiNOi61Yz3xoSt0vlWeFOgOPQp3jrMu8936fIagb9UmDMDZjL4JWsI7Wozxp8RL8y3Tw6gkw==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@takumi-rs/core-linux-x64-gnu@0.62.6':
+    resolution: {integrity: sha512-tWqCpIrDY4IccFk6Dp4wRlIWhc2Vtj5WTwxRjrPLqsEW/6uV4Oc8OUBY4tCmhll523BWxwSRAsqXyk4IR1D6uA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@takumi-rs/core-linux-x64-musl@0.62.6':
+    resolution: {integrity: sha512-Q4L2NyxynlrUqKDNWys81lgIunH2BBc10g13iIYiKlpliXwZccGBcrsl2QwcjdyVcGXPc8fqL28LOwaVdOcqkA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@takumi-rs/core-win32-arm64-msvc@0.62.6':
+    resolution: {integrity: sha512-HYF6ES0SYaJ0ZSUGeVI4zrc1wvUOqtEkXJQb/DgwGcZlbQSkEVDzdKC119orBCqpVDsxTwAEeDu7eg/m135x3A==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@takumi-rs/core-win32-x64-msvc@0.62.6':
+    resolution: {integrity: sha512-Sl19GuKovAxxsSh/23q4RZhh/zdRUAwwOdLRb0VgEG+TCJmIewBBMlxMyppUBXB5xm/9N8jtVbXetxEyU5tHUQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@takumi-rs/core@0.62.6':
+    resolution: {integrity: sha512-EsThHYARwTJyrl2Yq40GCjwvpfmuh0jWkHsx8i+EcL5UM3j1WfrTU8hGAewJFwiISdSlMgyDh87EH8ywfUJ4mQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+
+  '@takumi-rs/helpers@0.62.6':
+    resolution: {integrity: sha512-sQ7gBgdY7HeCH+lsSheapCUYJnBkZ4kPbqKBaD6LwD1ejX2gNGlDLbkvMDPRdCZzEWXkYU48+5YokADJys2J6w==}
+
+  '@takumi-rs/image-response@0.62.6':
+    resolution: {integrity: sha512-g+soCdxo6BRInb+vsiNyP6aZJT4D+9hlCd0xRCviUFTLVmweLoIK4mGxLJzgl0mEc+gr8QVIHnV+uBCJTkusjw==}
+
+  '@takumi-rs/wasm@0.62.6':
+    resolution: {integrity: sha512-txQkgHMT1jLvbqbH+xlztKeL8jyIe09BEyh+rZcaXhjtym0wl0OqgKO7v0m4JxBV4a2gkWxOmthzLLODRE7C9g==}
 
   '@tanstack/devtools-event-client@0.3.5':
     resolution: {integrity: sha512-RL1f5ZlfZMpghrCIdzl6mLOFLTuhqmPNblZgBaeKfdtk5rfbjykurv+VfYydOFXj0vxVIoA2d/zT7xfD7Ph8fw==}
@@ -9508,6 +9572,51 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
       vite: 7.1.7(@types/node@24.3.0)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@takumi-rs/core-darwin-arm64@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-darwin-x64@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-linux-arm64-gnu@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-linux-arm64-musl@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-linux-x64-gnu@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-linux-x64-musl@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-win32-arm64-msvc@0.62.6':
+    optional: true
+
+  '@takumi-rs/core-win32-x64-msvc@0.62.6':
+    optional: true
+
+  '@takumi-rs/core@0.62.6':
+    optionalDependencies:
+      '@takumi-rs/core-darwin-arm64': 0.62.6
+      '@takumi-rs/core-darwin-x64': 0.62.6
+      '@takumi-rs/core-linux-arm64-gnu': 0.62.6
+      '@takumi-rs/core-linux-arm64-musl': 0.62.6
+      '@takumi-rs/core-linux-x64-gnu': 0.62.6
+      '@takumi-rs/core-linux-x64-musl': 0.62.6
+      '@takumi-rs/core-win32-arm64-msvc': 0.62.6
+      '@takumi-rs/core-win32-x64-msvc': 0.62.6
+
+  '@takumi-rs/helpers@0.62.6': {}
+
+  '@takumi-rs/image-response@0.62.6':
+    dependencies:
+      '@takumi-rs/core': 0.62.6
+      '@takumi-rs/helpers': 0.62.6
+      '@takumi-rs/wasm': 0.62.6
+
+  '@takumi-rs/wasm@0.62.6': {}
 
   '@tanstack/devtools-event-client@0.3.5': {}
 

--- a/src/components/og/BlogImage.tsx
+++ b/src/components/og/BlogImage.tsx
@@ -1,0 +1,40 @@
+import { Post } from 'content-collections'
+import { formatAuthors } from '~/utils/blog'
+
+export function BlogImage({
+  title,
+  description,
+  headerImage,
+  authors,
+  published,
+}: Post) {
+  return (
+    <div
+      tw="w-full h-full bg-cover bg-center bg-no-repeat bg-[#171717]"
+      style={{
+        backgroundImage: headerImage
+          ? `url(https://tanstack.com${headerImage})`
+          : 'none',
+      }}
+    >
+      <div tw="w-full h-full flex-col p-16 text-pretty backdrop-blur-md backdrop-brightness-30">
+        <img
+          src="https://tanstack.com/images/logos/splash-dark.png"
+          tw="w-24"
+        />
+        <div tw="grow" />
+        <p tw="text-white text-6xl mb-4 font-bold line-clamp-2 text-ellipsis">
+          {title}
+        </p>
+        <p tw="text-white/85 text-4xl font-medium line-clamp-2 text-ellipsis mb-6">
+          {description}
+        </p>
+        <div tw="flex items-center gap-2">
+          <p tw="text-white/85 text-2xl font-medium uppercase tracking-wider font-mono">
+            by {formatAuthors(authors)} on {published}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -89,6 +89,7 @@ import { Route as LibrariesDbVersionIndexRouteImport } from './routes/_libraries
 import { Route as LibrariesConfigVersionIndexRouteImport } from './routes/_libraries/config.$version.index'
 import { Route as LibrariesAiVersionIndexRouteImport } from './routes/_libraries/ai.$version.index'
 import { Route as LibraryIdVersionDocsIndexRouteImport } from './routes/$libraryId/$version.docs.index'
+import { Route as ApiOgBlogSplatRouteImport } from './routes/api/og/blog.$'
 import { Route as ApiAuthCallbackProviderRouteImport } from './routes/api/auth/callback/$provider'
 import { Route as LibraryIdVersionDocsChar123Char125DotmdRouteImport } from './routes/$libraryId/$version.docs.{$}[.]md'
 import { Route as LibraryIdVersionDocsContributorsRouteImport } from './routes/$libraryId/$version.docs.contributors'
@@ -513,6 +514,11 @@ const LibraryIdVersionDocsIndexRoute =
     path: '/',
     getParentRoute: () => LibraryIdVersionDocsRoute,
   } as any)
+const ApiOgBlogSplatRoute = ApiOgBlogSplatRouteImport.update({
+  id: '/api/og/blog/$',
+  path: '/api/og/blog/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthCallbackProviderRoute = ApiAuthCallbackProviderRouteImport.update({
   id: '/api/auth/callback/$provider',
   path: '/api/auth/callback/$provider',
@@ -644,6 +650,7 @@ export interface FileRoutesByFullPath {
   '/$libraryId/$version/docs/contributors': typeof LibraryIdVersionDocsContributorsRoute
   '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
   '/api/auth/callback/$provider': typeof ApiAuthCallbackProviderRoute
+  '/api/og/blog/$': typeof ApiOgBlogSplatRoute
   '/$libraryId/$version/docs/': typeof LibraryIdVersionDocsIndexRoute
   '/ai/$version': typeof LibrariesAiVersionIndexRoute
   '/config/$version': typeof LibrariesConfigVersionIndexRoute
@@ -730,6 +737,7 @@ export interface FileRoutesByTo {
   '/$libraryId/$version/docs/contributors': typeof LibraryIdVersionDocsContributorsRoute
   '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
   '/api/auth/callback/$provider': typeof ApiAuthCallbackProviderRoute
+  '/api/og/blog/$': typeof ApiOgBlogSplatRoute
   '/$libraryId/$version/docs': typeof LibraryIdVersionDocsIndexRoute
   '/ai/$version': typeof LibrariesAiVersionIndexRoute
   '/config/$version': typeof LibrariesConfigVersionIndexRoute
@@ -823,6 +831,7 @@ export interface FileRoutesById {
   '/$libraryId/$version/docs/contributors': typeof LibraryIdVersionDocsContributorsRoute
   '/$libraryId/$version/docs/{$}.md': typeof LibraryIdVersionDocsChar123Char125DotmdRoute
   '/api/auth/callback/$provider': typeof ApiAuthCallbackProviderRoute
+  '/api/og/blog/$': typeof ApiOgBlogSplatRoute
   '/$libraryId/$version/docs/': typeof LibraryIdVersionDocsIndexRoute
   '/_libraries/ai/$version/': typeof LibrariesAiVersionIndexRoute
   '/_libraries/config/$version/': typeof LibrariesConfigVersionIndexRoute
@@ -916,6 +925,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/contributors'
     | '/$libraryId/$version/docs/{$}.md'
     | '/api/auth/callback/$provider'
+    | '/api/og/blog/$'
     | '/$libraryId/$version/docs/'
     | '/ai/$version'
     | '/config/$version'
@@ -1002,6 +1012,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/contributors'
     | '/$libraryId/$version/docs/{$}.md'
     | '/api/auth/callback/$provider'
+    | '/api/og/blog/$'
     | '/$libraryId/$version/docs'
     | '/ai/$version'
     | '/config/$version'
@@ -1094,6 +1105,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/contributors'
     | '/$libraryId/$version/docs/{$}.md'
     | '/api/auth/callback/$provider'
+    | '/api/og/blog/$'
     | '/$libraryId/$version/docs/'
     | '/_libraries/ai/$version/'
     | '/_libraries/config/$version/'
@@ -1137,6 +1149,7 @@ export interface RootRouteChildren {
   StatsNpmPackagesRoute: typeof StatsNpmPackagesRoute
   StatsNpmIndexRoute: typeof StatsNpmIndexRoute
   ApiAuthCallbackProviderRoute: typeof ApiAuthCallbackProviderRoute
+  ApiOgBlogSplatRoute: typeof ApiOgBlogSplatRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1701,6 +1714,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LibraryIdVersionDocsIndexRouteImport
       parentRoute: typeof LibraryIdVersionDocsRoute
     }
+    '/api/og/blog/$': {
+      id: '/api/og/blog/$'
+      path: '/api/og/blog/$'
+      fullPath: '/api/og/blog/$'
+      preLoaderRoute: typeof ApiOgBlogSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/auth/callback/$provider': {
       id: '/api/auth/callback/$provider'
       path: '/api/auth/callback/$provider'
@@ -2018,6 +2038,7 @@ const rootRouteChildren: RootRouteChildren = {
   StatsNpmPackagesRoute: StatsNpmPackagesRoute,
   StatsNpmIndexRoute: StatsNpmIndexRoute,
   ApiAuthCallbackProviderRoute: ApiAuthCallbackProviderRoute,
+  ApiOgBlogSplatRoute: ApiOgBlogSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_libraries/blog.$.tsx
+++ b/src/routes/_libraries/blog.$.tsx
@@ -62,25 +62,14 @@ const fetchBlogPost = createServerFn({ method: 'GET' })
 export const Route = createFileRoute('/_libraries/blog/$')({
   staleTime: Infinity,
   loader: ({ params }) => fetchBlogPost({ data: params._splat }),
-  head: ({ loaderData }) => {
-    // Generate optimized social media image URL using Netlify Image CDN
-    const getSocialImageUrl = (headerImage?: string) => {
-      if (!headerImage) return undefined
-
-      // Use Netlify Image CDN to optimize for social media (1200x630 is the standard for og:image)
-      const netlifyImageUrl = `https://tanstack.com/.netlify/images?url=${encodeURIComponent(
-        headerImage,
-      )}&w=1200&h=630&fit=cover&fm=jpg&q=80`
-      return netlifyImageUrl
-    }
-
+  head: ({ loaderData, params }) => {
     return {
       meta: loaderData
         ? [
             ...seo({
               title: `${loaderData?.title ?? 'Docs'} | TanStack Blog`,
               description: loaderData?.description,
-              image: getSocialImageUrl(loaderData?.headerImage),
+              image: `/api/og/blog/${params._splat}`,
             }),
             {
               name: 'author',

--- a/src/routes/api/og/blog.$.tsx
+++ b/src/routes/api/og/blog.$.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { ImageResponse, ImageResponseOptions } from '@takumi-rs/image-response'
+import { BlogImage } from '~/components/og/BlogImage'
+import { allPosts } from 'content-collections'
+
+function handleRedirects(docsPath: string) {
+  if (docsPath.includes('directives-the-new-framework-lock-in')) {
+    return 'directives-and-the-platform-boundary'
+  }
+
+  return docsPath
+}
+
+export const Route = createFileRoute('/api/og/blog/$')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        if (!params._splat) {
+          throw notFound()
+        }
+
+        const slug = handleRedirects(params._splat)
+
+        const post = allPosts.find((post) => post.slug === slug)
+
+        if (!post) {
+          throw notFound()
+        }
+
+        return new ImageResponse(<BlogImage {...post} />, {
+          width: 1200,
+          height: 630,
+          format: 'webp',
+          headers: {
+            'Cache-Control': 'public, max-age=0, must-revalidate',
+            'Netlify-CDN-Cache-Control':
+              'public, max-age=300, durable, stale-while-revalidate=300',
+          },
+        })
+      },
+    },
+  },
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
   },
   ssr: {
     external: ['postgres'],
-    noExternal: ['drizzle-orm'],
+    noExternal: ['drizzle-orm', '@takumi-rs/image-response', '@takumi-rs/core'],
   },
   optimizeDeps: {
-    exclude: ['postgres'],
+    exclude: ['postgres', '@takumi-rs/core'],
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
Since Tanner expressed interest in Takumi, I've taken some free time to work on a proposal for generating blog og images with Takumi.

If this PR is acceptable, docs site og can be implemented incrementally.

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/07693bfe-ce43-477e-bac8-073fe4b6a5cb" />
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/2f274106-19df-4668-bc5c-19d79d6c5b4d" />
