### PR TITLE
fix: replace blog ISO dates with readable dates

### DIFF
--- a/src/routes/_libraries/blog.$.tsx
+++ b/src/routes/_libraries/blog.$.tsx
@@ -101,7 +101,7 @@ function BlogPost() {
 
   const blogContent = `<small>_by ${formatAuthors(authors)} on ${format(
     new Date(published || 0),
-    'MMM dd, yyyy',
+    'MMM d, yyyy',
   )}._</small>
 
 ${content}`

--- a/src/routes/_libraries/blog.index.tsx
+++ b/src/routes/_libraries/blog.index.tsx
@@ -88,10 +88,10 @@ function BlogIndex() {
                       {published ? (
                         <time
                           dateTime={published}
-                          title={format(new Date(published), 'MMM dd, yyyy')}
+                          title={format(new Date(published), 'MMM d, yyyy')}
                         >
                           {' '}
-                          on {format(new Date(published), 'MMM dd, yyyy')}
+                          on {format(new Date(published), 'MMM d, yyyy')}
                         </time>
                       ) : null}
                     </p>

--- a/src/routes/_libraries/index.tsx
+++ b/src/routes/_libraries/index.tsx
@@ -1,5 +1,4 @@
-import { Link, MatchRoute, createFileRoute } from '@tanstack/react-router'
-import { twMerge } from 'tailwind-merge'
+import { Link, createFileRoute } from '@tanstack/react-router'
 import { Footer } from '~/components/Footer'
 import { LazySponsorSection } from '~/components/LazySponsorSection'
 import discordImage from '~/images/discord-logo-white.svg'
@@ -385,11 +384,11 @@ function Index() {
                                 dateTime={published}
                                 title={format(
                                   new Date(published),
-                                  'MMM dd, yyyy',
+                                  'MMM d, yyyy',
                                 )}
                               >
                                 {' '}
-                                on {format(new Date(published), 'MMM dd, yyyy')}
+                                on {format(new Date(published), 'MMM d, yyyy')}
                               </time>
                             ) : null}
                           </p>


### PR DESCRIPTION
A wrongly formatted string caused the date formatter to fall back to ISO dates:

<img width="292" height="353" alt="image" src="https://github.com/user-attachments/assets/21698fdd-13dc-4740-9ad7-d19cd140a516" />

This PR changes the formatting strings to be `MMM d, yyyy` instead of `MMM dd, yyyy` for a readable date string.

(Image from local environment)

<img width="292" height="214" alt="image" src="https://github.com/user-attachments/assets/7f7490d1-dcf6-46c3-ba61-25e954a933df" />
