### PR TITLE
Fix wrong navbar height on 404 pages

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -198,22 +198,21 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   const containerRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
-    const updateContainerHeight = () => {
-      if (containerRef.current) {
-        const height = containerRef.current.offsetHeight
+    const el = containerRef.current
+    if (!el) return
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const height = entry.borderBoxSize?.[0]?.blockSize ?? el.offsetHeight
         document.documentElement.style.setProperty(
           '--navbar-height',
           `${height}px`,
         )
       }
-    }
+    })
 
-    updateContainerHeight() // Initial call to set the height
-
-    window.addEventListener('resize', updateContainerHeight)
-    return () => {
-      window.removeEventListener('resize', updateContainerHeight)
-    }
+    observer.observe(el)
+    return () => observer.disconnect()
   }, [])
 
   const [showMenu, setShowMenu] = React.useState(false)


### PR DESCRIPTION
[On mobile](https://tanstack.com/time) the `--navbar-height` css var is set to `1585px` adding lot of scroll to find 404 text

<img width="1465" height="752" alt="imagen" src="https://github.com/user-attachments/assets/6bd68395-64ea-46c1-a66e-6537a6ece810" />

this PR fixes it.  co-authored by Opus 4.6 btw


---

While making the commit I was getting

```sh
Running smoke tests against http://localhost:57756

  ✓ home page
  ✗ query docs: HTTP 500
  ✗ router docs: HTTP 500
  ✗ table docs: HTTP 404

1 passed, 3 failed
```

but I checked `main` branch and also having the same test issue.