### PR TITLE
MCP: Relax redirectUri validation to allow any URI scheme

### DIFF
--- a/src/routes/oauth/authorize.tsx
+++ b/src/routes/oauth/authorize.tsx
@@ -9,23 +9,23 @@ import { useIsDark } from '~/hooks/useIsDark'
 import { BrandContextMenu } from '~/components/BrandContextMenu'
 
 /**
- * Validate redirect URI - must be localhost or HTTPS
+ * Validate redirect URI - block only HTTP to non-localhost
+ * Allows: HTTPS, localhost (any protocol), custom schemes (cursor://, vscode://, etc.)
  * Inlined here to avoid pulling in server-only dependencies
  */
 function validateRedirectUri(uri: string): boolean {
   try {
     const url = new URL(uri)
-    if (
-      url.hostname === 'localhost' ||
-      url.hostname === '127.0.0.1' ||
-      url.hostname === '[::1]'
-    ) {
-      return true
+    // Block only HTTP to non-localhost
+    if (url.protocol === 'http:') {
+      return (
+        url.hostname === 'localhost' ||
+        url.hostname === '127.0.0.1' ||
+        url.hostname === '[::1]'
+      )
     }
-    if (url.protocol === 'https:') {
-      return true
-    }
-    return false
+    // Allow everything else: HTTPS, custom schemes
+    return true
   } catch {
     return false
   }
@@ -84,7 +84,7 @@ export const Route = createFileRoute('/oauth/authorize')({
     if (!validateRedirectUri(deps.redirect_uri)) {
       return {
         error: 'invalid_request',
-        errorDescription: 'redirect_uri must be localhost or HTTPS',
+        errorDescription: 'HTTP redirect URIs are only allowed for localhost',
       }
     }
 


### PR DESCRIPTION
Cursor is not able to use oauth DCR to connect to the MCP server because they want to redirect to `cursor://anysphere.cursor-mcp/oauth/callback`, which is currently not allowed and results in the following error: `Redirect URIs must be localhost or HTTPS`. This PR relaxes redirectUri validation to allow for any URI scheme, except for http to external URIs. 

Seems like cursor is a bit ahead of the spec here, though the python SDK has also gone this path: https://github.com/modelcontextprotocol/python-sdk/pull/895

Closes #652