### PR TITLE
fix: improve blog date formatting

### DIFF
--- a/src/routes/_libraries/blog.$.tsx
+++ b/src/routes/_libraries/blog.$.tsx
@@ -101,7 +101,7 @@ function BlogPost() {
 
   const blogContent = `<small>_by ${formatAuthors(authors)} on ${format(
     new Date(published || 0),
-    'MMM dd, yyyy',
+    'MMMM d, yyyy',
   )}._</small>
 
 ${content}`

--- a/src/routes/_libraries/blog.index.tsx
+++ b/src/routes/_libraries/blog.index.tsx
@@ -88,10 +88,10 @@ function BlogIndex() {
                       {published ? (
                         <time
                           dateTime={published}
-                          title={format(new Date(published), 'MMM dd, yyyy')}
+                          title={format(new Date(published), 'MMM d, yyyy')}
                         >
                           {' '}
-                          on {format(new Date(published), 'MMM dd, yyyy')}
+                          on {format(new Date(published), 'MMM d, yyyy')}
                         </time>
                       ) : null}
                     </p>

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -81,6 +81,14 @@ export function format(date: Date | number, formatStr: string): string {
         day: 'numeric',
       })
 
+    case 'MMMM d, yyyy':
+      // "April 29, 2023"
+      return d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+
     case 'yyyy-MM-dd':
       // "2023-04-29"
       return d.toISOString().split('T')[0]


### PR DESCRIPTION
## Summary
- Blog post: use full month name format (January 2, 2026)
- Posts list: use short month format without leading zero (Jan 2, 2026)

## Changes
- Updated `blog.$.tsx` to use `MMMM d, yyyy` format
- Updated `blog.index.tsx` to use `MMM d, yyyy` format
- Added `MMMM d, yyyy` format support to `dates.ts`