### PR TITLE
fix: codeblock header border-radius

### DIFF
--- a/src/components/markdown/CodeBlockView.tsx
+++ b/src/components/markdown/CodeBlockView.tsx
@@ -37,7 +37,7 @@ export function CodeBlockView({
       style={style}
     >
       {(title || showTypeCopyButton) && (
-        <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-900">
+        <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-900 rounded-t-md">
           <div className="text-xs text-gray-700 dark:text-gray-300">
             {title || (lang?.toLowerCase() === 'bash' ? 'sh' : (lang ?? ''))}
           </div>


### PR DESCRIPTION
## Summary
The codeblock header is missing `rounded-t-md`, causing a visual inconsistency
between the container's border-radius and the header background.

## Screenshots
| Before | After |
|--------|-------|
| <img width="317" height="220" alt="스크린샷 2026-04-15 12 08 24" src="https://github.com/user-attachments/assets/94056c06-4ce0-488b-94d5-ab5f206ead3a" /> | <img width="317" height="220" alt="스크린샷 2026-04-15 12 08 38" src="https://github.com/user-attachments/assets/d20a932b-18dd-4fa3-833e-de2e6cb04f3c" /> |

## Changes
- Add `rounded-t-md` to the header element in `CodeBlockView.tsx`


Issue: [#827](https://github.com/TanStack/tanstack.com/issues/827)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added rounded top corners to code block headers for improved visual presentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->