### PR TITLE
fix: restore MCP landing page flow

### DIFF
--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -1,7 +1,6 @@
 // Base library data - lightweight, stays in main bundle
 // Extended library data (with React nodes, testimonials, etc.) is in individual library files
 
-import { redirect } from '@tanstack/react-router'
 import type { LibrarySlim, LibraryId } from './types'
 
 export const query: LibrarySlim = {
@@ -413,21 +412,6 @@ export const mcp: LibrarySlim = {
   docsRoot: 'docs/mcp',
   defaultDocs: 'overview',
   visible: false,
-  handleRedirects: (href: string) => {
-    const pathMap: Record<string, string> = {
-      overview: 'mcp/mcp-overview',
-      connecting: 'mcp/mcp-connecting',
-      tools: 'mcp/mcp-tools',
-    }
-    const mcpDocsMatch = href.match(/\/mcp\/(latest|v1)\/docs\/(.*)/)
-    if (mcpDocsMatch) {
-      const newPath = pathMap[mcpDocsMatch[2]] || 'mcp/mcp-overview'
-      throw redirect({ href: `/cli/latest/docs/${newPath}` })
-    }
-    if (/\/mcp(\/latest)?$/.test(href)) {
-      throw redirect({ href: '/cli/latest/docs/mcp/mcp-overview' })
-    }
-  },
 }
 
 export const cli: LibrarySlim = {

--- a/src/routes/$libraryId/$version.index.tsx
+++ b/src/routes/$libraryId/$version.index.tsx
@@ -30,6 +30,7 @@ const landingComponents: Partial<
   ai: React.lazy(() => import('~/components/landing/AiLanding')),
   devtools: React.lazy(() => import('~/components/landing/DevtoolsLanding')),
   cli: React.lazy(() => import('~/components/landing/CliLanding')),
+  mcp: React.lazy(() => import('~/components/landing/McpLanding')),
 }
 
 export const Route = createFileRoute('/$libraryId/$version/')({


### PR DESCRIPTION
## Summary
Restore the MCP landing page and stop the infinite redirect loop that effectively bricked the site when clicking "Try TanStack MCP".

## Changes
- Remove MCP `handleRedirects` that routed all MCP URLs to CLI docs
- Add `mcp` to `landingComponents` so `/mcp/latest` renders `McpLanding`

## Context
This behavior was introduced in commit **1889db30** ("builder alpha.2"), which added `handleRedirects` for MCP in `src/libraries/libraries.ts`. The MCP library was originally added in **a71ea35c** ("mcp") with its own landing page and docs.

## What went wrong
The `handleRedirects` added in 1889db30 redirected any `/mcp` or `/mcp/latest` navigation to `/cli/latest/docs/mcp/mcp-overview`. Because the navigation was client side, this caused an infinite redirect loop where the app would keep attempting to resolve MCP routes and immediately redirect again. In practice, clicking "Try TanStack MCP" would freeze the UI and make the site unusable until a hard refresh. That is effectively a full-site brick from a single nav action.

## Why this fix is necessary
This PR fixes a critical bug that renders the website unusable when the MCP entry point is clicked, restoring the intended landing flow for MCP users.