### PR TITLE
fix(deps): bump @tanstack/dom-vite to 0.1.0-alpha.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@playwright/test": "^1.59.0",
     "@shikijs/transformers": "^4.0.2",
     "@tanstack/devtools-vite": "^0.6.0",
-    "@tanstack/dom-vite": "0.1.0-alpha.7",
+    "@tanstack/dom-vite": "0.1.0-alpha.8",
     "@tanstack/react-devtools": "^0.10.2",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@types/hast": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/dom-vite':
-        specifier: 0.1.0-alpha.7
-        version: 0.1.0-alpha.7(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 0.1.0-alpha.8
+        version: 0.1.0-alpha.8(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-devtools':
         specifier: ^0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.12)
@@ -3493,11 +3493,11 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/dom-core@0.1.0-alpha.7':
-    resolution: {integrity: sha512-IKxTlPhM4jTp0bVDS8dSzOMpFMDVHuTy2GYt+waMXtEpMrY+dLvzM1fqtTYSyfUe7PPoWWweFMil2L3pJAc8vw==}
+  '@tanstack/dom-core@0.1.0-alpha.8':
+    resolution: {integrity: sha512-FfqRSeKcfKY0PWDCgGwSNZyRM5fN+v5sgEloiPXHplJGQwW4WFIrr3ohGDl70m9TaZztQiYwqGpSSk7yFNHiGw==}
 
-  '@tanstack/dom-vite@0.1.0-alpha.7':
-    resolution: {integrity: sha512-UwRSHs9UkhiFjq6BlknEKE8s/kcDxhC5OypBKBf9XlOuuWrjs+zN094UYPUtPY5vN3PefVuZ7PzD5L+M+eN+lQ==}
+  '@tanstack/dom-vite@0.1.0-alpha.8':
+    resolution: {integrity: sha512-z58qqOE6lx/scYX6+jArWDOiuQYR08ynmPKatRQXEVlECJPQzrrodcwjx/naN65c0AxjenzCDUgJKLN/efHscw==}
     peerDependencies:
       vite: '>=5'
 
@@ -3528,11 +3528,11 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-dom-server@0.1.0-alpha.7':
-    resolution: {integrity: sha512-37BPFaDuLQZhCoRbZMg+VIuZDcf0QNoyqQ38NKseo27Uxna3fs3oLJoaTQaZl73Jq3ouOLEMEajjiTFR1N9v3Q==}
+  '@tanstack/react-dom-server@0.1.0-alpha.8':
+    resolution: {integrity: sha512-JbNNNRzX8Fn5OnJyL1GagFPrQ2f0hf0E0h+Bm1Ibxrk6XbdKZTXa06rXcYQZJ7QYzIx8O/dtZOMAEGTRbRT95g==}
 
-  '@tanstack/react-dom@0.1.0-alpha.7':
-    resolution: {integrity: sha512-F5dTI35tONIdvFB4leaK8CjePFWwacWwmzfM0i3FL2PrW865WLhCp9oEZDWVIL1uQPocvfJeWQdvZpZCxcZNhg==}
+  '@tanstack/react-dom@0.1.0-alpha.8':
+    resolution: {integrity: sha512-Ipovf5sxevddf/8AhYCnc17R9Uc5O9+9DcKgzw4PbDRH+zzhXSVNOFPvuLTQK1mH7dDSa9vrhL8k14O9IoTL6Q==}
 
   '@tanstack/react-hotkeys@0.9.1':
     resolution: {integrity: sha512-/qdQUUVkYAHAWRGdFXqFgWpW/S+a6OzkvxWNWKLLDHQODJlO6EPBPa073CglaafBfzig58RK07T09ET+NnZhpg==}
@@ -3639,8 +3639,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react@0.1.0-alpha.7':
-    resolution: {integrity: sha512-ZEtTSuO0VltxvzscXXOg9WWELGbXV+lfIvw7lIRqkd2YV8pFcEuUf+XHaJdwsCW9zaowUR4Yt7/NULDcDzAvkg==}
+  '@tanstack/react@0.1.0-alpha.8':
+    resolution: {integrity: sha512-t2CKBs77h/pXaIQxHVPtXT7oJlhSTATjmRrs/xH1Eyq1P58mucVksHv7le/lRnW+nX7dwWO/W0wGduV51mljPQ==}
 
   '@tanstack/router-core@1.168.13':
     resolution: {integrity: sha512-RjFUQDLfa05WnPZLV+xENUni2CUF1ftz3cFLpm/AdrXdN6VFHp0mhu94zHVPgt0XJwXEEcIyNHjQn+9IcXk0JA==}
@@ -3699,8 +3699,8 @@ packages:
     resolution: {integrity: sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/scheduler@0.1.0-alpha.7':
-    resolution: {integrity: sha512-dWrryDcBySUvmo8ljwzyMT/VAxfRCfDohc/BdIF33WGMyjH0tm345Av2IU8zMQkqgxF06PpqHJYzqHWERd89BA==}
+  '@tanstack/scheduler@0.1.0-alpha.8':
+    resolution: {integrity: sha512-l5kU6Fo8wtQrW8vKRbhRUWHmuGX23cJYWEikSQSsn0HC4HArWRIId+QBYIecr+zv4HtVnfCpRz0HKUMz31CDKA==}
 
   '@tanstack/start-client-core@1.167.15':
     resolution: {integrity: sha512-WT4vy+aoc6kVKJeTt+uTwIiwCvhtQ0Nx2GavRyL4ks3l0YYnzv9qgGgNHPlvDY8crA1zO280v9SYEe/UjDuizQ==}
@@ -11407,15 +11407,15 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/dom-core@0.1.0-alpha.7': {}
+  '@tanstack/dom-core@0.1.0-alpha.8': {}
 
-  '@tanstack/dom-vite@0.1.0-alpha.7(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/dom-vite@0.1.0-alpha.8(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.7
-      '@tanstack/react': 0.1.0-alpha.7
-      '@tanstack/react-dom': 0.1.0-alpha.7
-      '@tanstack/react-dom-server': 0.1.0-alpha.7
-      '@tanstack/scheduler': 0.1.0-alpha.7
+      '@tanstack/dom-core': 0.1.0-alpha.8
+      '@tanstack/react': 0.1.0-alpha.8
+      '@tanstack/react-dom': 0.1.0-alpha.8
+      '@tanstack/react-dom-server': 0.1.0-alpha.8
+      '@tanstack/scheduler': 0.1.0-alpha.8
       vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/history@1.161.6': {}
@@ -11446,15 +11446,15 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-dom-server@0.1.0-alpha.7':
+  '@tanstack/react-dom-server@0.1.0-alpha.8':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.7
-      '@tanstack/react': 0.1.0-alpha.7
+      '@tanstack/dom-core': 0.1.0-alpha.8
+      '@tanstack/react': 0.1.0-alpha.8
 
-  '@tanstack/react-dom@0.1.0-alpha.7':
+  '@tanstack/react-dom@0.1.0-alpha.8':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.7
-      '@tanstack/react': 0.1.0-alpha.7
+      '@tanstack/dom-core': 0.1.0-alpha.8
+      '@tanstack/react': 0.1.0-alpha.8
 
   '@tanstack/react-hotkeys@0.9.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -11592,9 +11592,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react@0.1.0-alpha.7':
+  '@tanstack/react@0.1.0-alpha.8':
     dependencies:
-      '@tanstack/dom-core': 0.1.0-alpha.7
+      '@tanstack/dom-core': 0.1.0-alpha.8
 
   '@tanstack/router-core@1.168.13':
     dependencies:
@@ -11671,7 +11671,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/scheduler@0.1.0-alpha.7': {}
+  '@tanstack/scheduler@0.1.0-alpha.8': {}
 
   '@tanstack/start-client-core@1.167.15':
     dependencies:


### PR DESCRIPTION
## Summary

Picks up [TanStack/react@fb904fa](https://github.com/TanStack/react/commit/fb904fa) — `fix(react-dom): reverse-iterate placeChildrenInOrder`.

**Fixes these user-reported reorder bugs:**
- **Application starter**: clicking Analyze → picking a different idea chip swapped the Analyze and "I'm feeling lucky" buttons.
- **npm stats page**: library dropdown items reordered after filter changes.

Root cause was the shim's forward iteration over the placement loop. When the starting DOM diverged from the target, each \`insertBefore(doms[i], doms[i+1])\` pulled doms[i] forward past nodes that should move behind it, cascading into the wrong final order.

## Test plan

- [x] Reproduced the app-starter swap locally, verified fix clears it
- [x] Site search still returns results (no regression on last week's fix)
- [x] \`pnpm husky\` passes (format + tsc + lint + smoke 4/4)
- [x] 692/692 unit tests in the shim (688 prior + 4 new child-reorder regression tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest versions for improved build tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->