### PR TITLE
fix(search): exclude Configure from devtools source injection

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -194,7 +194,20 @@ export default defineConfig({
   },
   plugins: [
     tanstackDom(),
-    ...(isDev ? [tanstackDevtools()] : []),
+    ...(isDev
+      ? [
+          tanstackDevtools({
+            // react-instantsearch's <Configure> forwards all JSX props as
+            // Algolia search parameters. Injecting `data-tsd-source` as a
+            // JSX attr leaks it into the request and Algolia 400s with
+            // "Unknown parameter: data-tsd-source" — breaks site search in dev.
+            injectSource: {
+              enabled: true,
+              ignore: { components: ['Configure'] },
+            },
+          }),
+        ]
+      : []),
     tanstackStart({
       rsc: {
         enabled: true,


### PR DESCRIPTION
## Summary

- `react-instantsearch`'s `<Configure>` widget forwards all JSX props to Algolia's search parameters.
- The `@tanstack/devtools-vite` plugin injects `data-tsd-source="file:line:col"` onto every JSX element in dev.
- Those two combined meant the attribute leaked into the request body, Algolia returned `{"message":"Unknown parameter: data-tsd-source","status":400}`, and InstantSearch silently circuit-broke — **typing in the site search produced no results in dev**.

Pass `injectSource.ignore.components: ['Configure']` so the devtools plugin leaves `<Configure>` alone. Dev-only change; prod builds already strip the attribute (so prod search was unaffected).

## Test plan

- [x] In dev, search opens and returns results when typing
- [x] Verified against both shim and real React (via `NO_SHIM=1`) — both now return 20 hits for "useQuery"
- [x] `pnpm husky` passes (format + tsc + lint + smoke: 4/4)

Isolated from the site-search symptom: the shim also had a latent bug where `event.nativeEvent` was `undefined` on dispatched handlers (react-instantsearch reads `event.nativeEvent.isComposing`). That was fixed upstream in the shim repo: [TanStack/react@1c71ed6](https://github.com/TanStack/react/commit/1c71ed6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment tooling configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->