### PR TITLE
fix: use current location for canonical URL during SSR

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -185,7 +185,7 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
   }, [isNavigating])
 
   const canonicalPath = useRouterState({
-    select: (s) => s.resolvedLocation?.pathname || '/',
+    select: (s) => s.location?.pathname || '/',
   })
 
   const preferredCanonicalPath = getCanonicalPath(canonicalPath)


### PR DESCRIPTION
The canonical path selector read from `state.resolvedLocation`, which
represents the previously resolved location and is undefined on the
initial SSR render. That made every server-rendered page fall back to
`/`, so blog posts (and every other route) emitted
`<link rel="canonical" href="https://tanstack.com/">`. Mobile share
sheets that honor the canonical then shared the root URL instead of the
actual post.

Switch to `state.location`, which is always populated with the current
requested location.

https://claude.ai/code/session_01UdssKwjy5SkB6gbB9y6XZS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed canonical URL and search indexing metadata calculation to use the correct routing source for accurate page identification and indexing directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->