### PR TITLE
fix: preserve search params in canonical URL on stateful routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -78,6 +78,7 @@ declare module '@tanstack/react-router' {
     baseParent?: boolean
     Title?: () => any
     showNavbar?: boolean
+    includeSearchInCanonical?: boolean
   }
 }
 

--- a/src/routes/$libraryId/$version.docs.npm-stats.tsx
+++ b/src/routes/$libraryId/$version.docs.npm-stats.tsx
@@ -83,6 +83,9 @@ export const Route = createFileRoute('/$libraryId/$version/docs/npm-stats')({
     height: v.fallback(v.optional(v.number(), 400), 400),
   }),
   component: RouteComponent,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 type NpmStatsSearch = {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -184,8 +184,21 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
     select: (s) => s.location?.pathname || '/',
   })
 
+  const canonicalSearchStr = useRouterState({
+    select: (s) => s.location?.searchStr || '',
+  })
+
+  const includeSearchInCanonical = useMatches({
+    select: (s) =>
+      s.some((d) => d.staticData?.includeSearchInCanonical === true),
+  })
+
   const preferredCanonicalPath = getCanonicalPath(canonicalPath)
-  const pageUrl = canonicalUrl(preferredCanonicalPath ?? canonicalPath)
+  const canonicalSearch = includeSearchInCanonical ? canonicalSearchStr : ''
+  const pageUrl = canonicalUrl(
+    preferredCanonicalPath ?? canonicalPath,
+    canonicalSearch,
+  )
 
   const showDevtools = import.meta.env.DEV && canShowDevtools
 
@@ -199,7 +212,10 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
     <html lang="en" className={htmlClass} suppressHydrationWarning>
       <head>
         {preferredCanonicalPath ? (
-          <link rel="canonical" href={canonicalUrl(preferredCanonicalPath)} />
+          <link
+            rel="canonical"
+            href={canonicalUrl(preferredCanonicalPath, canonicalSearch)}
+          />
         ) : null}
         <meta property="og:url" content={pageUrl} />
         <meta name="twitter:url" content={pageUrl} />

--- a/src/routes/builder.index.tsx
+++ b/src/routes/builder.index.tsx
@@ -31,6 +31,7 @@ export const Route = createFileRoute('/builder/')({
   validateSearch: builderSearchSchema,
   component: RouteComponent,
   staticData: {
+    includeSearchInCanonical: true,
     Title: () => (
       <Link
         to="/builder"

--- a/src/routes/intent/registry/index.tsx
+++ b/src/routes/intent/registry/index.tsx
@@ -58,6 +58,9 @@ export const Route = createFileRoute('/intent/registry/')({
     }),
   }),
   component: IntentRegistryPage,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 function IntentRegistryPage() {

--- a/src/routes/maintainers.tsx
+++ b/src/routes/maintainers.tsx
@@ -35,6 +35,9 @@ const searchSchema = v.object({
 export const Route = createFileRoute('/maintainers')({
   component: RouteComponent,
   validateSearch: searchSchema,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
   head: () => ({
     meta: seo({
       title: 'Maintainers | TanStack',

--- a/src/routes/partners.index.tsx
+++ b/src/routes/partners.index.tsx
@@ -78,6 +78,9 @@ function getPartnerFilterAnalytics(search: PartnersSearch) {
 export const Route = createFileRoute('/partners/')({
   component: PartnersIndexPage,
   validateSearch: searchSchema,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
   head: () => ({
     meta: seo({
       title: 'Partners',

--- a/src/routes/shop.collections.$handle.tsx
+++ b/src/routes/shop.collections.$handle.tsx
@@ -63,6 +63,9 @@ export const Route = createFileRoute('/shop/collections/$handle')({
     }
   },
   component: CollectionPage,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 function CollectionPage() {

--- a/src/routes/shop.index.tsx
+++ b/src/routes/shop.index.tsx
@@ -47,6 +47,9 @@ export const Route = createFileRoute('/shop/')({
     return { page, sortId: sortOptionId(sortOption) }
   },
   component: ShopIndex,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 function ShopIndex() {

--- a/src/routes/shop.search.tsx
+++ b/src/routes/shop.search.tsx
@@ -30,6 +30,9 @@ export const Route = createFileRoute('/shop/search')({
     return { query: q, totalCount: page.totalCount, page }
   },
   component: SearchPage,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 function SearchPage() {

--- a/src/routes/stats/npm/$packages.tsx
+++ b/src/routes/stats/npm/$packages.tsx
@@ -76,6 +76,9 @@ export const Route = createFileRoute('/stats/npm/$packages')({
     }
   },
   component: RouteComponent,
+  staticData: {
+    includeSearchInCanonical: true,
+  },
 })
 
 function RouteComponent() {

--- a/src/routes/stats/npm/index.tsx
+++ b/src/routes/stats/npm/index.tsx
@@ -192,6 +192,7 @@ export const Route = createFileRoute('/stats/npm/')({
   },
   component: RouteComponent,
   staticData: {
+    includeSearchInCanonical: true,
     Title: () => {
       return (
         <Link

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -35,14 +35,16 @@ export function shouldIndexPath(path: string) {
   return getCanonicalPath(path) !== null
 }
 
-export function canonicalUrl(path: string) {
+export function canonicalUrl(path: string, search?: string) {
   const origin = trimTrailingSlash(
     env.URL ||
       (import.meta.env.SSR ? env.SITE_URL : undefined) ||
       DEFAULT_SITE_URL,
   )
 
-  return `${origin}${normalizePath(path)}`
+  const normalizedSearch = search && search !== '?' ? search : ''
+
+  return `${origin}${normalizePath(path)}${normalizedSearch}`
 }
 
 type SeoOptions = {


### PR DESCRIPTION
## Summary

The npm stats pages (and several other tools/dashboards) encode their entire UI state in URL search params, but `__root.tsx` built the canonical link, `og:url`, and `twitter:url` from `pathname` only. iOS Share read those tags and shared a bare URL, dropping the user's configured view (e.g. selected packages, range, filters).

- `canonicalUrl(path, search?)` now optionally appends a search string (`src/utils/seo.ts`).
- `__root.tsx` reads `location.searchStr` and uses `useMatches` to check for `staticData.includeSearchInCanonical === true`; when set, the search string is threaded through the canonical link, `og:url`, and `twitter:url`.
- `StaticDataRouteOption` in `src/router.tsx` augmented with `includeSearchInCanonical?: boolean`.
- Flag enabled on routes whose state lives in search params:
  - `/stats/npm/`, `/stats/npm/$packages`, `/$libraryId/$version/docs/npm-stats`
  - `/builder`
  - `/maintainers`
  - `/partners`
  - `/intent/registry`
  - `/shop`, `/shop/search`, `/shop/collections/$handle`

Routes whose only search params are incidental (pagination, UI prefs) are intentionally left as-is to keep their canonical URLs SEO-clean.

## Test plan

- [ ] Visit `/stats/npm`, configure a non-default package comparison, view source — confirm `<link rel="canonical">`, `og:url`, `twitter:url` all include the `?packageGroups=…` search params
- [ ] Repeat on `/builder` with a non-default config
- [ ] Visit a plain page like `/` — confirm canonical URL is unchanged (no spurious search params)
- [ ] iOS Share from `/stats/npm?packageGroups=…` now produces a URL that loads the same comparison

https://claude.ai/code/session_01VbTHG1oRfPsECJ8pcr3qj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbTHG1oRfPsECJ8pcr3qj8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canonical URLs now optionally include search parameters for improved SEO and page identification on filterable pages (shop, stats, partners, builder, and related routes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->