### PR TITLE
Change dark code theme to aurora-x

### DIFF
--- a/src/components/builder/ExplorerPanel.tsx
+++ b/src/components/builder/ExplorerPanel.tsx
@@ -34,7 +34,7 @@ let highlighterPromise: Promise<HighlighterGeneric<any, any>> | null = null
 async function getShikiHighlighter(): Promise<HighlighterGeneric<any, any>> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: ['github-light', 'vitesse-dark'],
+      themes: ['github-light', 'aurora-x'],
       langs: [
         'typescript',
         'javascript',
@@ -1439,7 +1439,7 @@ function SyntaxHighlightedCode({
         })
         const darkHtml = highlighter.codeToHtml(content.trimEnd(), {
           lang: effectiveLang,
-          theme: 'vitesse-dark',
+          theme: 'aurora-x',
         })
         if (!cancelled) {
           setHighlightedLight(lightHtml)

--- a/src/components/markdown/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock.tsx
@@ -36,7 +36,7 @@ async function getHighlighter(language: string): Promise<{
 }> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: ['github-light', 'vitesse-dark'],
+      themes: ['github-light', 'aurora-x'],
       langs: [
         'typescript',
         'javascript',
@@ -155,7 +155,7 @@ export function CodeBlock({
   const code = children?.props.children
 
   const [codeElement, setCodeElement] = React.useState(
-    <pre ref={ref} className={`shiki h-full github-light dark:vitesse-dark`}>
+    <pre ref={ref} className={`shiki h-full github-light dark:aurora-x`}>
       <code>{lang === 'mermaid' ? <svg /> : code}</code>
     </pre>,
   )
@@ -164,7 +164,7 @@ export function CodeBlock({
     typeof document !== 'undefined' ? 'useLayoutEffect' : 'useEffect'
   ](() => {
     ;(async () => {
-      const themes = ['github-light', 'vitesse-dark']
+      const themes = ['github-light', 'aurora-x']
       const langStr = lang || 'plaintext'
 
       const { highlighter, effectiveLang } = await getHighlighter(langStr)

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -349,7 +349,7 @@ pre.shiki {
 
   @apply bg-white;
 
-  &.vitesse-dark {
+  &.aurora-x {
     @apply text-gray-400 bg-gray-950;
   }
 }
@@ -669,7 +669,7 @@ pre .logger.log-log svg {
   margin-right: 9px;
 }
 
-html:not(.dark) .shiki.vitesse-dark {
+html:not(.dark) .shiki.aurora-x {
   display: none;
 }
 
@@ -678,11 +678,11 @@ html.dark .shiki.github-light {
 }
 
 /* Improve comment contrast in dark mode */
-html.dark .shiki.vitesse-dark .token.comment,
-html.dark .shiki.vitesse-dark span[style*='color:#565F89'],
-html.dark .shiki.vitesse-dark span[style*='color: #565F89'],
-html.dark .shiki.vitesse-dark span[style*='color:#51597D'],
-html.dark .shiki.vitesse-dark span[style*='color: #51597D'] {
+html.dark .shiki.aurora-x .token.comment,
+html.dark .shiki.aurora-x span[style*='color:#546E7A'],
+html.dark .shiki.aurora-x span[style*='color:#546E7A'],
+html.dark .shiki.aurora-x span[style*='color:#546E7A'],
+html.dark .shiki.aurora-x span[style*='color:#546E7A'] {
   color: #9099c0 !important;
 }
 


### PR DESCRIPTION
This PR changes the theme used in the codeblocks in the documentation.

The theme AuroraX has better contrast and the colors suit the reset of the website better.

Before:

<img width="941" height="757" alt="Screenshot 2026-03-02 at 14 08 36" src="https://github.com/user-attachments/assets/a09b2920-adc8-4aad-8b3d-d8f2c3aeac19" />

After:
<img width="940" height="757" alt="Screenshot 2026-03-02 at 14 08 40" src="https://github.com/user-attachments/assets/3bb90129-97b9-46a7-9621-f345b704742e" />
