### PR TITLE
fix(builder): add `title` attribute to template card

### DIFF
--- a/src/components/builder/config/TemplatePicker.tsx
+++ b/src/components/builder/config/TemplatePicker.tsx
@@ -268,6 +268,7 @@ function TemplateCard({
           : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800',
         isLoading && 'opacity-50 cursor-wait',
       )}
+      title={description}
     >
       <div
         className={twMerge(


### PR DESCRIPTION
> Sorry for the very short PR.

Adds `title` attribute to the TemplateCard to show the truncated description on hover.

After:
<img width="1079" height="906" alt="image" src="https://github.com/user-attachments/assets/7fdafd73-7541-4387-98aa-8a24341c1247" />
