### PR TITLE
fix(LandingCodeExampleCard): prevent horizontal overflow on mobile

### DIFF
--- a/src/components/landing/LandingCodeExampleCard.server.tsx
+++ b/src/components/landing/LandingCodeExampleCard.server.tsx
@@ -25,29 +25,33 @@ export function LandingCodeExampleCard({
   return (
     <div className="px-4 space-y-4 flex flex-col items-center">
       <div className="text-3xl font-black">{title}</div>
-      <Tabs tabs={tabs}>
-        {frameworks.map((framework) => {
-          const example = codeByFramework[framework]
+      <div className="max-w-full min-w-0">
+        <Tabs tabs={tabs}>
+          {frameworks.map((framework) => {
+            const example = codeByFramework[framework]
 
-          if (!example) {
+            if (!example) {
+              return (
+                <div key={framework}>
+                  {renderFallback ? renderFallback(framework) : null}
+                </div>
+              )
+            }
+
             return (
-              <div key={framework}>
-                {renderFallback ? renderFallback(framework) : null}
-              </div>
+              <CodeBlock
+                key={framework}
+                className="mt-0 border-0"
+                showTypeCopyButton={false}
+              >
+                <code className={`language-${example.lang}`}>
+                  {example.code}
+                </code>
+              </CodeBlock>
             )
-          }
-
-          return (
-            <CodeBlock
-              key={framework}
-              className="mt-0 border-0"
-              showTypeCopyButton={false}
-            >
-              <code className={`language-${example.lang}`}>{example.code}</code>
-            </CodeBlock>
-          )
-        })}
-      </Tabs>
+          })}
+        </Tabs>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Wrap `Tabs` (with `CodeBlock` children) in a `max-w-full min-w-0` container so the landing code example stays within the parent width on mobile, allowing the inner `overflow-x-auto` to take effect.

## Why

In the parent `flex flex-col items-center` layout, flex items default to `min-width: auto`, so `Tabs` and `CodeBlock` expanded to their natural content width (~496px) and overflowed past the mobile viewport (375px). The last tab (`angular`) was clipped and content appeared to overflow horizontally.

## Behavior

- **Desktop**: unchanged
- **Mobile**: `Tabs` and `CodeBlock` are constrained to the parent width and scroll horizontally within their own containers (no page-level horizontal scroll)

## Screenshot

### AS-IS

<img width="375" height="668" alt="image" src="https://github.com/user-attachments/assets/9f1286ad-2f8e-41cc-95fa-d214e2ede930" />

### TO-BE

<img width="377" height="667" alt="image" src="https://github.com/user-attachments/assets/f3f9a664-0265-4e6b-a978-c8c44fecc316" />
