### PR TITLE
Update sponsor: Replace Promptmonitor with Supalytics

### DIFF
--- a/src/utils/gh-sponsor-meta.json
+++ b/src/utils/gh-sponsor-meta.json
@@ -297,9 +297,9 @@
   },
   {
     "login": "yogesharc",
-    "name": "Promptmonitor",
-    "imageUrl": "https://bvatwanklwlvzlcxrcxn.supabase.co/storage/v1/object/public/assets/promptmonitor-icon-brandfill.png",
-    "linkUrl": "https://www.promptmonitor.io/?utm_source=tanstack"
+    "name": "Supalytics",
+    "imageUrl": "https://www.supalytics.co/supalytics-icon-filled.png",
+    "linkUrl": "https://www.supalytics.co/?utm_source=tanstack"
   },
   {
     "login": "TextToHuman",


### PR DESCRIPTION
Updates the sponsor metadata for @yogesharc to reflect the new project:

**Changes:**
- Name: Promptmonitor → Supalytics
- URL: promptmonitor.io → supalytics.co
- Logo: Updated to Supalytics branding

**About Supalytics:**
Supalytics is a fast, privacy-focused web analytics tool with advanced funnel tracking and AI-powered optimization suggestions.