### PR TITLE
fix: preload Inter font and use font-display: optional

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -76,6 +76,13 @@ export const Route = createRootRouteWithContext<{
       }),
     ],
     links: [
+      {
+        rel: 'preload',
+        href: '/fonts/Inter-latin.woff2',
+        as: 'font',
+        type: 'font/woff2',
+        crossOrigin: 'anonymous',
+      },
       { rel: 'stylesheet', href: appCss },
       {
         rel: 'preload',

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -807,7 +807,7 @@ mark {
 }
 
 @font-face {
-  font-display: swap;
+  font-display: optional;
   font-family: 'Inter';
   font-style: normal;
   font-weight: 100 900;
@@ -819,7 +819,7 @@ mark {
 }
 
 @font-face {
-  font-display: swap;
+  font-display: optional;
   font-family: 'Inter';
   font-style: normal;
   font-weight: 100 900;


### PR DESCRIPTION
## Summary

- Preload the latin Inter woff2 font file so it's available before first paint
- Switch `font-display` from `swap` to `optional` — the browser uses the font if cached, otherwise sticks with the fallback, eliminating text reflow CLS

## Test plan

- [ ] Hard refresh home page — H1 and body text should not reflow/shift
- [ ] Verify Inter font still loads and displays on subsequent navigations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Preloaded the Inter font to speed up initial page rendering.
  * Changed font display behavior to "optional" to reduce layout shifts and improve perceived loading consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->