### PR TITLE
fix: Docs feature grid alignment and icon sizing

### DIFF
--- a/src/components/FeatureGrid.tsx
+++ b/src/components/FeatureGrid.tsx
@@ -22,8 +22,8 @@ export function FeatureGrid({ title, items, gridClassName }: FeatureGridProps) {
         }
       >
         {items.map((d, i) => (
-          <span key={i} className="flex items-center gap-2">
-            <CheckCircleIcon className="text-green-500 " /> {d}
+          <span key={i} className="flex gap-2">
+            <CheckCircleIcon className="text-green-500 h-lh w-4 shrink-0" /> {d}
           </span>
         ))}
       </div>


### PR DESCRIPTION
- Aligns icon to first line of text vs vertically centered
- Prevents icon from shrinking

| BEFORE | AFTER |
|--------|--------|
| <img width="1147" height="470" alt="Screenshot 2026-02-13 at 12 03 54 PM" src="https://github.com/user-attachments/assets/a624a7d5-08df-461e-88bc-3e9b15f50e87" /> | <img width="1143" height="344" alt="Screenshot 2026-02-13 at 12 03 34 PM" src="https://github.com/user-attachments/assets/4e5b79a4-cb6d-4ba4-ba13-c54b735465fb" /> |