### PR TITLE
fix: Update MCP documentation redirects

### DIFF
--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -413,7 +413,7 @@ export const mcp: LibrarySlim = {
   handleRedirects: (href: string) => {
     // All /mcp routes redirect to CLI MCP docs
     if (/\/mcp(\/|$)/.test(href)) {
-      throw redirect({ href: '/cli/latest/docs/mcp/mcp-overview' })
+      throw redirect({ href: '/cli/latest/docs/mcp/overview' })
     }
   },
 }


### PR DESCRIPTION
`/mcp` routes were redirecting to the previous MCP overview page: [/docs/mcp/mcp-overview](https://tanstack.com/cli/latest/docs/mcp/mcp-overview)

<img width="1092" height="588" alt="Screenshot" src="https://github.com/user-attachments/assets/6822ff1f-9466-4917-8077-e8289cce3774" />

<br />
<br />
This updates the redirect to the current path: <a href="https://tanstack.com/cli/latest/docs/mcp/overview">/docs/mcp/overview</a>