### PR TITLE
fix(deps): bump @tanstack/dom-vite to 0.1.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@playwright/test": "^1.59.0",
     "@shikijs/transformers": "^4.0.2",
     "@tanstack/devtools-vite": "^0.6.0",
-    "@tanstack/dom-vite": "0.1.0-alpha.6",
+    "@tanstack/dom-vite": "0.1.0-alpha.7",
     "@tanstack/react-devtools": "^0.10.2",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@types/hast": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/dom-vite':
-        specifier: 0.1.0-alpha.6
-        version: 0.1.0-alpha.6(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 0.1.0-alpha.7
+        version: 0.1.0-alpha.7(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-devtools':
         specifier: ^0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.12)
@@ -3493,11 +3493,11 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/dom-core@0.1.0-alpha.3':
-    resolution: {integrity: sha512-H28e7bhNySHyRloQiGSP+N6/XZzfhvG39Y8/j4wZ2LYWCVVAO1HLmpvAxPGR7qlGt1Nb1wa6VJJkenxr3fiZRA==}
+  '@tanstack/dom-core@0.1.0-alpha.7':
+    resolution: {integrity: sha512-IKxTlPhM4jTp0bVDS8dSzOMpFMDVHuTy2GYt+waMXtEpMrY+dLvzM1fqtTYSyfUe7PPoWWweFMil2L3pJAc8vw==}
 
-  '@tanstack/dom-vite@0.1.0-alpha.6':
-    resolution: {integrity: sha512-w0JLWd2hBjqMeNA2N1rV1hMbEbPy/A4bJivQV/a8NoZp23Msp9+Tmq1cPH/gX/x8WtumYEihONjKccaRVj6nuQ==}
+  '@tanstack/dom-vite@0.1.0-alpha.7':
+    resolution: {integrity: sha512-UwRSHs9UkhiFjq6BlknEKE8s/kcDxhC5OypBKBf9XlOuuWrjs+zN094UYPUtPY5vN3PefVuZ7PzD5L+M+eN+lQ==}
     peerDependencies:
       vite: '>=5'
 
@@ -3528,11 +3528,11 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-dom-server@0.1.0-alpha.4':
-    resolution: {integrity: sha512-fJNgE/+H/y/jubOCF+29CypuVUe/FDYP19rTDf5NK8UdeUlQ7KIKs7ZAhLg2i3gz/U7c+DFnaennRciKX8cp5g==}
+  '@tanstack/react-dom-server@0.1.0-alpha.7':
+    resolution: {integrity: sha512-37BPFaDuLQZhCoRbZMg+VIuZDcf0QNoyqQ38NKseo27Uxna3fs3oLJoaTQaZl73Jq3ouOLEMEajjiTFR1N9v3Q==}
 
-  '@tanstack/react-dom@0.1.0-alpha.5':
-    resolution: {integrity: sha512-IGCTZdoQ1sA5rWznRucF6Vwz7tiGUaqB3f2Wt0+Tomy8g7/7BTcgaDhfmo7PIJQGGkgfObx3vbCMZev45wg+dg==}
+  '@tanstack/react-dom@0.1.0-alpha.7':
+    resolution: {integrity: sha512-F5dTI35tONIdvFB4leaK8CjePFWwacWwmzfM0i3FL2PrW865WLhCp9oEZDWVIL1uQPocvfJeWQdvZpZCxcZNhg==}
 
   '@tanstack/react-hotkeys@0.9.1':
     resolution: {integrity: sha512-/qdQUUVkYAHAWRGdFXqFgWpW/S+a6OzkvxWNWKLLDHQODJlO6EPBPa073CglaafBfzig58RK07T09ET+NnZhpg==}
@@ -3639,8 +3639,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react@0.1.0-alpha.3':
-    resolution: {integrity: sha512-CYjIS8nRfRo1h9iHlNIQs2ihdDDL1lKOGCkAqBKRDfmThqg47smLgQCFJ/oD9dkwiskY8fmtW9Ixw2lTzZL2PQ==}
+  '@tanstack/react@0.1.0-alpha.7':
+    resolution: {integrity: sha512-ZEtTSuO0VltxvzscXXOg9WWELGbXV+lfIvw7lIRqkd2YV8pFcEuUf+XHaJdwsCW9zaowUR4Yt7/NULDcDzAvkg==}
 
   '@tanstack/router-core@1.168.13':
     resolution: {integrity: sha512-RjFUQDLfa05WnPZLV+xENUni2CUF1ftz3cFLpm/AdrXdN6VFHp0mhu94zHVPgt0XJwXEEcIyNHjQn+9IcXk0JA==}
@@ -3699,8 +3699,8 @@ packages:
     resolution: {integrity: sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/scheduler@0.1.0-alpha.3':
-    resolution: {integrity: sha512-RyETyBYefa1xVOEKj8WIRnoXisKL2yc8fG+u07PAiidvFuS5K4+PMgVVWnnaLy5jH98epxTxaoKoxJxQvnkfpw==}
+  '@tanstack/scheduler@0.1.0-alpha.7':
+    resolution: {integrity: sha512-dWrryDcBySUvmo8ljwzyMT/VAxfRCfDohc/BdIF33WGMyjH0tm345Av2IU8zMQkqgxF06PpqHJYzqHWERd89BA==}
 
   '@tanstack/start-client-core@1.167.15':
     resolution: {integrity: sha512-WT4vy+aoc6kVKJeTt+uTwIiwCvhtQ0Nx2GavRyL4ks3l0YYnzv9qgGgNHPlvDY8crA1zO280v9SYEe/UjDuizQ==}
@@ -11407,15 +11407,15 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/dom-core@0.1.0-alpha.3': {}
+  '@tanstack/dom-core@0.1.0-alpha.7': {}
 
-  '@tanstack/dom-vite@0.1.0-alpha.6(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/dom-vite@0.1.0-alpha.7(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.3
-      '@tanstack/react': 0.1.0-alpha.3
-      '@tanstack/react-dom': 0.1.0-alpha.5
-      '@tanstack/react-dom-server': 0.1.0-alpha.4
-      '@tanstack/scheduler': 0.1.0-alpha.3
+      '@tanstack/dom-core': 0.1.0-alpha.7
+      '@tanstack/react': 0.1.0-alpha.7
+      '@tanstack/react-dom': 0.1.0-alpha.7
+      '@tanstack/react-dom-server': 0.1.0-alpha.7
+      '@tanstack/scheduler': 0.1.0-alpha.7
       vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/history@1.161.6': {}
@@ -11446,15 +11446,15 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-dom-server@0.1.0-alpha.4':
+  '@tanstack/react-dom-server@0.1.0-alpha.7':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.3
-      '@tanstack/react': 0.1.0-alpha.3
+      '@tanstack/dom-core': 0.1.0-alpha.7
+      '@tanstack/react': 0.1.0-alpha.7
 
-  '@tanstack/react-dom@0.1.0-alpha.5':
+  '@tanstack/react-dom@0.1.0-alpha.7':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.3
-      '@tanstack/react': 0.1.0-alpha.3
+      '@tanstack/dom-core': 0.1.0-alpha.7
+      '@tanstack/react': 0.1.0-alpha.7
 
   '@tanstack/react-hotkeys@0.9.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -11592,9 +11592,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react@0.1.0-alpha.3':
+  '@tanstack/react@0.1.0-alpha.7':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.3
+      '@tanstack/dom-core': 0.1.0-alpha.7
 
   '@tanstack/router-core@1.168.13':
     dependencies:
@@ -11671,7 +11671,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/scheduler@0.1.0-alpha.3': {}
+  '@tanstack/scheduler@0.1.0-alpha.7': {}
 
   '@tanstack/start-client-core@1.167.15':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the shim to 0.1.0-alpha.7, which fixes site search (the nativeEvent alias — react-instantsearch's SearchBox was silently throwing on every keystroke) and a few other things:

- **fix(react-dom)**: alias `event.nativeEvent` on dispatched handlers. Without this, libraries that read `event.nativeEvent.isComposing` (react-instantsearch) or `event.nativeEvent.shiftKey` (DnD/UI kits) hit a `TypeError` inside their handler, the call is swallowed, and the user-visible action never runs. [TanStack/react@1c71ed6](https://github.com/TanStack/react/commit/1c71ed6)
- **fix(react-dom)**: `onChange` on text-like inputs now fires on every keystroke (native `input` event) instead of only on blur/enter.
- **perf(react-dom)**: renderFiber pointer-table dispatch (−140 B min, tiny parse-time win).
- **feat(react)**: dev-mode error hint pointing at `"use client"` when a hooks error fires during RSC render. Zero prod-bundle impact.

Combined with the `Configure` source-injection fix from #841, this restores in-dev site search end-to-end.

## Test plan

- [x] Verified against running dev server — search modal returns 20 hits for "useQuery"
- [x] `pnpm husky` passes (format + tsc + lint + smoke 4/4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->