### PR TITLE
feat(shop): collections, search, policies, PDP gallery, qty, cart drawer, discounts

### DIFF
--- a/src/components/NavbarCartButton.tsx
+++ b/src/components/NavbarCartButton.tsx
@@ -1,7 +1,8 @@
-import { Link, useLocation } from '@tanstack/react-router'
+import { useLocation } from '@tanstack/react-router'
 import { ShoppingCart } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 import { useCart } from '~/hooks/useCart'
+import { useCartDrawerStore } from '~/components/shop/cartDrawerStore'
 
 /**
  * Cart button in the main Navbar.
@@ -10,17 +11,22 @@ import { useCart } from '~/hooks/useCart'
  *   • Always visible on /shop/* routes (even at zero items)
  *   • Site-wide when the cart has at least one item
  *   • Hidden elsewhere when the cart is empty
+ *
+ * Click opens the global CartDrawer — no navigation, so the user keeps
+ * their place in the docs or blog while reviewing their cart.
  */
 export function NavbarCartButton() {
   const { pathname } = useLocation()
   const { totalQuantity } = useCart()
+  const openDrawer = useCartDrawerStore((s) => s.openDrawer)
   const onShopRoute = pathname === '/shop' || pathname.startsWith('/shop/')
 
   if (!onShopRoute && totalQuantity === 0) return null
 
   return (
-    <Link
-      to="/shop/cart"
+    <button
+      type="button"
+      onClick={openDrawer}
       aria-label={totalQuantity > 0 ? `Cart (${totalQuantity} items)` : 'Cart'}
       className={twMerge(
         'relative flex items-center justify-center',
@@ -41,6 +47,6 @@ export function NavbarCartButton() {
           {totalQuantity > 99 ? '99+' : totalQuantity}
         </span>
       ) : null}
-    </Link>
+    </button>
   )
 }

--- a/src/components/shop/Breadcrumbs.tsx
+++ b/src/components/shop/Breadcrumbs.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { Link } from '@tanstack/react-router'
+import { ChevronRight } from 'lucide-react'
+
+export type Crumb = {
+  label: string
+  href?: string
+}
+
+/**
+ * Accessible breadcrumb trail. The last crumb renders as plain text
+ * (current location); intermediate crumbs link back.
+ */
+export function Breadcrumbs({ crumbs }: { crumbs: Array<Crumb> }) {
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm">
+      <ol className="flex items-center gap-1.5 flex-wrap text-gray-600 dark:text-gray-400">
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1
+          return (
+            <React.Fragment key={`${crumb.label}-${i}`}>
+              <li>
+                {crumb.href && !isLast ? (
+                  <Link
+                    to={crumb.href}
+                    className="hover:text-black dark:hover:text-white transition-colors"
+                  >
+                    {crumb.label}
+                  </Link>
+                ) : (
+                  <span
+                    aria-current={isLast ? 'page' : undefined}
+                    className={
+                      isLast ? 'text-black dark:text-white font-medium' : ''
+                    }
+                  >
+                    {crumb.label}
+                  </span>
+                )}
+              </li>
+              {isLast ? null : (
+                <li aria-hidden="true" className="text-gray-400">
+                  <ChevronRight className="w-3.5 h-3.5" />
+                </li>
+              )}
+            </React.Fragment>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/src/components/shop/CartDrawer.tsx
+++ b/src/components/shop/CartDrawer.tsx
@@ -1,0 +1,240 @@
+import * as React from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { Link } from '@tanstack/react-router'
+import { Minus, Plus, ShoppingCart, Trash2, X } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { useCart, useRemoveCartLine, useUpdateCartLine } from '~/hooks/useCart'
+import { formatMoney, shopifyImageUrl } from '~/utils/shopify-format'
+import type { CartLineDetail } from '~/utils/shopify-queries'
+
+type CartDrawerProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Slide-in cart drawer. Shares state with /shop/cart through the same
+ * useCart React Query key, so adds in the drawer mirror the full page
+ * and vice-versa. Pinned to the right on desktop; full-width slide-up on
+ * mobile would be nice later, but a right-anchored sheet is the standard
+ * Shopify-theme pattern and works on phones too.
+ */
+export function CartDrawer({ open, onOpenChange }: CartDrawerProps) {
+  const { cart, totalQuantity } = useCart()
+  const hasLines = !!cart && cart.lines.nodes.length > 0
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={twMerge(
+            'fixed inset-0 z-50 bg-black/40',
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+          )}
+        />
+        <Dialog.Content
+          className={twMerge(
+            'fixed right-0 top-0 bottom-0 z-50 w-full sm:max-w-md flex flex-col',
+            'bg-white dark:bg-gray-950 shadow-xl border-l border-gray-200 dark:border-gray-800',
+            'data-[state=open]:animate-in data-[state=open]:slide-in-from-right',
+            'data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right',
+          )}
+          aria-describedby={undefined}
+        >
+          <header className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800">
+            <Dialog.Title className="font-semibold">
+              Cart{totalQuantity > 0 ? ` (${totalQuantity})` : ''}
+            </Dialog.Title>
+            <Dialog.Close
+              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-900"
+              aria-label="Close cart"
+            >
+              <X className="w-4 h-4" />
+            </Dialog.Close>
+          </header>
+
+          {hasLines ? (
+            <>
+              <ul className="flex-1 overflow-y-auto px-6 divide-y divide-gray-200 dark:divide-gray-800">
+                {cart.lines.nodes.map((line) => (
+                  <DrawerCartLine
+                    key={line.id}
+                    line={line}
+                    onClose={() => onOpenChange(false)}
+                  />
+                ))}
+              </ul>
+              <DrawerFooter cart={cart} onClose={() => onOpenChange(false)} />
+            </>
+          ) : (
+            <DrawerEmpty onClose={() => onOpenChange(false)} />
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function DrawerEmpty({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-4 p-6 text-center">
+      <ShoppingCart className="w-10 h-10 text-gray-400" />
+      <p className="text-gray-600 dark:text-gray-400">Your cart is empty.</p>
+      <Link
+        to="/shop"
+        onClick={onClose}
+        className="inline-flex items-center px-4 py-2 rounded-lg bg-black text-white dark:bg-white dark:text-black font-semibold"
+      >
+        Shop all products
+      </Link>
+    </div>
+  )
+}
+
+function DrawerFooter({
+  cart,
+  onClose,
+}: {
+  cart: NonNullable<ReturnType<typeof useCart>['cart']>
+  onClose: () => void
+}) {
+  const subtotal = cart.cost.subtotalAmount
+  return (
+    <footer className="border-t border-gray-200 dark:border-gray-800 px-6 py-4 flex flex-col gap-3">
+      <div className="flex justify-between text-sm">
+        <span className="text-gray-600 dark:text-gray-400">Subtotal</span>
+        <span className="font-semibold">
+          {formatMoney(subtotal.amount, subtotal.currencyCode)}
+        </span>
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-500">
+        Shipping and taxes calculated at checkout.
+      </p>
+      <a
+        href={cart.checkoutUrl}
+        className="w-full text-center px-6 py-3 rounded-lg bg-black text-white dark:bg-white dark:text-black font-semibold"
+      >
+        Checkout
+      </a>
+      <Link
+        to="/shop/cart"
+        onClick={onClose}
+        className="w-full text-center text-sm text-gray-600 dark:text-gray-400 hover:underline"
+      >
+        View cart
+      </Link>
+    </footer>
+  )
+}
+
+function DrawerCartLine({
+  line,
+  onClose,
+}: {
+  line: CartLineDetail
+  onClose: () => void
+}) {
+  const update = useUpdateCartLine()
+  const remove = useRemoveCartLine()
+  const { merchandise } = line
+  const options = merchandise.selectedOptions
+    .filter((o) => o.name.toLowerCase() !== 'title')
+    .map((o) => `${o.name}: ${o.value}`)
+    .join(' · ')
+
+  const isBusy = update.isPending || remove.isPending
+
+  return (
+    <li className="flex gap-3 py-4">
+      <Link
+        to="/shop/products/$handle"
+        params={{ handle: merchandise.product.handle }}
+        onClick={onClose}
+        className="shrink-0"
+      >
+        <div className="w-16 h-16 rounded-lg overflow-hidden bg-gray-100 dark:bg-gray-900">
+          {merchandise.image ? (
+            <img
+              src={shopifyImageUrl(merchandise.image.url, {
+                width: 160,
+                format: 'webp',
+              })}
+              alt={merchandise.image.altText ?? merchandise.product.title}
+              className="h-full w-full object-cover"
+            />
+          ) : null}
+        </div>
+      </Link>
+      <div className="flex-1 min-w-0 flex flex-col gap-1">
+        <Link
+          to="/shop/products/$handle"
+          params={{ handle: merchandise.product.handle }}
+          onClick={onClose}
+          className="text-sm font-semibold hover:underline truncate"
+        >
+          {merchandise.product.title}
+        </Link>
+        {options ? (
+          <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
+            {options}
+          </p>
+        ) : null}
+        <div className="flex items-center justify-between mt-1">
+          <div className="inline-flex items-center rounded-md border border-gray-200 dark:border-gray-800 text-xs">
+            <button
+              type="button"
+              onClick={() => {
+                if (line.quantity <= 1) {
+                  remove.mutate({ lineId: line.id })
+                } else {
+                  update.mutate({
+                    lineId: line.id,
+                    quantity: line.quantity - 1,
+                  })
+                }
+              }}
+              disabled={isBusy}
+              aria-label="Decrease quantity"
+              className="p-1.5 disabled:opacity-50"
+            >
+              <Minus className="w-3 h-3" />
+            </button>
+            <span className="min-w-[1.5rem] text-center">{line.quantity}</span>
+            <button
+              type="button"
+              onClick={() =>
+                update.mutate({
+                  lineId: line.id,
+                  quantity: line.quantity + 1,
+                })
+              }
+              disabled={isBusy}
+              aria-label="Increase quantity"
+              className="p-1.5 disabled:opacity-50"
+            >
+              <Plus className="w-3 h-3" />
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">
+              {formatMoney(
+                line.cost.totalAmount.amount,
+                line.cost.totalAmount.currencyCode,
+              )}
+            </span>
+            <button
+              type="button"
+              onClick={() => remove.mutate({ lineId: line.id })}
+              disabled={isBusy}
+              aria-label="Remove from cart"
+              className="p-1 rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/src/components/shop/ProductCard.tsx
+++ b/src/components/shop/ProductCard.tsx
@@ -1,0 +1,64 @@
+import { Link } from '@tanstack/react-router'
+import { twMerge } from 'tailwind-merge'
+import { ProductImage } from './ProductImage'
+import { formatMoney } from '~/utils/shopify-format'
+import type { ProductListItem } from '~/utils/shopify-queries'
+
+type ProductCardProps = {
+  product: ProductListItem
+  sizes?: string
+  loading?: 'eager' | 'lazy'
+}
+
+/**
+ * Grid tile for a product. Handles compare-at-price strike-through and
+ * the "from $X" treatment when a product has variants at different prices.
+ */
+export function ProductCard({
+  product,
+  sizes,
+  loading = 'lazy',
+}: ProductCardProps) {
+  const { minVariantPrice, maxVariantPrice } = product.priceRange
+  const compareAt = product.compareAtPriceRange?.minVariantPrice
+  const isRange = minVariantPrice.amount !== maxVariantPrice.amount
+  const isDiscounted =
+    compareAt && Number(compareAt.amount) > Number(minVariantPrice.amount)
+
+  return (
+    <Link
+      to="/shop/products/$handle"
+      params={{ handle: product.handle }}
+      className="group flex flex-col gap-3"
+    >
+      <div className="aspect-square overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900">
+        <ProductImage
+          image={product.featuredImage}
+          alt={product.title}
+          width={600}
+          sizes={sizes}
+          loading={loading}
+          className="transition-transform duration-300 group-hover:scale-105"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="font-semibold line-clamp-2">{product.title}</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 flex items-baseline gap-2">
+          <span>
+            {isRange ? 'From ' : ''}
+            {formatMoney(minVariantPrice.amount, minVariantPrice.currencyCode)}
+          </span>
+          {isDiscounted ? (
+            <span
+              className={twMerge(
+                'text-xs line-through text-gray-400 dark:text-gray-500',
+              )}
+            >
+              {formatMoney(compareAt.amount, compareAt.currencyCode)}
+            </span>
+          ) : null}
+        </p>
+      </div>
+    </Link>
+  )
+}

--- a/src/components/shop/ProductImage.tsx
+++ b/src/components/shop/ProductImage.tsx
@@ -1,0 +1,66 @@
+import { twMerge } from 'tailwind-merge'
+import { shopifyImageUrl } from '~/utils/shopify-format'
+
+type ShopifyImageFields = {
+  url: string
+  altText?: string | null
+  width?: number | null
+  height?: number | null
+}
+
+type ProductImageProps = {
+  image: ShopifyImageFields | null | undefined
+  alt: string
+  /** Intrinsic width rendered for layout. The srcset still covers multiple DPRs. */
+  width: number
+  /**
+   * Viewport widths this image occupies, for correct `sizes` hinting.
+   * Default assumes 1–4 column grid. Override for hero/PDP placements.
+   */
+  sizes?: string
+  loading?: 'eager' | 'lazy'
+  className?: string
+}
+
+/**
+ * Responsive Shopify CDN image. Emits a srcset with DPR-aware widths so
+ * retina gets sharper pixels and mobile doesn't download desktop-sized
+ * assets. Shopify's CDN serves WebP on-the-fly via `?format=webp`.
+ */
+export function ProductImage({
+  image,
+  alt,
+  width,
+  sizes = '(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 100vw',
+  loading = 'lazy',
+  className,
+}: ProductImageProps) {
+  if (!image) return null
+  const aspect = image.width && image.height ? image.width / image.height : 1
+  const height = Math.round(width / aspect)
+
+  // Provide 1x, 1.5x, 2x, 3x variants bounded by the image's intrinsic width.
+  const multipliers = [1, 1.5, 2, 3]
+  const srcset = multipliers
+    .map((m) => Math.round(width * m))
+    .filter((w, i, arr) => w <= (image.width ?? w) && arr.indexOf(w) === i)
+    .map(
+      (w) =>
+        `${shopifyImageUrl(image.url, { width: w, format: 'webp' })} ${w}w`,
+    )
+    .join(', ')
+
+  return (
+    <img
+      src={shopifyImageUrl(image.url, { width, format: 'webp' })}
+      srcSet={srcset}
+      sizes={sizes}
+      alt={image.altText ?? alt}
+      width={width}
+      height={height}
+      loading={loading}
+      decoding="async"
+      className={twMerge('h-full w-full object-cover', className)}
+    />
+  )
+}

--- a/src/components/shop/ShopLayout.tsx
+++ b/src/components/shop/ShopLayout.tsx
@@ -3,8 +3,10 @@ import { Link, useLocation } from '@tanstack/react-router'
 import {
   ChevronLeft,
   ChevronRight,
+  FileText,
   Menu,
   Package,
+  Search,
   ShoppingBag,
   ShoppingCart,
   X,
@@ -12,11 +14,20 @@ import {
 import { twMerge } from 'tailwind-merge'
 import { useLocalStorage } from '~/utils/useLocalStorage'
 import type { CollectionListItem } from '~/utils/shopify-queries'
+import { CartDrawer } from './CartDrawer'
+import { useCartDrawerStore } from './cartDrawerStore'
 
 type ShopLayoutProps = {
   collections: Array<CollectionListItem>
   children: React.ReactNode
 }
+
+const POLICY_PAGES = [
+  { handle: 'shipping-policy', label: 'Shipping' },
+  { handle: 'refund-policy', label: 'Returns' },
+  { handle: 'privacy-policy', label: 'Privacy' },
+  { handle: 'terms-of-service', label: 'Terms' },
+] as const
 
 /**
  * /shop layout: persistent left sidebar on md+, slide-in drawer on mobile.
@@ -139,8 +150,16 @@ export function ShopLayout({ collections, children }: ShopLayoutProps) {
       >
         {children}
       </main>
+
+      <GlobalCartDrawer />
     </div>
   )
+}
+
+function GlobalCartDrawer() {
+  const open = useCartDrawerStore((s) => s.open)
+  const setOpen = useCartDrawerStore((s) => s.setOpen)
+  return <CartDrawer open={open} onOpenChange={setOpen} />
 }
 
 function ShopSidebarNav({
@@ -162,6 +181,13 @@ function ShopSidebarNav({
           showLabels={showLabels}
           onNavigate={onNavigate}
           exact
+        />
+        <SidebarLink
+          to="/shop/search"
+          label="Search"
+          icon={Search}
+          showLabels={showLabels}
+          onNavigate={onNavigate}
         />
         <SidebarLink
           to="/shop/cart"
@@ -187,6 +213,20 @@ function ShopSidebarNav({
           ))}
         </SidebarSection>
       ) : null}
+
+      <SidebarSection label="Info" showLabels={showLabels}>
+        {POLICY_PAGES.map((page) => (
+          <SidebarLink
+            key={page.handle}
+            to="/shop/pages/$handle"
+            params={{ handle: page.handle }}
+            label={page.label}
+            icon={FileText}
+            showLabels={showLabels}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </SidebarSection>
     </nav>
   )
 }

--- a/src/components/shop/cartDrawerStore.ts
+++ b/src/components/shop/cartDrawerStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+
+/**
+ * Tiny store that controls the global cart drawer's open state. Kept in a
+ * module rather than React context so any component — the navbar button,
+ * the "Add to cart" button on the PDP, etc. — can trigger it without
+ * threading props.
+ */
+export const useCartDrawerStore = create<{
+  open: boolean
+  setOpen: (open: boolean) => void
+  openDrawer: () => void
+  closeDrawer: () => void
+}>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  openDrawer: () => set({ open: true }),
+  closeDrawer: () => set({ open: false }),
+}))

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   addToCart,
+  applyDiscountCode,
   getCart,
   removeCartLine,
+  removeDiscountCode,
   updateCartLine,
 } from '~/utils/shop.functions'
 import type { CartDetail } from '~/utils/shopify-queries'
@@ -151,6 +153,48 @@ export function useRemoveCartLine() {
       qc.setQueryData(CART_QUERY_KEY, cart)
     },
 
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: CART_QUERY_KEY })
+    },
+  })
+}
+
+export function useApplyDiscountCode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { code: string }) =>
+      applyDiscountCode({ data: { code: input.code } }),
+    onSuccess: (cart) => {
+      qc.setQueryData(CART_QUERY_KEY, cart)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: CART_QUERY_KEY })
+    },
+  })
+}
+
+export function useRemoveDiscountCode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => removeDiscountCode(),
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: CART_QUERY_KEY })
+      const previous = qc.getQueryData<CartDetail | null>(CART_QUERY_KEY)
+      if (previous) {
+        qc.setQueryData<CartDetail | null>(CART_QUERY_KEY, {
+          ...previous,
+          discountCodes: [],
+        })
+      }
+      return { previous }
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.previous !== undefined)
+        qc.setQueryData(CART_QUERY_KEY, ctx.previous)
+    },
+    onSuccess: (cart) => {
+      qc.setQueryData(CART_QUERY_KEY, cart)
+    },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: CART_QUERY_KEY })
     },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as AccountIndexRouteImport } from './routes/account/index'
 import { Route as LibraryIdIndexRouteImport } from './routes/$libraryId/index'
 import { Route as ShowcaseSubmitRouteImport } from './routes/showcase/submit'
 import { Route as ShowcaseIdRouteImport } from './routes/showcase/$id'
