### PR TITLE
fix: remove Suspense from hero splash logo

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,6 +27,7 @@ import { Card } from '~/components/Card'
 import LibraryCard from '~/components/LibraryCard'
 import { FeaturedShowcases } from '~/components/ShowcaseSection'
 import { Button } from '~/ui'
+import { BrandContextMenu } from '~/components/BrandContextMenu'
 
 export const textColors = [
   `text-rose-500`,
@@ -121,25 +122,27 @@ function Index() {
                   />
                 </Link>
               </ClientOnly>
-              <NetlifyImage
-                src="/images/logos/splash-light.png"
-                width={500}
-                height={500}
-                quality={85}
-                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
-                alt="TanStack Logo"
-                loading="eager"
-                fetchPriority="high"
-              />
-              <NetlifyImage
-                src="/images/logos/splash-dark.png"
-                width={500}
-                height={500}
-                quality={85}
-                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
-                alt="TanStack Logo"
-                loading="lazy"
-              />
+              <BrandContextMenu className="cursor-pointer relative z-10">
+                <NetlifyImage
+                  src="/images/logos/splash-light.png"
+                  width={500}
+                  height={500}
+                  quality={85}
+                  className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
+                  alt="TanStack Logo"
+                  loading="eager"
+                  fetchPriority="high"
+                />
+                <NetlifyImage
+                  src="/images/logos/splash-dark.png"
+                  width={500}
+                  height={500}
+                  quality={85}
+                  className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
+                  alt="TanStack Logo"
+                  loading="lazy"
+                />
+              </BrandContextMenu>
             </div>
             <div className="flex flex-col items-center gap-6 text-center px-4 xl:text-left xl:items-start">
               <div className="flex gap-2 lg:gap-4 items-center">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -28,12 +28,6 @@ import LibraryCard from '~/components/LibraryCard'
 import { FeaturedShowcases } from '~/components/ShowcaseSection'
 import { Button } from '~/ui'
 
-const LazyBrandContextMenu = React.lazy(() =>
-  import('~/components/BrandContextMenu').then((m) => ({
-    default: m.BrandContextMenu,
-  })),
-)
-
 export const textColors = [
   `text-rose-500`,
   `text-yellow-500`,
@@ -127,55 +121,26 @@ function Index() {
                   />
                 </Link>
               </ClientOnly>
-              <React.Suspense
-                fallback={
-                  <div className="cursor-pointer relative z-10">
-                    <NetlifyImage
-                      src="/images/logos/splash-light.png"
-                      width={500}
-                      height={500}
-                      quality={85}
-                      className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
-                      alt="TanStack Logo"
-                      loading="eager"
-                      fetchPriority="high"
-                    />
-                    <NetlifyImage
-                      src="/images/logos/splash-dark.png"
-                      width={500}
-                      height={500}
-                      quality={85}
-                      className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
-                      alt="TanStack Logo"
-                      loading="eager"
-                      fetchPriority="high"
-                    />
-                  </div>
-                }
-              >
-                <LazyBrandContextMenu className="cursor-pointer relative z-10">
-                  <NetlifyImage
-                    src="/images/logos/splash-light.png"
-                    width={500}
-                    height={500}
-                    quality={85}
-                    className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
-                    alt="TanStack Logo"
-                    loading="eager"
-                    fetchPriority="high"
-                  />
-                  <NetlifyImage
-                    src="/images/logos/splash-dark.png"
-                    width={500}
-                    height={500}
-                    quality={85}
-                    className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
-                    alt="TanStack Logo"
-                    loading="eager"
-                    fetchPriority="high"
-                  />
-                </LazyBrandContextMenu>
-              </React.Suspense>
+              <NetlifyImage
+                src="/images/logos/splash-light.png"
+                width={500}
+                height={500}
+                quality={85}
+                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
+                alt="TanStack Logo"
+                loading="eager"
+                fetchPriority="high"
+              />
+              <NetlifyImage
+                src="/images/logos/splash-dark.png"
+                width={500}
+                height={500}
+                quality={85}
+                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
+                alt="TanStack Logo"
+                loading="eager"
+                fetchPriority="high"
+              />
             </div>
             <div className="flex flex-col items-center gap-6 text-center px-4 xl:text-left xl:items-start">
               <div className="flex gap-2 lg:gap-4 items-center">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -126,10 +126,19 @@ function Index() {
                 width={500}
                 height={500}
                 quality={85}
-                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px]"
+                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
                 alt="TanStack Logo"
                 loading="eager"
                 fetchPriority="high"
+              />
+              <NetlifyImage
+                src="/images/logos/splash-dark.png"
+                width={500}
+                height={500}
+                quality={85}
+                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
+                alt="TanStack Logo"
+                loading="lazy"
               />
             </div>
             <div className="flex flex-col items-center gap-6 text-center px-4 xl:text-left xl:items-start">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -126,17 +126,7 @@ function Index() {
                 width={500}
                 height={500}
                 quality={85}
-                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] dark:hidden"
-                alt="TanStack Logo"
-                loading="eager"
-                fetchPriority="high"
-              />
-              <NetlifyImage
-                src="/images/logos/splash-dark.png"
-                width={500}
-                height={500}
-                quality={85}
-                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px] hidden dark:block"
+                className="w-[300px] pt-8 xl:pt-0 xl:w-[400px] 2xl:w-[500px]"
                 alt="TanStack Logo"
                 loading="eager"
                 fetchPriority="high"


### PR DESCRIPTION
## Summary

- Remove `React.Suspense` / `LazyBrandContextMenu` wrapper around the hero splash logo images
- The Suspense fallback and loaded state rendered identical images but with different wrapper elements (`<div>` vs `<BrandContextMenu>`), causing layout shift on every page load
- Images are now rendered directly — no lazy loading needed since they're the same in both states

## Test plan

- [ ] Hard refresh home page — splash logo should not shift/shake
- [ ] Verify dark mode splash logo still displays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed deferred loading around the brand/context area so splash imagery is rendered directly, improving visual stability and eliminating initial flicker across light/dark themes.
* **Performance**
  * Dark-theme splash image now lazy-loaded while light splash remains eager, reducing initial bandwidth and speeding perceived load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->