### PR TITLE
fix: match navbar Suspense fallback to loaded wrapper

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -272,12 +272,14 @@ export function Navbar({ children }: { children: React.ReactNode }) {
         <div className="flex items-center gap-2 font-black text-xl uppercase min-w-0">
           <React.Suspense
             fallback={
-              <LogoSection
-                menuButtonRef={menuButtonRef}
-                setShowMenu={setShowMenu}
-                showMenu={showMenu}
-                title={Title}
-              />
+              <div className={twMerge(`flex items-center group flex-shrink-0`)}>
+                <LogoSection
+                  menuButtonRef={menuButtonRef}
+                  setShowMenu={setShowMenu}
+                  showMenu={showMenu}
+                  title={Title}
+                />
+              </div>
             }
           >
             <LazyBrandContextMenu


### PR DESCRIPTION
## Summary

- Wrap the Suspense fallback `LogoSection` in a `<div>` with the same `flex items-center group flex-shrink-0` classes that `LazyBrandContextMenu` uses
- Without this, the fallback has no wrapper while the loaded state does, causing a layout shift when the lazy component resolves

## Test plan

- [ ] Navbar logo should not shift when BrandContextMenu loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated logo/brand area loading layout so the logo region preserves alignment and spacing during content loading, improving visual consistency and reducing layout shifts in the navigation bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->