+import { Route as ShopSearchRouteImport } from './routes/shop.search'
 import { Route as ShopCartRouteImport } from './routes/shop.cart'
 import { Route as PartnersPartnerRouteImport } from './routes/partners.$partner'
 import { Route as OauthTokenRouteImport } from './routes/oauth/token'
@@ -102,6 +103,8 @@ import { Route as LibraryIdVersionIndexRouteImport } from './routes/$libraryId/$
 import { Route as StatsNpmPackagesRouteImport } from './routes/stats/npm/$packages'
 import { Route as ShowcaseEditIdRouteImport } from './routes/showcase/edit.$id'
 import { Route as ShopProductsHandleRouteImport } from './routes/shop.products.$handle'
+import { Route as ShopPagesHandleRouteImport } from './routes/shop.pages.$handle'
+import { Route as ShopCollectionsHandleRouteImport } from './routes/shop.collections.$handle'
 import { Route as IntentRegistryPackageNameRouteImport } from './routes/intent/registry/$packageName'
 import { Route as AuthProviderStartRouteImport } from './routes/auth/$provider/start'
 import { Route as ApiMcpSplatRouteImport } from './routes/api/mcp/$'
@@ -355,6 +358,11 @@ const ShowcaseIdRoute = ShowcaseIdRouteImport.update({
   id: '/showcase/$id',
   path: '/showcase/$id',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ShopSearchRoute = ShopSearchRouteImport.update({
+  id: '/search',
+  path: '/search',
+  getParentRoute: () => ShopRoute,
 } as any)
 const ShopCartRoute = ShopCartRouteImport.update({
   id: '/cart',
@@ -610,6 +618,16 @@ const ShowcaseEditIdRoute = ShowcaseEditIdRouteImport.update({
 const ShopProductsHandleRoute = ShopProductsHandleRouteImport.update({
   id: '/products/$handle',
   path: '/products/$handle',
+  getParentRoute: () => ShopRoute,
+} as any)
+const ShopPagesHandleRoute = ShopPagesHandleRouteImport.update({
+  id: '/pages/$handle',
+  path: '/pages/$handle',
+  getParentRoute: () => ShopRoute,
+} as any)
+const ShopCollectionsHandleRoute = ShopCollectionsHandleRouteImport.update({
+  id: '/collections/$handle',
+  path: '/collections/$handle',
   getParentRoute: () => ShopRoute,
 } as any)
 const IntentRegistryPackageNameRoute =
@@ -906,6 +924,7 @@ export interface FileRoutesByFullPath {
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
   '/shop/cart': typeof ShopCartRoute
+  '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
   '/showcase/submit': typeof ShowcaseSubmitRoute
   '/$libraryId/': typeof LibraryIdIndexRoute
@@ -941,6 +960,8 @@ export interface FileRoutesByFullPath {
   '/api/mcp/$': typeof ApiMcpSplatRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
   '/intent/registry/$packageName': typeof IntentRegistryPackageNameRouteWithChildren
+  '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
+  '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/products/$handle': typeof ShopProductsHandleRoute
   '/showcase/edit/$id': typeof ShowcaseEditIdRoute
   '/stats/npm/$packages': typeof StatsNpmPackagesRoute
@@ -1036,6 +1057,7 @@ export interface FileRoutesByTo {
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
   '/shop/cart': typeof ShopCartRoute
+  '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
   '/showcase/submit': typeof ShowcaseSubmitRoute
   '/$libraryId': typeof LibraryIdIndexRoute
@@ -1069,6 +1091,8 @@ export interface FileRoutesByTo {
   '/api/github/webhook': typeof ApiGithubWebhookRoute
   '/api/mcp/$': typeof ApiMcpSplatRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
+  '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
+  '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/products/$handle': typeof ShopProductsHandleRoute
   '/showcase/edit/$id': typeof ShowcaseEditIdRoute
   '/stats/npm/$packages': typeof StatsNpmPackagesRoute
@@ -1173,6 +1197,7 @@ export interface FileRoutesById {
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
   '/shop/cart': typeof ShopCartRoute
+  '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
   '/showcase/submit': typeof ShowcaseSubmitRoute
   '/$libraryId/': typeof LibraryIdIndexRoute
@@ -1208,6 +1233,8 @@ export interface FileRoutesById {
   '/api/mcp/$': typeof ApiMcpSplatRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
   '/intent/registry/$packageName': typeof IntentRegistryPackageNameRouteWithChildren
+  '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
+  '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/products/$handle': typeof ShopProductsHandleRoute
   '/showcase/edit/$id': typeof ShowcaseEditIdRoute
   '/stats/npm/$packages': typeof StatsNpmPackagesRoute
@@ -1313,6 +1340,7 @@ export interface FileRouteTypes {
     | '/oauth/token'
     | '/partners/$partner'
     | '/shop/cart'
+    | '/shop/search'
     | '/showcase/$id'
     | '/showcase/submit'
     | '/$libraryId/'
@@ -1348,6 +1376,8 @@ export interface FileRouteTypes {
     | '/api/mcp/$'
     | '/auth/$provider/start'
     | '/intent/registry/$packageName'
+    | '/shop/collections/$handle'
+    | '/shop/pages/$handle'
     | '/shop/products/$handle'
     | '/showcase/edit/$id'
     | '/stats/npm/$packages'
@@ -1443,6 +1473,7 @@ export interface FileRouteTypes {
     | '/oauth/token'
     | '/partners/$partner'
     | '/shop/cart'
+    | '/shop/search'
     | '/showcase/$id'
     | '/showcase/submit'
     | '/$libraryId'
@@ -1476,6 +1507,8 @@ export interface FileRouteTypes {
     | '/api/github/webhook'
     | '/api/mcp/$'
     | '/auth/$provider/start'
+    | '/shop/collections/$handle'
+    | '/shop/pages/$handle'
     | '/shop/products/$handle'
     | '/showcase/edit/$id'
     | '/stats/npm/$packages'
@@ -1579,6 +1612,7 @@ export interface FileRouteTypes {
     | '/oauth/token'
     | '/partners/$partner'
     | '/shop/cart'
+    | '/shop/search'
     | '/showcase/$id'
     | '/showcase/submit'
     | '/$libraryId/'
@@ -1614,6 +1648,8 @@ export interface FileRouteTypes {
     | '/api/mcp/$'
     | '/auth/$provider/start'
     | '/intent/registry/$packageName'
+    | '/shop/collections/$handle'
+    | '/shop/pages/$handle'
     | '/shop/products/$handle'
     | '/showcase/edit/$id'
     | '/stats/npm/$packages'
@@ -2049,6 +2085,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShowcaseIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/shop/search': {
+      id: '/shop/search'
+      path: '/search'
+      fullPath: '/shop/search'
+      preLoaderRoute: typeof ShopSearchRouteImport
+      parentRoute: typeof ShopRoute
+    }
     '/shop/cart': {
       id: '/shop/cart'
       path: '/cart'
@@ -2404,6 +2447,20 @@ declare module '@tanstack/react-router' {
       path: '/products/$handle'
       fullPath: '/shop/products/$handle'
       preLoaderRoute: typeof ShopProductsHandleRouteImport
+      parentRoute: typeof ShopRoute
+    }
+    '/shop/pages/$handle': {
+      id: '/shop/pages/$handle'
+      path: '/pages/$handle'
+      fullPath: '/shop/pages/$handle'
+      preLoaderRoute: typeof ShopPagesHandleRouteImport
+      parentRoute: typeof ShopRoute
+    }
+    '/shop/collections/$handle': {
+      id: '/shop/collections/$handle'
+      path: '/collections/$handle'
+      fullPath: '/shop/collections/$handle'
+      preLoaderRoute: typeof ShopCollectionsHandleRouteImport
       parentRoute: typeof ShopRoute
     }
     '/intent/registry/$packageName': {
@@ -2887,13 +2944,19 @@ const PartnersRouteWithChildren = PartnersRoute._addFileChildren(
 
 interface ShopRouteChildren {
   ShopCartRoute: typeof ShopCartRoute
+  ShopSearchRoute: typeof ShopSearchRoute
   ShopIndexRoute: typeof ShopIndexRoute
+  ShopCollectionsHandleRoute: typeof ShopCollectionsHandleRoute
+  ShopPagesHandleRoute: typeof ShopPagesHandleRoute
   ShopProductsHandleRoute: typeof ShopProductsHandleRoute
 }
 
 const ShopRouteChildren: ShopRouteChildren = {
   ShopCartRoute: ShopCartRoute,
+  ShopSearchRoute: ShopSearchRoute,
   ShopIndexRoute: ShopIndexRoute,
+  ShopCollectionsHandleRoute: ShopCollectionsHandleRoute,
+  ShopPagesHandleRoute: ShopPagesHandleRoute,
   ShopProductsHandleRoute: ShopProductsHandleRoute,
 }
 

--- a/src/routes/shop.cart.tsx
+++ b/src/routes/shop.cart.tsx
@@ -1,9 +1,17 @@
+import * as React from 'react'
 import { Link, createFileRoute } from '@tanstack/react-router'
-import { Minus, Plus, ShoppingCart, Trash2 } from 'lucide-react'
+import { Minus, Plus, ShoppingCart, Trash2, X } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
-import { useCart, useRemoveCartLine, useUpdateCartLine } from '~/hooks/useCart'
+import { Breadcrumbs } from '~/components/shop/Breadcrumbs'
+import {
+  useApplyDiscountCode,
+  useCart,
+  useRemoveCartLine,
+  useRemoveDiscountCode,
+  useUpdateCartLine,
+} from '~/hooks/useCart'
 import { formatMoney, shopifyImageUrl } from '~/utils/shopify-format'
-import type { CartLineDetail } from '~/utils/shopify-queries'
+import type { CartDetail, CartLineDetail } from '~/utils/shopify-queries'
 
 export const Route = createFileRoute('/shop/cart')({
   component: CartPage,
@@ -22,6 +30,9 @@ function CartPage() {
 
   return (
     <div className="flex flex-col max-w-4xl mx-auto gap-8 p-4 md:p-8">
+      <Breadcrumbs
+        crumbs={[{ label: 'Shop', href: '/shop' }, { label: 'Cart' }]}
+      />
       <header>
         <h1 className="text-3xl font-black">Cart</h1>
         <p className="text-sm mt-2 text-gray-600 dark:text-gray-400">
@@ -38,6 +49,9 @@ function CartPage() {
 
         <aside className="flex flex-col gap-4 rounded-xl border border-gray-200 dark:border-gray-800 p-6 h-fit">
           <h2 className="font-semibold">Summary</h2>
+
+          <DiscountCodeSection cart={cart} />
+
           <dl className="flex flex-col gap-2 text-sm">
             <div className="flex justify-between">
               <dt className="text-gray-600 dark:text-gray-400">Subtotal</dt>
@@ -65,6 +79,84 @@ function CartPage() {
           </Link>
         </aside>
       </div>
+    </div>
+  )
+}
+
+function DiscountCodeSection({ cart }: { cart: CartDetail }) {
+  const apply = useApplyDiscountCode()
+  const remove = useRemoveDiscountCode()
+  const [input, setInput] = React.useState('')
+
+  const applied = cart.discountCodes.filter((c) => c.applicable)
+
+  // Clear the input after a successful apply so the user can see it landed
+  React.useEffect(() => {
+    if (apply.isSuccess) {
+      setInput('')
+      apply.reset()
+    }
+  }, [apply.isSuccess, apply])
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-gray-200 dark:border-gray-800 pt-3">
+      {applied.length > 0 ? (
+        <ul className="flex flex-col gap-1">
+          {applied.map((d) => (
+            <li
+              key={d.code}
+              className="flex items-center justify-between text-sm"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <span className="px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-900 font-mono text-xs">
+                  {d.code}
+                </span>
+                <span className="text-xs text-gray-500">applied</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => remove.mutate()}
+                disabled={remove.isPending}
+                aria-label={`Remove discount ${d.code}`}
+                className="p-1 rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            const code = input.trim()
+            if (code) apply.mutate({ code })
+          }}
+          className="flex items-center gap-2"
+        >
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Discount code"
+            className="flex-1 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={apply.isPending || input.trim().length === 0}
+            className="px-3 py-1.5 rounded-md bg-black text-white dark:bg-white dark:text-black text-sm font-semibold disabled:opacity-50"
+          >
+            {apply.isPending ? 'Applying…' : 'Apply'}
+          </button>
+        </form>
+      )}
+      {apply.isError ? (
+        <p className="text-xs text-red-600 dark:text-red-400">
+          {apply.error instanceof Error
+            ? apply.error.message
+            : 'Could not apply discount.'}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/src/routes/shop.collections.$handle.tsx
+++ b/src/routes/shop.collections.$handle.tsx
@@ -1,21 +1,24 @@
 import * as React from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router'
 import { useMutation } from '@tanstack/react-query'
 import * as v from 'valibot'
+import { Breadcrumbs } from '~/components/shop/Breadcrumbs'
 import { ProductCard } from '~/components/shop/ProductCard'
-import { getProducts } from '~/utils/shop.functions'
+import { getCollection } from '~/utils/shop.functions'
 import {
-  SORT_OPTIONS,
-  resolveSortOption,
-  sortOptionId,
+  COLLECTION_SORT_OPTIONS,
+  collectionSortOptionId,
+  resolveCollectionSortOption,
   type ProductListItem,
 } from '~/utils/shopify-queries'
+import { seo } from '~/utils/seo'
 
 const searchSchema = v.object({
   sort: v.optional(
     v.picklist([
+      'COLLECTION_DEFAULT',
       'BEST_SELLING',
-      'CREATED_AT:rev',
+      'CREATED:rev',
       'PRICE',
       'PRICE:rev',
       'TITLE',
@@ -23,57 +26,71 @@ const searchSchema = v.object({
   ),
 })
 
-type ValidSortId = NonNullable<v.InferOutput<typeof searchSchema>['sort']>
+type ValidCollectionSortId = NonNullable<
+  v.InferOutput<typeof searchSchema>['sort']
+>
 
 const PAGE_SIZE = 24
 
-export const Route = createFileRoute('/shop/')({
+export const Route = createFileRoute('/shop/collections/$handle')({
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({ sort: search.sort }),
-  loader: async ({ deps }) => {
-    const sortOption = resolveSortOption(deps.sort)
-    const page = await getProducts({
+  loader: async ({ params, deps }) => {
+    const sortOption = resolveCollectionSortOption(deps.sort)
+    const collection = await getCollection({
       data: {
+        handle: params.handle,
         first: PAGE_SIZE,
         sortKey: sortOption.key,
         reverse: sortOption.reverse,
       },
     })
-    return { page, sortId: sortOptionId(sortOption) }
+    if (!collection) throw notFound()
+    return {
+      collection,
+      sortId: collectionSortOptionId(sortOption),
+    }
   },
-  component: ShopIndex,
+  head: ({ loaderData }) => {
+    const c = loaderData?.collection
+    if (!c) return { meta: [] }
+    return {
+      meta: seo({
+        title: `${c.seo.title ?? c.title} | TanStack Shop`,
+        description: c.seo.description ?? c.description ?? undefined,
+      }),
+    }
+  },
+  component: CollectionPage,
 })
 
-function ShopIndex() {
-  const { page, sortId } = Route.useLoaderData()
-  const navigate = useNavigate({ from: '/shop' })
+function CollectionPage() {
+  const { collection, sortId } = Route.useLoaderData()
+  const navigate = useNavigate({ from: '/shop/collections/$handle' })
 
-  // Client-side accumulated pages for the "Load More" path. The first page
-  // always comes from the loader (SSR), subsequent pages append on click.
   const [accumulated, setAccumulated] = React.useState<Array<ProductListItem>>(
     [],
   )
   const [endCursor, setEndCursor] = React.useState<string | null>(
-    page.pageInfo.endCursor,
+    collection.products.pageInfo.endCursor,
   )
   const [hasNextPage, setHasNextPage] = React.useState(
-    page.pageInfo.hasNextPage,
+    collection.products.pageInfo.hasNextPage,
   )
 
-  // Reset accumulated pages whenever the loader-provided first page changes
-  // (e.g. on sort change). The loader's page becomes the new canonical start.
   React.useEffect(() => {
     setAccumulated([])
-    setEndCursor(page.pageInfo.endCursor)
-    setHasNextPage(page.pageInfo.hasNextPage)
-  }, [page])
+    setEndCursor(collection.products.pageInfo.endCursor)
+    setHasNextPage(collection.products.pageInfo.hasNextPage)
+  }, [collection])
 
   const loadMore = useMutation({
     mutationFn: async () => {
       if (!endCursor) return null
-      const sortOption = resolveSortOption(sortId)
-      return getProducts({
+      const sortOption = resolveCollectionSortOption(sortId)
+      return getCollection({
         data: {
+          handle: collection.handle,
           first: PAGE_SIZE,
           after: endCursor,
           sortKey: sortOption.key,
@@ -83,43 +100,52 @@ function ShopIndex() {
     },
     onSuccess: (next) => {
       if (!next) return
-      setAccumulated((prev) => [...prev, ...next.nodes])
-      setEndCursor(next.pageInfo.endCursor)
-      setHasNextPage(next.pageInfo.hasNextPage)
+      setAccumulated((prev) => [...prev, ...next.products.nodes])
+      setEndCursor(next.products.pageInfo.endCursor)
+      setHasNextPage(next.products.pageInfo.hasNextPage)
     },
   })
 
-  const products = [...page.nodes, ...accumulated]
+  const products = [...collection.products.nodes, ...accumulated]
 
   return (
     <div className="flex flex-col max-w-6xl mx-auto gap-8 p-4 md:p-8">
+      <Breadcrumbs
+        crumbs={[{ label: 'Shop', href: '/shop' }, { label: collection.title }]}
+      />
+
       <header className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-black">All Products</h1>
-          <p className="text-sm mt-2 text-gray-600 dark:text-gray-400">
-            {products.length}
-            {hasNextPage ? '+' : ''}{' '}
-            {products.length === 1 ? 'product' : 'products'}
-          </p>
+          <h1 className="text-3xl font-black">{collection.title}</h1>
+          {collection.description ? (
+            <p className="text-sm mt-2 text-gray-600 dark:text-gray-400 max-w-2xl">
+              {collection.description}
+            </p>
+          ) : null}
         </div>
         <label className="flex items-center gap-2 text-sm">
           <span className="text-gray-600 dark:text-gray-400">Sort by</span>
           <select
             value={sortId}
             onChange={(e) => {
-              // Cast is safe: the select only emits ids from SORT_OPTIONS
-              // which align with the valibot search schema.
-              const nextId = e.target.value as ValidSortId
-              // Default sort omits the search param entirely for a clean URL
+              // Cast is safe: the select only emits ids built from
+              // COLLECTION_SORT_OPTIONS, all of which are valid per the
+              // valibot search schema. The generated CollectionSortOptionId
+              // type is a wider permutation set than the schema accepts.
+              const nextId = e.target.value as ValidCollectionSortId
               navigate({
-                to: '/shop',
-                search: nextId === 'BEST_SELLING' ? {} : { sort: nextId },
+                to: '/shop/collections/$handle',
+                params: { handle: collection.handle },
+                search: nextId === 'COLLECTION_DEFAULT' ? {} : { sort: nextId },
               })
             }}
             className="px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm"
           >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={sortOptionId(opt)} value={sortOptionId(opt)}>
+            {COLLECTION_SORT_OPTIONS.map((opt) => (
+              <option
+                key={collectionSortOptionId(opt)}
+                value={collectionSortOptionId(opt)}
+              >
                 {opt.label}
               </option>
             ))}
@@ -129,7 +155,7 @@ function ShopIndex() {
 
       {products.length === 0 ? (
         <div className="text-center py-24 text-gray-500">
-          No products yet. Check back soon!
+          No products in this collection yet.
         </div>
       ) : (
         <>

--- a/src/routes/shop.pages.$handle.tsx
+++ b/src/routes/shop.pages.$handle.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { Breadcrumbs } from '~/components/shop/Breadcrumbs'
+import { getPage } from '~/utils/shop.functions'
+import { seo } from '~/utils/seo'
+
+export const Route = createFileRoute('/shop/pages/$handle')({
+  loader: async ({ params }) => {
+    const page = await getPage({ data: { handle: params.handle } })
+    if (!page) throw notFound()
+    return { page }
+  },
+  head: ({ loaderData }) => {
+    const p = loaderData?.page
+    if (!p) return { meta: [] }
+    return {
+      meta: seo({
+        title: `${p.seo.title ?? p.title} | TanStack Shop`,
+        description: p.seo.description ?? p.bodySummary ?? undefined,
+      }),
+    }
+  },
+  component: ShopPage,
+})
+
+function ShopPage() {
+  const { page } = Route.useLoaderData()
+  return (
+    <article className="flex flex-col max-w-3xl mx-auto gap-8 p-4 md:p-8">
+      <Breadcrumbs
+        crumbs={[{ label: 'Shop', href: '/shop' }, { label: page.title }]}
+      />
+      <header>
+        <h1 className="text-3xl font-black">{page.title}</h1>
+      </header>
+      {page.body ? (
+        <div
+          className="prose dark:prose-invert max-w-none"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: page.body }}
+        />
+      ) : (
+        <p className="text-gray-600 dark:text-gray-400">
+          This page has no content yet.
+        </p>
+      )}
+    </article>
+  )
+}

--- a/src/routes/shop.products.$handle.tsx
+++ b/src/routes/shop.products.$handle.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react'
 import { createFileRoute, notFound } from '@tanstack/react-router'
+import { Minus, Plus } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Breadcrumbs } from '~/components/shop/Breadcrumbs'
+import { ProductImage } from '~/components/shop/ProductImage'
+import { useCartDrawerStore } from '~/components/shop/cartDrawerStore'
+import { useAddToCart } from '~/hooks/useCart'
 import { getProduct } from '~/utils/shop.functions'
-import type {
-  ProductDetail,
-  ProductDetailVariant,
+import {
+  type ProductDetail,
+  type ProductDetailVariant,
 } from '~/utils/shopify-queries'
 import { formatMoney, shopifyImageUrl } from '~/utils/shopify-format'
 import { seo } from '~/utils/seo'
-import { twMerge } from 'tailwind-merge'
-import { useAddToCart } from '~/hooks/useCart'
 
 export const Route = createFileRoute('/shop/products/$handle')({
   loader: async ({ params }) => {
@@ -19,10 +23,19 @@ export const Route = createFileRoute('/shop/products/$handle')({
   head: ({ loaderData }) => {
     const product = loaderData?.product
     if (!product) return { meta: [] }
+    const ogImage = product.images.nodes[0]
     return {
       meta: seo({
         title: `${product.seo.title ?? product.title} | TanStack Shop`,
         description: product.seo.description ?? undefined,
+        image: ogImage
+          ? shopifyImageUrl(ogImage.url, {
+              width: 1200,
+              height: 630,
+              format: 'jpg',
+              crop: 'center',
+            })
+          : undefined,
       }),
     }
   },
@@ -31,33 +44,51 @@ export const Route = createFileRoute('/shop/products/$handle')({
 
 function ProductPage() {
   const { product } = Route.useLoaderData()
+  const variants = product.variants.nodes
+
   const [selected, setSelected] = React.useState<Record<string, string>>(() =>
     Object.fromEntries(product.options.map((o) => [o.name, o.values[0]!])),
   )
+  const [quantity, setQuantity] = React.useState(1)
 
-  const selectedVariant = findMatchingVariant(product.variants.nodes, selected)
+  const selectedVariant = findMatchingVariant(variants, selected)
+
+  // Use the variant's image if it has one, else the first product image
+  const variantImage = selectedVariant?.image ?? null
+  const initialImageIndex = React.useMemo(() => {
+    if (!variantImage) return 0
+    const i = product.images.nodes.findIndex(
+      (img) => img.url === variantImage.url,
+    )
+    return i >= 0 ? i : 0
+  }, [variantImage, product.images.nodes])
+  const [activeImageIndex, setActiveImageIndex] =
+    React.useState(initialImageIndex)
+
+  // Keep gallery in sync when the selected variant swaps its image
+  React.useEffect(() => {
+    setActiveImageIndex(initialImageIndex)
+  }, [initialImageIndex])
+
+  const heroImage =
+    product.images.nodes[activeImageIndex] ?? variantImage ?? null
+
   const displayPrice = selectedVariant?.price ?? null
 
-  // Use the variant's image if it has one, else fall back to the first product image
-  const heroImage = selectedVariant?.image ?? product.images.nodes[0] ?? null
-
   return (
-    <div className="max-w-6xl mx-auto p-4 md:p-8">
+    <div className="max-w-6xl mx-auto p-4 md:p-8 flex flex-col gap-6">
+      <Breadcrumbs
+        crumbs={[{ label: 'Shop', href: '/shop' }, { label: product.title }]}
+      />
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
-        <div className="aspect-square overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-900">
-          {heroImage ? (
-            <img
-              src={shopifyImageUrl(heroImage.url, {
-                width: 1200,
-                format: 'webp',
-              })}
-              alt={heroImage.altText ?? product.title}
-              width={heroImage.width ?? undefined}
-              height={heroImage.height ?? undefined}
-              className="h-full w-full object-cover"
-            />
-          ) : null}
-        </div>
+        <ProductGallery
+          images={product.images.nodes}
+          activeIndex={activeImageIndex}
+          onChange={setActiveImageIndex}
+          title={product.title}
+          hero={heroImage}
+        />
 
         <div className="flex flex-col gap-6">
           <header className="flex flex-col gap-2">
@@ -69,42 +100,19 @@ function ProductPage() {
             ) : null}
           </header>
 
-          {product.options.map((option) => {
-            // Skip auto-generated single-value options like "Title: Default Title"
-            if (option.values.length <= 1) return null
-            return (
-              <fieldset key={option.id} className="flex flex-col gap-2">
-                <legend className="text-sm font-medium">{option.name}</legend>
-                <div className="flex flex-wrap gap-2">
-                  {option.values.map((value) => {
-                    const isSelected = selected[option.name] === value
-                    return (
-                      <button
-                        key={value}
-                        type="button"
-                        onClick={() =>
-                          setSelected((prev) => ({
-                            ...prev,
-                            [option.name]: value,
-                          }))
-                        }
-                        className={twMerge(
-                          'px-4 py-2 rounded-lg border text-sm transition-colors',
-                          isSelected
-                            ? 'border-black bg-black text-white dark:border-white dark:bg-white dark:text-black'
-                            : 'border-gray-300 dark:border-gray-700 hover:border-gray-500',
-                        )}
-                      >
-                        {value}
-                      </button>
-                    )
-                  })}
-                </div>
-              </fieldset>
-            )
-          })}
+          <VariantSelector
+            options={product.options}
+            variants={variants}
+            selected={selected}
+            onChange={setSelected}
+          />
 
-          <AddToCartButton variant={selectedVariant} />
+          <QuantityStepper
+            quantity={quantity}
+            onChange={(n) => setQuantity(Math.max(1, n))}
+          />
+
+          <AddToCartButton variant={selectedVariant} quantity={quantity} />
 
           {product.descriptionHtml ? (
             <div
@@ -114,6 +122,169 @@ function ProductPage() {
             />
           ) : null}
         </div>
+      </div>
+
+      <ProductJsonLd product={product} selectedVariant={selectedVariant} />
+    </div>
+  )
+}
+
+type ProductGalleryImage = ProductDetail['images']['nodes'][number]
+
+function ProductGallery({
+  images,
+  activeIndex,
+  onChange,
+  title,
+  hero,
+}: {
+  images: Array<ProductGalleryImage>
+  activeIndex: number
+  onChange: (i: number) => void
+  title: string
+  hero: ProductGalleryImage | null
+}) {
+  if (!hero) {
+    return (
+      <div className="aspect-square rounded-2xl bg-gray-100 dark:bg-gray-900" />
+    )
+  }
+  const hasMultiple = images.length > 1
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="aspect-square overflow-hidden rounded-2xl bg-gray-100 dark:bg-gray-900">
+        <ProductImage
+          image={hero}
+          alt={title}
+          width={1200}
+          sizes="(min-width: 768px) 50vw, 100vw"
+          loading="eager"
+        />
+      </div>
+      {hasMultiple ? (
+        <div className="grid grid-cols-5 gap-2">
+          {images.map((img, i) => (
+            <button
+              key={`${img.url}-${i}`}
+              type="button"
+              onClick={() => onChange(i)}
+              aria-label={`View image ${i + 1} of ${images.length}`}
+              aria-current={i === activeIndex}
+              className={twMerge(
+                'aspect-square overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-900 transition-all',
+                i === activeIndex
+                  ? 'ring-2 ring-black dark:ring-white'
+                  : 'opacity-70 hover:opacity-100',
+              )}
+            >
+              <ProductImage
+                image={img}
+                alt={`${title} thumbnail ${i + 1}`}
+                width={160}
+                sizes="20vw"
+              />
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function VariantSelector({
+  options,
+  variants,
+  selected,
+  onChange,
+}: {
+  options: ProductDetail['options']
+  variants: Array<ProductDetailVariant>
+  selected: Record<string, string>
+  onChange: (next: Record<string, string>) => void
+}) {
+  return (
+    <>
+      {options.map((option) => {
+        // Skip auto-generated single-value options like "Title: Default Title"
+        if (option.values.length <= 1) return null
+        return (
+          <fieldset key={option.id} className="flex flex-col gap-2">
+            <legend className="text-sm font-medium">
+              <span>{option.name}</span>
+              <span className="ml-2 text-gray-500 dark:text-gray-400">
+                {selected[option.name]}
+              </span>
+            </legend>
+            <div className="flex flex-wrap gap-2">
+              {option.values.map((value) => {
+                const isSelected = selected[option.name] === value
+                // Would this value + current selections resolve to an
+                // available variant? Drives disabled styling without
+                // preventing clicks (Shopify themes tend to allow clicks
+                // so users can see the sold-out state).
+                const candidate = { ...selected, [option.name]: value }
+                const match = findMatchingVariant(variants, candidate)
+                const isAvailable = !!match?.availableForSale
+
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() =>
+                      onChange({ ...selected, [option.name]: value })
+                    }
+                    aria-pressed={isSelected}
+                    className={twMerge(
+                      'px-4 py-2 rounded-lg border text-sm transition-colors relative',
+                      isSelected
+                        ? 'border-black bg-black text-white dark:border-white dark:bg-white dark:text-black'
+                        : 'border-gray-300 dark:border-gray-700 hover:border-gray-500',
+                      !isAvailable && !isSelected
+                        ? 'opacity-50 line-through decoration-gray-400'
+                        : '',
+                    )}
+                  >
+                    {value}
+                  </button>
+                )
+              })}
+            </div>
+          </fieldset>
+        )
+      })}
+    </>
+  )
+}
+
+function QuantityStepper({
+  quantity,
+  onChange,
+}: {
+  quantity: number
+  onChange: (next: number) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-medium">Quantity</span>
+      <div className="inline-flex items-center rounded-lg border border-gray-300 dark:border-gray-700 w-fit">
+        <button
+          type="button"
+          onClick={() => onChange(quantity - 1)}
+          disabled={quantity <= 1}
+          aria-label="Decrease quantity"
+          className="p-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Minus className="w-4 h-4" />
+        </button>
+        <span className="w-10 text-center text-sm font-medium">{quantity}</span>
+        <button
+          type="button"
+          onClick={() => onChange(quantity + 1)}
+          aria-label="Increase quantity"
+          className="p-2"
+        >
+          <Plus className="w-4 h-4" />
+        </button>
       </div>
     </div>
   )
@@ -130,10 +301,13 @@ function findMatchingVariant(
 
 function AddToCartButton({
   variant,
+  quantity,
 }: {
   variant: ProductDetailVariant | undefined
+  quantity: number
 }) {
   const addToCart = useAddToCart()
+  const openDrawer = useCartDrawerStore((s) => s.openDrawer)
 
   const disabled = !variant || !variant.availableForSale || addToCart.isPending
 
@@ -147,7 +321,6 @@ function AddToCartButton({
           ? 'Sold out'
           : 'Add to cart'
 
-  // Reset the "Added ✓" confirmation after a moment so repeat adds feel fresh
   React.useEffect(() => {
     if (!addToCart.isSuccess) return
     const id = window.setTimeout(() => addToCart.reset(), 1500)
@@ -161,7 +334,10 @@ function AddToCartButton({
         disabled={disabled}
         onClick={() => {
           if (!variant) return
-          addToCart.mutate({ variantId: variant.id, quantity: 1 })
+          addToCart.mutate(
+            { variantId: variant.id, quantity },
+            { onSuccess: () => openDrawer() },
+          )
         }}
         className={twMerge(
           'mt-2 px-6 py-3 rounded-lg font-semibold transition-colors',
@@ -179,6 +355,67 @@ function AddToCartButton({
         </p>
       ) : null}
     </div>
+  )
+}
+
+/**
+ * schema.org Product JSON-LD for rich search results. Shopify's Storefront
+ * API already returns availability and pricing; we just reshape it.
+ */
+function ProductJsonLd({
+  product,
+  selectedVariant,
+}: {
+  product: ProductDetail
+  selectedVariant: ProductDetailVariant | undefined
+}) {
+  const firstImage = product.images.nodes[0]
+  const offers = product.variants.nodes.map((v) => ({
+    '@type': 'Offer',
+    sku: v.id,
+    price: v.price.amount,
+    priceCurrency: v.price.currencyCode,
+    availability: v.availableForSale
+      ? 'https://schema.org/InStock'
+      : 'https://schema.org/OutOfStock',
+    itemCondition: 'https://schema.org/NewCondition',
+    url: `https://tanstack.com/shop/products/${product.handle}`,
+  }))
+
+  const jsonLd = {
+    '@context': 'https://schema.org/',
+    '@type': 'Product',
+    name: product.title,
+    description: product.seo.description ?? undefined,
+    image: product.images.nodes.map((img) => img.url),
+    sku: selectedVariant?.id,
+    offers:
+      offers.length === 1
+        ? offers[0]
+        : {
+            '@type': 'AggregateOffer',
+            offerCount: offers.length,
+            lowPrice: Math.min(
+              ...product.variants.nodes.map((v) => Number(v.price.amount)),
+            ),
+            highPrice: Math.max(
+              ...product.variants.nodes.map((v) => Number(v.price.amount)),
+            ),
+            priceCurrency:
+              product.variants.nodes[0]?.price.currencyCode ?? 'USD',
+            offers,
+          },
+  }
+
+  // void-used just to keep TS happy about firstImage
+  void firstImage
+
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
   )
 }
 

--- a/src/routes/shop.search.tsx
+++ b/src/routes/shop.search.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMutation } from '@tanstack/react-query'
+import * as v from 'valibot'
+import { Search as SearchIcon } from 'lucide-react'
+import { ProductCard } from '~/components/shop/ProductCard'
+import { searchProducts } from '~/utils/shop.functions'
+import type { ProductListItem } from '~/utils/shopify-queries'
+
+const searchSchema = v.object({
+  q: v.optional(v.string()),
+})
+
+const PAGE_SIZE = 24
+
+export const Route = createFileRoute('/shop/search')({
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({ q: search.q }),
+  loader: async ({ deps }) => {
+    const q = deps.q?.trim()
+    if (!q)
+      return {
+        query: '',
+        totalCount: 0,
+        page: null as null | Awaited<ReturnType<typeof searchProducts>>,
+      }
+    const page = await searchProducts({ data: { query: q, first: PAGE_SIZE } })
+    return { query: q, totalCount: page.totalCount, page }
+  },
+  component: SearchPage,
+})
+
+function SearchPage() {
+  const { query, page } = Route.useLoaderData()
+  const navigate = useNavigate({ from: '/shop/search' })
+  const [inputValue, setInputValue] = React.useState(query)
+
+  // Sync input when navigating with a new ?q
+  React.useEffect(() => {
+    setInputValue(query)
+  }, [query])
+
+  const [accumulated, setAccumulated] = React.useState<Array<ProductListItem>>(
+    [],
+  )
+  const [endCursor, setEndCursor] = React.useState<string | null>(
+    page?.pageInfo.endCursor ?? null,
+  )
+  const [hasNextPage, setHasNextPage] = React.useState(
+    page?.pageInfo.hasNextPage ?? false,
+  )
+
+  React.useEffect(() => {
+    setAccumulated([])
+    setEndCursor(page?.pageInfo.endCursor ?? null)
+    setHasNextPage(page?.pageInfo.hasNextPage ?? false)
+  }, [page])
+
+  const loadMore = useMutation({
+    mutationFn: async () => {
+      if (!endCursor || !query) return null
+      return searchProducts({
+        data: { query, first: PAGE_SIZE, after: endCursor },
+      })
+    },
+    onSuccess: (next) => {
+      if (!next) return
+      setAccumulated((prev) => [...prev, ...next.products])
+      setEndCursor(next.pageInfo.endCursor)
+      setHasNextPage(next.pageInfo.hasNextPage)
+    },
+  })
+
+  const products = [...(page?.products ?? []), ...accumulated]
+
+  return (
+    <div className="flex flex-col max-w-6xl mx-auto gap-8 p-4 md:p-8">
+      <header>
+        <h1 className="text-3xl font-black">Search</h1>
+      </header>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          const trimmed = inputValue.trim()
+          navigate({
+            to: '/shop/search',
+            search: trimmed ? { q: trimmed } : {},
+          })
+        }}
+        className="flex items-center gap-2 max-w-xl"
+      >
+        <div className="relative flex-1">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="search"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder="Search products…"
+            className="w-full pl-9 pr-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 text-sm"
+          />
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 rounded-lg bg-black text-white dark:bg-white dark:text-black font-semibold text-sm"
+        >
+          Search
+        </button>
+      </form>
+
+      {!query ? (
+        <p className="text-gray-600 dark:text-gray-400">
+          Type a query above to find products.
+        </p>
+      ) : products.length === 0 ? (
+        <p className="text-gray-600 dark:text-gray-400">
+          No products match{' '}
+          <span className="font-semibold">&ldquo;{query}&rdquo;</span>.
+        </p>
+      ) : (
+        <>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {products.length}
+            {hasNextPage ? '+' : ''}{' '}
+            {products.length === 1 ? 'result' : 'results'} for{' '}
+            <span className="font-semibold">&ldquo;{query}&rdquo;</span>
+          </p>
+          <section className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {products.map((product, i) => (
+              <ProductCard
+                key={product.id}
+                product={product}
+                loading={i < 8 ? 'eager' : 'lazy'}
+              />
+            ))}
+          </section>
+          {hasNextPage ? (
+            <div className="flex justify-center py-6">
+              <button
+                type="button"
+                onClick={() => loadMore.mutate()}
+                disabled={loadMore.isPending}
+                className="px-6 py-3 rounded-lg border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900 font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loadMore.isPending ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/utils/shop.functions.ts
+++ b/src/utils/shop.functions.ts
@@ -9,27 +9,38 @@ import * as v from 'valibot'
 import { shopifyServerFetch } from '~/server/shopify/fetch'
 import {
   CART_CREATE_MUTATION,
+  CART_DISCOUNT_CODES_UPDATE_MUTATION,
   CART_LINES_ADD_MUTATION,
   CART_LINES_REMOVE_MUTATION,
   CART_LINES_UPDATE_MUTATION,
   CART_QUERY,
+  COLLECTION_QUERY,
   COLLECTIONS_QUERY,
+  PAGE_QUERY,
   PRODUCTS_QUERY,
   PRODUCT_QUERY,
+  SEARCH_QUERY,
   SHOP_QUERY,
   type CartCreateResult,
   type CartDetail,
+  type CartDiscountCodesUpdateResult,
   type CartLinesAddResult,
   type CartLinesRemoveResult,
   type CartLinesUpdateResult,
   type CartQueryResult,
   type CartUserError,
+  type CollectionDetail,
   type CollectionListItem,
+  type CollectionQueryResult,
   type CollectionsQueryResult,
+  type PageDetail,
+  type PageQueryResult,
   type ProductDetail,
-  type ProductListItem,
+  type ProductListPage,
   type ProductQueryResult,
   type ProductsQueryResult,
+  type ProductsQueryVariables,
+  type SearchQueryResult,
   type ShopQueryResult,
 } from '~/utils/shopify-queries'
 
@@ -77,19 +88,43 @@ export const getShop = createServerFn({ method: 'GET' }).handler(
   },
 )
 
-export const getProducts = createServerFn({ method: 'GET' }).handler(
-  async (): Promise<Array<ProductListItem>> => {
+const productSortKeys = [
+  'BEST_SELLING',
+  'CREATED_AT',
+  'ID',
+  'PRICE',
+  'PRODUCT_TYPE',
+  'RELEVANCE',
+  'TITLE',
+  'UPDATED_AT',
+  'VENDOR',
+] as const
+
+export const getProducts = createServerFn({ method: 'POST' })
+  .inputValidator(
+    v.object({
+      first: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 24),
+      after: v.optional(v.nullable(v.string())),
+      sortKey: v.optional(v.picklist(productSortKeys)),
+      reverse: v.optional(v.boolean()),
+    }),
+  )
+  .handler(async ({ data }): Promise<ProductListPage> => {
     setBrowseCacheHeaders()
     const result = await shopifyServerFetch<
       ProductsQueryResult,
-      { first: number }
+      ProductsQueryVariables
     >({
       query: PRODUCTS_QUERY,
-      variables: { first: 50 },
+      variables: {
+        first: data.first,
+        after: data.after ?? null,
+        sortKey: data.sortKey ?? null,
+        reverse: data.reverse ?? null,
+      },
     })
-    return result.products.nodes
-  },
-)
+    return result.products
+  })
 
 export const getCollections = createServerFn({ method: 'GET' }).handler(
   async (): Promise<Array<CollectionListItem>> => {
@@ -118,6 +153,101 @@ export const getProduct = createServerFn({ method: 'POST' })
     })
     return result.product
   })
+
+const collectionSortKeys = [
+  'BEST_SELLING',
+  'COLLECTION_DEFAULT',
+  'CREATED',
+  'ID',
+  'MANUAL',
+  'PRICE',
+  'RELEVANCE',
+  'TITLE',
+] as const
+
+export const getCollection = createServerFn({ method: 'POST' })
+  .inputValidator(
+    v.object({
+      handle: v.string(),
+      first: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 24),
+      after: v.optional(v.nullable(v.string())),
+      sortKey: v.optional(v.picklist(collectionSortKeys)),
+      reverse: v.optional(v.boolean()),
+    }),
+  )
+  .handler(async ({ data }): Promise<CollectionDetail | null> => {
+    setBrowseCacheHeaders()
+    const result = await shopifyServerFetch<
+      CollectionQueryResult,
+      {
+        handle: string
+        first: number
+        after: string | null
+        sortKey: (typeof collectionSortKeys)[number] | null
+        reverse: boolean | null
+      }
+    >({
+      query: COLLECTION_QUERY,
+      variables: {
+        handle: data.handle,
+        first: data.first,
+        after: data.after ?? null,
+        sortKey: data.sortKey ?? null,
+        reverse: data.reverse ?? null,
+      },
+    })
+    return result.collection
+  })
+
+export const getPage = createServerFn({ method: 'POST' })
+  .inputValidator(v.object({ handle: v.string() }))
+  .handler(async ({ data }): Promise<PageDetail | null> => {
+    setBrowseCacheHeaders()
+    const result = await shopifyServerFetch<
+      PageQueryResult,
+      { handle: string }
+    >({
+      query: PAGE_QUERY,
+      variables: { handle: data.handle },
+    })
+    return result.page
+  })
+
+export const searchProducts = createServerFn({ method: 'POST' })
+  .inputValidator(
+    v.object({
+      query: v.pipe(v.string(), v.minLength(1)),
+      first: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 24),
+      after: v.optional(v.nullable(v.string())),
+    }),
+  )
+  .handler(
+    async ({
+      data,
+    }): Promise<{
+      totalCount: number
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+      products: ProductListPage['nodes']
+    }> => {
+      setBrowseCacheHeaders()
+      const result = await shopifyServerFetch<
+        SearchQueryResult,
+        { query: string; first: number; after: string | null }
+      >({
+        query: SEARCH_QUERY,
+        variables: {
+          query: data.query,
+          first: data.first,
+          after: data.after ?? null,
+        },
+      })
+      return {
+        totalCount: result.search.totalCount,
+        pageInfo: result.search.pageInfo,
+        products: result.search.nodes,
+      }
+    },
+  )
 
 /* ──────────────────────────────────────────────────────────────────────────
  * Cart server functions
@@ -260,3 +390,49 @@ export const removeCartLine = createServerFn({ method: 'POST' })
     if (!cart) throw new Error('Shopify returned no cart after remove.')
     return cart
   })
+
+export const applyDiscountCode = createServerFn({ method: 'POST' })
+  .inputValidator(v.object({ code: v.pipe(v.string(), v.minLength(1)) }))
+  .handler(async ({ data }): Promise<CartDetail> => {
+    setCartResponseHeaders()
+    const cartId = getCookie(CART_COOKIE_NAME)
+    if (!cartId) throw new Error('No cart exists to apply a discount to.')
+    const result = await shopifyServerFetch<CartDiscountCodesUpdateResult>({
+      query: CART_DISCOUNT_CODES_UPDATE_MUTATION,
+      variables: { cartId, discountCodes: [data.code] },
+    })
+    throwIfUserErrors(result.cartDiscountCodesUpdate.userErrors)
+    const cart = result.cartDiscountCodesUpdate.cart
+    if (!cart)
+      throw new Error('Shopify returned no cart after discount update.')
+    // Shopify silently drops invalid codes — surface that to the UI by
+    // checking whether the code we sent is present and applicable.
+    const applied = cart.discountCodes.find(
+      (c) => c.code.toLowerCase() === data.code.toLowerCase(),
+    )
+    if (!applied || !applied.applicable) {
+      throw new CartUserErrorsError([
+        {
+          field: null,
+          message: `Discount code "${data.code}" is not valid or not applicable to this cart.`,
+        },
+      ])
+    }
+    return cart
+  })
+
+export const removeDiscountCode = createServerFn({ method: 'POST' }).handler(
+  async (): Promise<CartDetail> => {
+    setCartResponseHeaders()
+    const cartId = getCookie(CART_COOKIE_NAME)
+    if (!cartId) throw new Error('No cart exists.')
+    const result = await shopifyServerFetch<CartDiscountCodesUpdateResult>({
+      query: CART_DISCOUNT_CODES_UPDATE_MUTATION,
+      variables: { cartId, discountCodes: [] },
+    })
+    throwIfUserErrors(result.cartDiscountCodesUpdate.userErrors)
+    const cart = result.cartDiscountCodesUpdate.cart
+    if (!cart) throw new Error('Shopify returned no cart after discount clear.')
+    return cart
+  },
+)

--- a/src/utils/shopify-queries.ts
+++ b/src/utils/shopify-queries.ts
@@ -4,8 +4,10 @@ import type {
   Collection,
   Image as StorefrontImage,
   MoneyV2,
+  Page,
   Product,
   ProductOption,
+  ProductSortKeys,
   ProductVariant,
 } from '@shopify/hydrogen-react/storefront-api-types'
 
@@ -46,25 +48,56 @@ export type ShopQueryResult = {
  * Product list — used by /shop landing
  * ────────────────────────────────────────────────────────────────────────── */
 
+const PRODUCT_CARD_FRAGMENT = /* GraphQL */ `
+  fragment ProductCard on Product {
+    id
+    handle
+    title
+    featuredImage {
+      url
+      altText
+      width
+      height
+    }
+    priceRange {
+      minVariantPrice {
+        amount
+        currencyCode
+      }
+      maxVariantPrice {
+        amount
+        currencyCode
+      }
+    }
+    compareAtPriceRange {
+      minVariantPrice {
+        amount
+        currencyCode
+      }
+    }
+  }
+`
+
 export const PRODUCTS_QUERY = /* GraphQL */ `
-  query Products($first: Int!) {
-    products(first: $first, sortKey: BEST_SELLING) {
+  ${PRODUCT_CARD_FRAGMENT}
+  query Products(
+    $first: Int!
+    $after: String
+    $sortKey: ProductSortKeys
+    $reverse: Boolean
+  ) {
+    products(
+      first: $first
+      after: $after
+      sortKey: $sortKey
+      reverse: $reverse
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       nodes {
-        id
-        handle
-        title
-        featuredImage {
-          url
-          altText
-          width
-          height
-        }
-        priceRange {
-          minVariantPrice {
-            amount
-            currencyCode
-          }
-        }
+        ...ProductCard
       }
     }
   }
@@ -76,11 +109,54 @@ export type ProductListItem = Pick<Product, 'id' | 'handle' | 'title'> & {
     | null
   priceRange: {
     minVariantPrice: Pick<MoneyV2, 'amount' | 'currencyCode'>
+    maxVariantPrice: Pick<MoneyV2, 'amount' | 'currencyCode'>
+  }
+  compareAtPriceRange: {
+    minVariantPrice: Pick<MoneyV2, 'amount' | 'currencyCode'>
   }
 }
 
+export type ProductListPage = {
+  nodes: Array<ProductListItem>
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+}
+
+export type ProductsQueryVariables = {
+  first: number
+  after?: string | null
+  sortKey?: ProductSortKeys | null
+  reverse?: boolean | null
+}
+
+export const SORT_OPTIONS = [
+  { key: 'BEST_SELLING', reverse: false, label: 'Best selling' },
+  { key: 'CREATED_AT', reverse: true, label: 'Newest' },
+  { key: 'PRICE', reverse: false, label: 'Price: low to high' },
+  { key: 'PRICE', reverse: true, label: 'Price: high to low' },
+  { key: 'TITLE', reverse: false, label: 'Title: A–Z' },
+] as const satisfies ReadonlyArray<{
+  key: ProductSortKeys
+  reverse: boolean
+  label: string
+}>
+
+export type SortOption = (typeof SORT_OPTIONS)[number]
+export type SortOptionId = `${SortOption['key']}${'' | ':rev'}`
+
+export function sortOptionId(opt: SortOption): SortOptionId {
+  return (opt.reverse ? `${opt.key}:rev` : opt.key) as SortOptionId
+}
+
+export function resolveSortOption(id: string | undefined): SortOption {
+  if (!id) return SORT_OPTIONS[0]
+  for (const opt of SORT_OPTIONS) {
+    if (sortOptionId(opt) === id) return opt
+  }
+  return SORT_OPTIONS[0]
+}
+
 export type ProductsQueryResult = {
-  products: { nodes: Array<ProductListItem> }
+  products: ProductListPage
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
@@ -252,6 +328,10 @@ const CART_FRAGMENT = /* GraphQL */ `
         }
       }
     }
+    discountCodes {
+      code
+      applicable
+    }
   }
 `
 
@@ -348,6 +428,7 @@ export type CartDetail = Pick<Cart, 'id' | 'checkoutUrl' | 'totalQuantity'> & {
     totalTaxAmount: Pick<MoneyV2, 'amount' | 'currencyCode'> | null
   }
   lines: { nodes: Array<CartLineDetail> }
+  discountCodes: Array<{ code: string; applicable: boolean }>
 }
 
 export type CartQueryResult = {
@@ -375,5 +456,188 @@ export type CartLinesRemoveResult = {
   cartLinesRemove: {
     cart: CartDetail | null
     userErrors: Array<CartUserError>
+  }
+}
+
+export const CART_DISCOUNT_CODES_UPDATE_MUTATION = /* GraphQL */ `
+  ${CART_FRAGMENT}
+  mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]) {
+    cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`
+
+export type CartDiscountCodesUpdateResult = {
+  cartDiscountCodesUpdate: {
+    cart: CartDetail | null
+    userErrors: Array<CartUserError>
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Collection (by handle) — backs /shop/collections/$handle
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const COLLECTION_QUERY = /* GraphQL */ `
+  ${PRODUCT_CARD_FRAGMENT}
+  query Collection(
+    $handle: String!
+    $first: Int!
+    $after: String
+    $sortKey: ProductCollectionSortKeys
+    $reverse: Boolean
+  ) {
+    collection(handle: $handle) {
+      id
+      handle
+      title
+      description
+      descriptionHtml
+      image {
+        url
+        altText
+        width
+        height
+      }
+      seo {
+        title
+        description
+      }
+      products(
+        first: $first
+        after: $after
+        sortKey: $sortKey
+        reverse: $reverse
+      ) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          ...ProductCard
+        }
+      }
+    }
+  }
+`
+
+export type CollectionDetail = Pick<
+  Collection,
+  'id' | 'handle' | 'title' | 'description' | 'descriptionHtml'
+> & {
+  image: Pick<StorefrontImage, 'url' | 'altText' | 'width' | 'height'> | null
+  seo: { title: string | null; description: string | null }
+  products: ProductListPage
+}
+
+export type CollectionQueryResult = {
+  collection: CollectionDetail | null
+}
+
+export const COLLECTION_SORT_OPTIONS = [
+  { key: 'COLLECTION_DEFAULT', reverse: false, label: 'Featured' },
+  { key: 'BEST_SELLING', reverse: false, label: 'Best selling' },
+  { key: 'CREATED', reverse: true, label: 'Newest' },
+  { key: 'PRICE', reverse: false, label: 'Price: low to high' },
+  { key: 'PRICE', reverse: true, label: 'Price: high to low' },
+  { key: 'TITLE', reverse: false, label: 'Title: A–Z' },
+] as const satisfies ReadonlyArray<{
+  key: string
+  reverse: boolean
+  label: string
+}>
+
+export type CollectionSortOption = (typeof COLLECTION_SORT_OPTIONS)[number]
+export type CollectionSortOptionId = `${CollectionSortOption['key']}${
+  | ''
+  | ':rev'}`
+
+export function collectionSortOptionId(
+  opt: CollectionSortOption,
+): CollectionSortOptionId {
+  return (opt.reverse ? `${opt.key}:rev` : opt.key) as CollectionSortOptionId
+}
+
+export function resolveCollectionSortOption(
+  id: string | undefined,
+): CollectionSortOption {
+  if (!id) return COLLECTION_SORT_OPTIONS[0]
+  for (const opt of COLLECTION_SORT_OPTIONS) {
+    if (collectionSortOptionId(opt) === id) return opt
+  }
+  return COLLECTION_SORT_OPTIONS[0]
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Shopify Pages (policies, about, etc) — backs /shop/pages/$handle
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const PAGE_QUERY = /* GraphQL */ `
+  query Page($handle: String!) {
+    page(handle: $handle) {
+      id
+      handle
+      title
+      body
+      bodySummary
+      seo {
+        title
+        description
+      }
+    }
+  }
+`
+
+export type PageDetail = Pick<
+  Page,
+  'id' | 'handle' | 'title' | 'body' | 'bodySummary'
+> & {
+  seo: { title: string | null; description: string | null }
+}
+
+export type PageQueryResult = {
+  page: PageDetail | null
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Search — backs /shop/search
+ * ────────────────────────────────────────────────────────────────────────── */
+
+export const SEARCH_QUERY = /* GraphQL */ `
+  ${PRODUCT_CARD_FRAGMENT}
+  query Search($query: String!, $first: Int!, $after: String) {
+    search(
+      query: $query
+      first: $first
+      after: $after
+      types: [PRODUCT]
+      productFilters: [{ available: true }]
+    ) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        ... on Product {
+          ...ProductCard
+        }
+      }
+    }
+  }
+`
+
+export type SearchQueryResult = {
+  search: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    nodes: Array<ProductListItem>
   }
 }


### PR DESCRIPTION
## Summary
Brings the shop to Shopify-theme parity. Everything on the "standard storefront" checklist that was missing after the initial ship is now in.

**New routes**
- `/shop/collections/$handle` — collection listings with sort + Load More pagination, SEO meta, breadcrumbs
- `/shop/pages/$handle` — renders Shopify-admin-managed pages (policies, about, etc.)
- `/shop/search` — Storefront API search with paginated results

**Listings**
- Sort dropdown on `/shop` and each collection (URL-driven; default sort uses a clean URL)
- Load More cursor pagination — SSR'd first page, client-accumulated pages after
- Responsive images via a shared `ProductImage` primitive (srcset 1x/1.5x/2x/3x via Shopify CDN transforms, correct sizes hint, lazy past the fold)

**PDP**
- Image gallery with thumbnails + active state; selected variant auto-focuses its own image
- Quantity stepper wired to Add to cart
- Variant availability awareness — unavailable option combos show a line-through + dim treatment
- JSON-LD `Product` / `AggregateOffer` schema for rich search results
- Per-product OG image via Shopify CDN (1200×630 jpg, center crop)
- Breadcrumbs

**Cart**
- Discount code apply/remove with invalid-code detection (Shopify silently drops unknown codes, so the server fn re-checks `applicable` and surfaces a user-facing error)
- Slide-in cart drawer (Radix Dialog) controlled by a zustand store. "Add to cart" on the PDP opens the drawer instead of redirecting, so the user can keep browsing
- Navbar cart button now opens the drawer instead of navigating — visibility rules unchanged (always on `/shop/*`, site-wide when cart has items)
- Cart page gains breadcrumbs + discount UI

**Sidebar**
- Search link, Info section with Shipping / Returns / Privacy / Terms
- Shopify Collections still rendered live from the parent `/shop` loader

**New shared components under `src/components/shop/`**
- `ProductCard` (handles "from $X" ranges + compare-at strike-through)
- `ProductImage` (srcset, no hydrogen-react Provider needed)
- `Breadcrumbs`
- `CartDrawer`
- `cartDrawerStore` (zustand)

**Queries**
- Shared `ProductCard` GraphQL fragment for products/collection/search
- New: `COLLECTION_QUERY`, `PAGE_QUERY`, `SEARCH_QUERY`, `CART_DISCOUNT_CODES_UPDATE_MUTATION`
- Cart fragment now includes `discountCodes`
- Products query gained cursor + sort args

**Env / infra**
- No new env vars.
- Policy pages will render whatever the Shopify admin has configured under Online Store > Pages. Create pages with handles `shipping-policy`, `refund-policy`, `privacy-policy`, `terms-of-service` to populate the sidebar Info links — missing pages fall through to the existing 404.

## Test plan
- [ ] `/shop?sort=PRICE` orders products ascending by price; default URL stays clean
- [ ] "Load more" appends a new page without resetting the first page or page scroll
- [ ] `/shop/collections/<handle>` renders with the collection's products and sort works
- [ ] PDP: click a thumbnail and the hero swaps; select a different variant with its own image and the gallery follows
- [ ] PDP: select an unavailable variant combination — the offending option value gets a strike-through style, Add to cart flips to Sold out
- [ ] PDP: adjust quantity, click Add to cart — drawer slides in, badge updates, subtotal reflects the quantity
- [ ] `/shop/search?q=...` returns results; empty query shows the prompt, no matches shows the "No products match" state
- [ ] Apply an invalid discount code — inline error message appears (no silent acceptance)
- [ ] Apply a valid discount — code chip shows with an X to remove
- [ ] Drawer works on every `/shop/*` route from the navbar cart button, and from non-shop routes when the cart has items
- [ ] View page source on a PDP → `<script type="application/ld+json">` present with valid schema.org Product
- [ ] Social-share preview on a PDP uses the product's first image (via Shopify CDN transform)
- [ ] Shop policies pages (`/shop/pages/shipping-policy` etc.) 404 gracefully until pages are created in Shopify admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added product search functionality to discover items quickly.
  * Introduced collections browsing with sorting and pagination support.
  * Enabled discount code application and removal in cart.
  * Implemented cart drawer for quick access without page navigation.
  * Enhanced product pages with image galleries, variant selectors, and quantity controls.
  * Added breadcrumb navigation for better orientation.
  * Added policy and info pages accessible from navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->