### PR TITLE
fix(docs): correct GitHub edit link on Community Resources page

### DIFF
--- a/src/routes/$libraryId/$version.docs.community-resources.tsx
+++ b/src/routes/$libraryId/$version.docs.community-resources.tsx
@@ -74,7 +74,7 @@ function RouteComponent() {
             Discover resources created by the <strong>{library.name}</strong>{' '}
             community. Have something to share?{' '}
             <a
-              href={`https://github.com/${libraryId}/edit/main/docs/community-resources.md`}
+              href={`https://github.com/${library.repo}/edit/main/docs/community-resources.md`}
               target="_blank"
               rel="noopener noreferrer"
               className="underline"


### PR DESCRIPTION
### Summary
This fixes the “Submit a PR on GitHub” link on the Community Resources page.
The link was previously generated using libraryId (e.g. query), which incorrectly pointed to `https://github.com/query/....` This PR switches it to use the configured library.repo (e.g. tanstack/query).

### Context
Reported in TanStack/query#10229. Even though the issue was filed in the Query repo, the broken link is generated in this website repository (tanstack.com).

Issue: TanStack/query#10229

### What changed
Update the Community Resources route to build the GitHub “edit” URL using library.repo instead of libraryId.

### AS-IS
https://github.com/user-attachments/assets/f446028b-ac23-49bf-b0d9-e515e78e0b1e

### TO-BE
https://github.com/user-attachments/assets/4d11ba9c-a3b7-4226-bd1e-818eb6c75210

