### PR TITLE
Refine Intent blog post copy

### DIFF
--- a/src/blog/from-docs-to-agents.md
+++ b/src/blog/from-docs-to-agents.md
@@ -36,7 +36,7 @@ For popular, stable patterns — standard React hooks, Express middleware, Tailw
 
 ![Model training data mixes versions permanently vs. skills pinned to your installed version](/blog-assets/from-docs-to-agents/diagram-split-brain.svg)
 
-Each skill declares which docs it was derived from:
+A skill is a short, versioned document that tells agents how to use a specific capability of your library — correct patterns, common mistakes, and when to apply them. Each skill declares which docs it was derived from:
 
 ```
 ---


### PR DESCRIPTION
## Summary
- Say "Agent Skills spec" instead of "Agent Skills is" for clarity
- Use "popular, stable patterns" framing (center/frontier) instead of listing specific libraries
- Simplify skill intro sentence
- Expand feedback loop section — skills compound via npm update
- Add "skills that dissolve" paragraph about skills signaling API design gaps

## Context
Follow-up to #745 with additional copy refinements from review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)