### PR TITLE
Fixes for cmd+k search palette

### DIFF
--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -829,6 +829,22 @@ export function SearchModal() {
     }
   }, [isOpen])
 
+  React.useEffect(() => {
+    if (!isOpen) return
+
+    const focusSearchInput = () => {
+      const input = containerRef.current?.querySelector<HTMLInputElement>(
+        'input[type="search"]',
+      )
+      input?.focus()
+    }
+
+    const id = window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(focusSearchInput)
+    })
+    return () => window.cancelAnimationFrame(id)
+  }, [isOpen])
+
   const focusedIndexRef = React.useRef(focusedIndex)
 
   React.useEffect(() => {
@@ -889,6 +905,7 @@ export function SearchModal() {
           className="fixed z-[1000] top-8 left-1/2 -translate-x-1/2 w-[98%] xl:w-full max-w-3xl text-left bg-white/80 dark:bg-black/80 shadow-lg rounded-lg xl:rounded-xl divide-y divide-gray-500/20 backdrop-blur-lg dark:border dark:border-white/20 outline-none"
           ref={containerRef}
           onKeyDown={handleKeyDown}
+          onOpenAutoFocus={(event) => event.preventDefault()}
         >
           <DialogPrimitive.Title className="sr-only">
             Search TanStack docs
@@ -916,8 +933,6 @@ export function SearchModal() {
                     reset: 'p-1 opacity-50 hover:opacity-100',
                   }}
                   resetIconComponent={resetIconComponent}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
-                  autoFocus
                 />
               </div>
               <SearchResults focusedIndex={focusedIndex} />

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -458,6 +458,10 @@ const Hit = ({
       persistFramework(framework)
     }
 
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return
+    }
+
     closeSearch()
   }
 


### PR DESCRIPTION
1. When you use the search palette to find a bunch of things and want to open them all with cmd+click, the first cmd+click closes the search palette
2. cmd+k should put the focus on the search input so you can start typing right away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search modal input focus behavior when opening the search dialog.
  * Enhanced search result activation to respect modifier keys (Cmd/Ctrl/Shift/Alt).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->