### PR TITLE
feat(partners): tiered partner display (gold/silver/bronze)

### DIFF
--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -599,10 +599,7 @@ export function DocsLayout({
 
   const [isFullWidth, setIsFullWidth] = useLocalStorage('docsFullWidth', false)
 
-  const activePartners = partners.filter(
-    (d) =>
-      d.status === 'active' && d.name !== 'Nozzle.io' && d.id !== 'fireship',
-  )
+  const activePartners = partners.filter((d) => d.status === 'active')
 
   const groupInitialOpenState = React.useMemo(() => {
     return menuConfig.reduce<Record<string, boolean>>((acc, group, index) => {
@@ -937,31 +934,14 @@ export function DocsLayout({
           </div>
           {!isLandingPage && (
             <RightRail breakpoint="md" className="md:w-[280px]">
-              <div className="relative">
-                <PartnersRail
-                  analyticsPlacement="docs_right_rail"
-                  analyticsProperties={{
-                    framework: currentFramework.framework,
-                    library_id: libraryId,
-                  }}
-                  partners={activePartners}
-                />
-                <a
-                  href="https://docs.google.com/document/d/1Hg2MzY2TU6U3hFEZ3MLe2oEOM3JS4-eByti3kdJU3I8"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="absolute right-3 top-2 font-medium opacity-60 hover:opacity-100 text-xs hover:underline"
-                  onClick={() => {
-                    trackEvent('become_partner_clicked', {
-                      framework: currentFramework.framework,
-                      library_id: libraryId,
-                      placement: 'docs_right_rail',
-                    })
-                  }}
-                >
-                  Become a Partner
-                </a>
-              </div>
+              <PartnersRail
+                analyticsPlacement="docs_right_rail"
+                analyticsProperties={{
+                  framework: currentFramework.framework,
+                  library_id: libraryId,
+                }}
+                partners={activePartners}
+              />
               <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
                 <RecentPostsWidget />
               </div>

--- a/src/components/Gam.tsx
+++ b/src/components/Gam.tsx
@@ -59,7 +59,10 @@ export function GamVrec1({
   return (
     <div
       {...props}
-      className={twMerge('w-[300px] flex flex-col gap-3', props.className)}
+      className={twMerge(
+        'w-full max-w-[300px] flex flex-col gap-3',
+        props.className,
+      )}
     >
       {promos.map((promo) => (
         <Link

--- a/src/components/PartnersGrid.tsx
+++ b/src/components/PartnersGrid.tsx
@@ -36,14 +36,14 @@ const tierLayout: Record<
     padding: 'p-12',
   },
   silver: {
-    flexBasis: 'basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4',
+    flexBasis: 'basis-full sm:basis-1/3 lg:basis-1/4',
     minHeight: 'min-h-[130px]',
     logoMaxWidth: 'max-w-[180px]',
     logoMaxHeight: 'max-h-[56px]',
     padding: 'p-6',
   },
   bronze: {
-    flexBasis: 'basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 xl:basis-1/6',
+    flexBasis: 'basis-1/2 sm:basis-1/4 lg:basis-1/5 xl:basis-1/6',
     minHeight: 'min-h-[100px]',
     logoMaxWidth: 'max-w-[110px]',
     logoMaxHeight: 'max-h-[36px]',
@@ -137,35 +137,35 @@ export function PartnersGrid({
       {tiersWithPartners.map((row) => {
         const flare = partnerTierFlares[row.tier]
         return (
-        <Card
-          key={row.tier}
-          className={`overflow-hidden rounded-none rounded-l-sm rounded-r-2xl bg-gradient-to-b ${flare.gradientStops}`}
-        >
-          <div className="ml-1.5 bg-white dark:bg-gray-900">
-            <div className="px-4 pt-3 pb-2 border-b border-gray-200 dark:border-gray-800 flex items-center gap-2">
-              <span className={flare.iconColor}>{flare.icon}</span>
-              <span
-                className={`text-[10px] uppercase tracking-[0.18em] font-semibold ${flare.labelColor}`}
-              >
-                {partnerTierLabels[row.tier]}
-              </span>
+          <Card
+            key={row.tier}
+            className={`overflow-hidden rounded-none rounded-l-sm rounded-r-2xl bg-gradient-to-b ${flare.gradientStops}`}
+          >
+            <div className="ml-1.5 bg-white dark:bg-gray-900">
+              <div className="px-4 pt-3 pb-2 border-b border-gray-200 dark:border-gray-800 flex items-center gap-2">
+                <span className={flare.iconColor}>{flare.icon}</span>
+                <span
+                  className={`text-[10px] uppercase tracking-[0.18em] font-semibold ${flare.labelColor}`}
+                >
+                  {partnerTierLabels[row.tier]}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-stretch -mr-px -mb-px">
+                {row.partners.map((partner) => {
+                  const index = slotIndex++
+                  return (
+                    <PartnerGridItem
+                      key={partner.id}
+                      analyticsPlacement={analyticsPlacement}
+                      analyticsProperties={analyticsProperties}
+                      index={index}
+                      partner={partner}
+                    />
+                  )
+                })}
+              </div>
             </div>
-            <div className="flex flex-wrap items-stretch -mr-px -mb-px">
-              {row.partners.map((partner) => {
-                const index = slotIndex++
-                return (
-                  <PartnerGridItem
-                    key={partner.id}
-                    analyticsPlacement={analyticsPlacement}
-                    analyticsProperties={analyticsProperties}
-                    index={index}
-                    partner={partner}
-                  />
-                )
-              })}
-            </div>
-          </div>
-        </Card>
+          </Card>
         )
       })}
     </div>

--- a/src/components/PartnersGrid.tsx
+++ b/src/components/PartnersGrid.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react'
-import { partners as allPartners, PartnerImage } from '~/utils/partners'
+import {
+  partners as allPartners,
+  PartnerImage,
+  partnerTierFlares,
+  partnerTierLabels,
+  partnerTierOrder,
+  type PartnerTier,
+} from '~/utils/partners'
 import { Card } from '~/components/Card'
 import { trackEvent, useTrackedImpression } from '~/utils/analytics'
 
@@ -9,6 +16,39 @@ type PartnersGridProps = {
   analyticsPlacement?: string
   analyticsProperties?: Record<string, unknown>
   partnersList?: PartnerItem[]
+}
+
+const tierLayout: Record<
+  PartnerTier,
+  {
+    flexBasis: string
+    minHeight: string
+    logoMaxWidth: string
+    logoMaxHeight: string
+    padding: string
+  }
+> = {
+  gold: {
+    flexBasis: 'basis-full sm:basis-1/2',
+    minHeight: 'min-h-[220px]',
+    logoMaxWidth: 'max-w-[400px]',
+    logoMaxHeight: 'max-h-[120px]',
+    padding: 'p-12',
+  },
+  silver: {
+    flexBasis: 'basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4',
+    minHeight: 'min-h-[130px]',
+    logoMaxWidth: 'max-w-[180px]',
+    logoMaxHeight: 'max-h-[56px]',
+    padding: 'p-6',
+  },
+  bronze: {
+    flexBasis: 'basis-1/2 sm:basis-1/3 md:basis-1/4 lg:basis-1/5 xl:basis-1/6',
+    minHeight: 'min-h-[100px]',
+    logoMaxWidth: 'max-w-[110px]',
+    logoMaxHeight: 'max-h-[36px]',
+    padding: 'p-4',
+  },
 }
 
 function PartnerGridItem({
@@ -33,7 +73,7 @@ function PartnerGridItem({
     },
   })
 
-  const width = Math.max(Math.round(120 + 280 * partner.score), 150)
+  const layout = tierLayout[partner.tier ?? 'bronze']
 
   return (
     <a
@@ -41,10 +81,10 @@ function PartnerGridItem({
       href={partner.href}
       target="_blank"
       rel="noreferrer"
-      className="flex items-center justify-center p-6
+      className={`flex items-center justify-center
         border-r border-b border-gray-200 dark:border-gray-800
-        hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors duration-150 ease-out"
-      style={{ width, flexGrow: partner.score }}
+        hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors duration-150 ease-out
+        ${layout.flexBasis} ${layout.minHeight} ${layout.padding}`}
       onClick={() => {
         trackEvent('partner_card_clicked', {
           partner_id: partner.id,
@@ -56,7 +96,15 @@ function PartnerGridItem({
         })
       }}
     >
-      <PartnerImage config={partner.image} alt={partner.name} />
+      <div
+        className={`w-full flex items-center justify-center ${layout.logoMaxWidth}`}
+      >
+        <PartnerImage
+          className={`w-full object-contain ${layout.logoMaxHeight}`}
+          config={partner.image}
+          alt={partner.name}
+        />
+      </div>
     </a>
   )
 }
@@ -70,22 +118,56 @@ export function PartnersGrid({
     (partner) => partner.status === 'active',
   )
 
-  // Sort by score descending so larger partners come first
-  const sortedItems = [...items].sort((a, b) => b.score - a.score)
+  const tiers: Array<PartnerTier> = ['gold', 'silver', 'bronze']
+
+  const tiersWithPartners = tiers
+    .map((tier) => ({
+      tier,
+      partners: items
+        .filter((partner) => (partner.tier ?? 'bronze') === tier)
+        .sort((a, b) => b.score - a.score),
+    }))
+    .filter((row) => row.partners.length > 0)
+    .sort((a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier])
+
+  let slotIndex = 0
 
   return (
-    <Card className="overflow-hidden">
-      <div className="flex flex-wrap justify-center items-stretch -mr-px -mb-px">
-        {sortedItems.map((partner, index) => (
-          <PartnerGridItem
-            key={partner.id}
-            analyticsPlacement={analyticsPlacement}
-            analyticsProperties={analyticsProperties}
-            index={index}
-            partner={partner}
-          />
-        ))}
-      </div>
-    </Card>
+    <div className="flex flex-col gap-3">
+      {tiersWithPartners.map((row) => {
+        const flare = partnerTierFlares[row.tier]
+        return (
+        <Card
+          key={row.tier}
+          className={`overflow-hidden rounded-none rounded-l-sm rounded-r-2xl bg-gradient-to-b ${flare.gradientStops}`}
+        >
+          <div className="ml-1.5 bg-white dark:bg-gray-900">
+            <div className="px-4 pt-3 pb-2 border-b border-gray-200 dark:border-gray-800 flex items-center gap-2">
+              <span className={flare.iconColor}>{flare.icon}</span>
+              <span
+                className={`text-[10px] uppercase tracking-[0.18em] font-semibold ${flare.labelColor}`}
+              >
+                {partnerTierLabels[row.tier]}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-stretch -mr-px -mb-px">
+              {row.partners.map((partner) => {
+                const index = slotIndex++
+                return (
+                  <PartnerGridItem
+                    key={partner.id}
+                    analyticsPlacement={analyticsPlacement}
+                    analyticsProperties={analyticsProperties}
+                    index={index}
+                    partner={partner}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        </Card>
+        )
+      })}
+    </div>
   )
 }

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -115,7 +115,7 @@ export function PartnersRail({
   let slotIndex = 0
 
   return (
-    <div className="flex flex-col border-l border-gray-500/20 rounded-bl-lg overflow-hidden w-full">
+    <div className="group/rail flex flex-col border-l border-gray-500/20 rounded-bl-lg overflow-hidden w-full">
       <div className="w-full flex gap-2 justify-between items-center border-b border-gray-500/20 px-3 py-2">
         <Link
           className="font-medium opacity-60 hover:opacity-100 text-xs"
@@ -205,7 +205,7 @@ function PartnersRailItem({
       target="_blank"
       rel="noreferrer"
       className={twMerge(
-        'group flex items-center justify-center overflow-hidden border-r border-b border-gray-500/20 hover:bg-gray-500/10 transition-colors duration-150 ease-out',
+        'flex items-center justify-center overflow-hidden border-r border-b border-gray-500/20 hover:bg-gray-500/10 transition-colors duration-150 ease-out',
         layout.flexBasis,
         layout.minHeight,
         layout.padding,
@@ -223,7 +223,7 @@ function PartnersRailItem({
     >
       <div
         className={twMerge(
-          'w-full flex items-center justify-center mx-auto grayscale brightness-90 group-hover:grayscale-0 group-hover:brightness-100 transition-[filter] duration-150 ease-out',
+          'w-full flex items-center justify-center mx-auto grayscale brightness-90 group-hover/rail:grayscale-0 group-hover/rail:brightness-100 transition-[filter] duration-150 ease-out',
           layout.logoMaxWidth,
         )}
       >

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -110,9 +110,7 @@ export function PartnersRail({
         .sort((a, b) => b.score - a.score),
     }))
     .filter((row) => row.partners.length > 0)
-    .sort(
-      (a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier],
-    )
+    .sort((a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier])
 
   let slotIndex = 0
 

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react'
 import { Link } from '@tanstack/react-router'
 import { twMerge } from 'tailwind-merge'
-import { PartnerImage } from '~/utils/partners'
+import {
+  PartnerImage,
+  partnerTierFlares,
+  partnerTierLabels,
+  partnerTierOrder,
+  type PartnerTier,
+} from '~/utils/partners'
 import { trackEvent, useTrackedImpression } from '~/utils/analytics'
 
 type RailPartner = {
@@ -9,6 +15,7 @@ type RailPartner = {
   name: string
   href: string
   score: number
+  tier?: PartnerTier
   image: Parameters<typeof PartnerImage>[0]['config']
 }
 
@@ -38,13 +45,46 @@ export function RightRail({
       <div
         className={twMerge(
           innerBreakpointClass,
-          'ml-auto flex flex-col gap-4 pb-4 max-w-full overflow-y-auto',
+          'ml-auto flex flex-col gap-4 pb-4 max-w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0',
         )}
       >
         {children}
       </div>
     </div>
   )
+}
+
+const railTierLayout: Record<
+  PartnerTier,
+  {
+    flexBasis: string
+    minHeight: string
+    logoMaxWidth: string
+    logoMaxHeight: string
+    padding: string
+  }
+> = {
+  gold: {
+    flexBasis: 'basis-full',
+    minHeight: 'min-h-[72px]',
+    logoMaxWidth: 'max-w-[180px]',
+    logoMaxHeight: 'max-h-[40px]',
+    padding: 'px-4 py-3',
+  },
+  silver: {
+    flexBasis: 'basis-1/2',
+    minHeight: 'min-h-[60px]',
+    logoMaxWidth: 'max-w-[100px]',
+    logoMaxHeight: 'max-h-[26px]',
+    padding: 'px-2.5 py-2.5',
+  },
+  bronze: {
+    flexBasis: 'basis-1/3',
+    minHeight: 'min-h-[56px]',
+    logoMaxWidth: 'max-w-[70px]',
+    logoMaxHeight: 'max-h-[22px]',
+    padding: 'px-2 py-2',
+  },
 }
 
 export function PartnersRail({
@@ -60,25 +100,79 @@ export function PartnersRail({
   title?: string
   titleTo?: '/partners'
 }) {
+  const tiers: Array<PartnerTier> = ['gold', 'silver', 'bronze']
+
+  const rowsByTier = tiers
+    .map((tier) => ({
+      tier,
+      partners: partners
+        .filter((partner) => (partner.tier ?? 'bronze') === tier)
+        .sort((a, b) => b.score - a.score),
+    }))
+    .filter((row) => row.partners.length > 0)
+    .sort(
+      (a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier],
+    )
+
+  let slotIndex = 0
+
   return (
-    <div className="flex flex-wrap items-stretch border-l border-gray-500/20 rounded-bl-lg overflow-hidden w-full">
-      <div className="w-full flex gap-2 justify-between border-b border-gray-500/20 px-3 py-2">
+    <div className="flex flex-col border-l border-gray-500/20 rounded-bl-lg overflow-hidden w-full">
+      <div className="w-full flex gap-2 justify-between items-center border-b border-gray-500/20 px-3 py-2">
         <Link
           className="font-medium opacity-60 hover:opacity-100 text-xs"
           to={titleTo}
         >
           {title}
         </Link>
+        <a
+          href="https://docs.google.com/document/d/1Hg2MzY2TU6U3hFEZ3MLe2oEOM3JS4-eByti3kdJU3I8"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium opacity-60 hover:opacity-100 text-xs hover:underline"
+          onClick={() => {
+            trackEvent('become_partner_clicked', {
+              placement: analyticsPlacement,
+              ...analyticsProperties,
+            })
+          }}
+        >
+          Become a Partner
+        </a>
       </div>
-      {partners.map((partner, index) => (
-        <PartnersRailItem
-          key={partner.id}
-          analyticsPlacement={analyticsPlacement}
-          analyticsProperties={analyticsProperties}
-          index={index}
-          partner={partner}
-        />
-      ))}
+      {rowsByTier.map((row) => {
+        const flare = partnerTierFlares[row.tier]
+        return (
+          <div
+            key={row.tier}
+            className="relative flex flex-wrap items-stretch w-full"
+          >
+            {/* Tier-colored top line */}
+            <div
+              className={`absolute top-0 left-0 right-0 h-1 bg-gradient-to-r ${flare.gradientStops}`}
+            />
+            {/* Absolute top-left tier label */}
+            <div
+              className={`absolute top-0.5 left-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-1 px-1.5 py-px rounded-full bg-white dark:bg-gray-900 z-10 ${flare.labelColor} text-[8px] uppercase tracking-[0.14em] font-semibold`}
+            >
+              <span className={flare.iconColor}>{flare.icon}</span>
+              <span>{partnerTierLabels[row.tier]}</span>
+            </div>
+            {row.partners.map((partner) => {
+              const index = slotIndex++
+              return (
+                <PartnersRailItem
+                  key={partner.id}
+                  analyticsPlacement={analyticsPlacement}
+                  analyticsProperties={analyticsProperties}
+                  index={index}
+                  partner={partner}
+                />
+              )
+            })}
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -94,7 +188,7 @@ function PartnersRailItem({
   index: number
   partner: RailPartner
 }) {
-  const widthPercent = Math.round(partner.score * 100)
+  const layout = railTierLayout[partner.tier ?? 'bronze']
   const ref = useTrackedImpression<HTMLAnchorElement>({
     event: 'partner_impression',
     properties: {
@@ -112,12 +206,12 @@ function PartnersRailItem({
       href={partner.href}
       target="_blank"
       rel="noreferrer"
-      className="flex items-center justify-center px-3 py-2 border-r border-b border-gray-500/20 hover:bg-gray-500/10 transition-colors duration-150 ease-out"
-      style={{
-        flexBasis: `${widthPercent}%`,
-        flexGrow: 1,
-        flexShrink: 0,
-      }}
+      className={twMerge(
+        'group flex items-center justify-center overflow-hidden border-r border-b border-gray-500/20 hover:bg-gray-500/10 transition-colors duration-150 ease-out',
+        layout.flexBasis,
+        layout.minHeight,
+        layout.padding,
+      )}
       onClick={() => {
         trackEvent('partner_click', {
           partner_id: partner.id,
@@ -130,11 +224,16 @@ function PartnersRailItem({
       }}
     >
       <div
-        style={{
-          width: Math.max(60 + Math.round(140 * partner.score), 70),
-        }}
+        className={twMerge(
+          'w-full flex items-center justify-center mx-auto grayscale brightness-90 group-hover:grayscale-0 group-hover:brightness-100 transition-[filter] duration-150 ease-out',
+          layout.logoMaxWidth,
+        )}
       >
-        <PartnerImage config={partner.image} alt={partner.name} />
+        <PartnerImage
+          className={twMerge('w-full object-contain', layout.logoMaxHeight)}
+          config={partner.image}
+          alt={partner.name}
+        />
       </div>
     </a>
   )

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -223,7 +223,7 @@ function PartnersRailItem({
     >
       <div
         className={twMerge(
-          'w-full flex items-center justify-center mx-auto grayscale brightness-90 group-hover/rail:grayscale-0 group-hover/rail:brightness-100 transition-[filter] duration-150 ease-out',
+          'w-full flex items-center justify-center mx-auto grayscale brightness-90 group-hover/rail:grayscale-0 group-hover/rail:brightness-100 transition-[filter] duration-500 ease-out',
           layout.logoMaxWidth,
         )}
       >

--- a/src/routes/blog.$.tsx
+++ b/src/routes/blog.$.tsx
@@ -113,13 +113,7 @@ function BlogPost() {
   const repo = 'tanstack/tanstack.com'
   const branch = 'main'
   const activePartners = React.useMemo(
-    () =>
-      partners.filter(
-        (d) =>
-          d.status === 'active' &&
-          d.name !== 'Nozzle.io' &&
-          d.id !== 'fireship',
-      ),
+    () => partners.filter((d) => d.status === 'active'),
     [],
   )
 

--- a/src/routes/blog.index.tsx
+++ b/src/routes/blog.index.tsx
@@ -70,16 +70,13 @@ export const Route = createFileRoute('/blog/')({
 
 function BlogIndex() {
   const frontMatters = Route.useLoaderData() as BlogFrontMatter[]
-  const activePartners = partners.filter(
-    (d) =>
-      d.status === 'active' && d.name !== 'Nozzle.io' && d.id !== 'fireship',
-  )
+  const activePartners = partners.filter((d) => d.status === 'active')
 
   return (
-    <div className="flex flex-col max-w-full min-h-screen gap-16 p-4 md:p-8 pb-0">
-      <div className="flex-1 w-full max-w-[1400px] mx-auto">
-        <div className="flex gap-8 items-start">
-          <div className="flex-1 space-y-12 min-w-0">
+    <div className="flex flex-col max-w-full min-h-screen">
+      <div className="flex-1 flex w-full mb-16">
+        <div className="flex-1 p-4 md:p-8 min-w-0 flex justify-center">
+          <div className="w-full max-w-[1100px] space-y-12">
             <header className="">
               <div className="flex gap-3 items-baseline">
                 <h1 className="text-3xl font-black">Blog</h1>
@@ -153,19 +150,19 @@ function BlogIndex() {
               )}
             </section>
           </div>
-          <RightRail breakpoint="md">
-            <PartnersRail
-              analyticsPlacement="blog_right_rail"
-              partners={activePartners}
-            />
-            <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
-              <RecentPostsWidget />
-            </div>
-            <Card>
-              <LibrariesWidget />
-            </Card>
-          </RightRail>
         </div>
+        <RightRail breakpoint="md">
+          <PartnersRail
+            analyticsPlacement="blog_right_rail"
+            partners={activePartners}
+          />
+          <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
+            <RecentPostsWidget />
+          </div>
+          <Card>
+            <LibrariesWidget />
+          </Card>
+        </RightRail>
       </div>
       <Footer />
     </div>

--- a/src/routes/partners.index.tsx
+++ b/src/routes/partners.index.tsx
@@ -1,14 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Footer } from '~/components/Footer'
 import { Card } from '~/components/Card'
-import { partners, PartnerImage } from '~/utils/partners'
+import {
+  partners,
+  PartnerImage,
+  partnerTierFlares,
+  partnerTierLabels,
+  partnerTierOrder,
+  type PartnerTier,
+} from '~/utils/partners'
 import { seo } from '~/utils/seo'
 import { Library } from '~/libraries'
 import { useState } from 'react'
 import * as React from 'react'
 import { ListFilter, X } from 'lucide-react'
 import { Button } from '~/ui'
-import { NetlifyImage } from '~/components/NetlifyImage'
 import { startProject } from '~/libraries/start'
 import { routerProject } from '~/libraries/router'
 import { queryProject } from '~/libraries/query'
@@ -301,16 +307,60 @@ function getFilteredPartners(search: PartnersSearch) {
   })
 }
 
+type CardSize = 'gold' | 'silver' | 'bronze' | 'flat'
+
+const cardSizeLayout: Record<
+  CardSize,
+  {
+    padding: string
+    logoFrame: string
+    logoMaxHeight: string
+    titleSize: string
+    showDescription: boolean
+  }
+> = {
+  gold: {
+    padding: 'p-8',
+    logoFrame: 'h-32',
+    logoMaxHeight: 'max-h-24',
+    titleSize: 'text-2xl',
+    showDescription: true,
+  },
+  silver: {
+    padding: 'p-6',
+    logoFrame: 'h-24',
+    logoMaxHeight: 'max-h-16',
+    titleSize: 'text-lg',
+    showDescription: true,
+  },
+  bronze: {
+    padding: 'p-4',
+    logoFrame: 'h-16',
+    logoMaxHeight: 'max-h-10',
+    titleSize: 'text-sm',
+    showDescription: false,
+  },
+  flat: {
+    padding: 'p-6',
+    logoFrame: 'h-24',
+    logoMaxHeight: 'max-h-16',
+    titleSize: 'text-xl',
+    showDescription: true,
+  },
+}
+
 function PartnerDirectoryCard({
   filters,
   isShowingPrevious,
   partner,
   slotIndex,
+  size = 'flat',
 }: {
   filters: PartnersSearch
   isShowingPrevious: boolean
   partner: (typeof partners)[number]
   slotIndex: number
+  size?: CardSize
 }) {
   const ref = useTrackedImpression<HTMLAnchorElement>({
     event: 'partner_impression',
@@ -329,6 +379,8 @@ function PartnerDirectoryCard({
       ? `${partner.startDate} - ${partner.endDate}`
       : null
 
+  const layout = cardSizeLayout[size]
+
   return (
     <a
       ref={ref}
@@ -346,48 +398,135 @@ function PartnerDirectoryCard({
       }}
     >
       <Card className="overflow-hidden hover:border-blue-500/40 hover:shadow-lg transition-all h-full">
-        <div className="p-6 h-full flex flex-col">
-          <div className="mb-4 h-24 flex items-center justify-center">
-            <PartnerImage config={partner.image} alt={partner.name} />
+        <div className={`${layout.padding} h-full flex flex-col`}>
+          <div
+            className={`mb-4 ${layout.logoFrame} flex items-center justify-center`}
+          >
+            <PartnerImage
+              className={`w-full object-contain ${layout.logoMaxHeight}`}
+              config={partner.image}
+              alt={partner.name}
+            />
           </div>
-          <h3 className="text-center text-xl font-semibold mb-2">
+          <h3
+            className={`text-center ${layout.titleSize} font-semibold mb-2`}
+          >
             {partner.name}
           </h3>
           {partner.tagline && (
-            <p className="text-center text-sm text-gray-600 dark:text-gray-400 mb-4">
+            <p className="text-center text-xs text-gray-600 dark:text-gray-400 mb-4">
               {partner.tagline}
             </p>
           )}
-          <div className="text-sm flex-1">
-            {isShowingPrevious ? (
-              <>
-                {duration && (
-                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 text-center">
-                    {duration}
-                  </p>
-                )}
-                {partner.libraries && partner.libraries.length > 0 && (
-                  <div className="flex flex-wrap gap-1 justify-center">
-                    {partner.libraries.map((library) => (
-                      <span
-                        key={library}
-                        className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 rounded-md"
-                      >
-                        {library}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </>
-            ) : (
-              <p className="text-gray-700 dark:text-gray-300">
-                {partner.llmDescription}
-              </p>
-            )}
-          </div>
+          {layout.showDescription && (
+            <div className="text-sm flex-1">
+              {isShowingPrevious ? (
+                <>
+                  {duration && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 text-center">
+                      {duration}
+                    </p>
+                  )}
+                  {partner.libraries && partner.libraries.length > 0 && (
+                    <div className="flex flex-wrap gap-1 justify-center">
+                      {partner.libraries.map((library) => (
+                        <span
+                          key={library}
+                          className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 rounded-md"
+                        >
+                          {library}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-gray-700 dark:text-gray-300">
+                  {partner.llmDescription}
+                </p>
+              )}
+            </div>
+          )}
         </div>
       </Card>
     </a>
+  )
+}
+
+const tierGridCols: Record<PartnerTier, string> = {
+  gold: 'grid grid-cols-1 lg:grid-cols-2 gap-6',
+  silver: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6',
+  bronze: 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4',
+}
+
+function TierSectionHeader({ tier }: { tier: PartnerTier }) {
+  const flare = partnerTierFlares[tier]
+  return (
+    <div className="flex items-center gap-4 mb-8">
+      <div
+        className={`h-px flex-1 bg-gradient-to-r from-transparent ${flare.gradientStops}`}
+      />
+      <div
+        className={`flex items-center gap-2 px-3 py-1 rounded-full ${flare.labelColor}`}
+      >
+        <span className={flare.iconColor}>{flare.icon}</span>
+        <span className="text-xs uppercase tracking-[0.2em] font-bold">
+          {partnerTierLabels[tier]}
+        </span>
+      </div>
+      <div
+        className={`h-px flex-1 bg-gradient-to-l from-transparent ${flare.gradientStops}`}
+      />
+    </div>
+  )
+}
+
+function TieredPartnerSections({
+  partners: allPartners,
+  filters,
+}: {
+  partners: Array<(typeof partners)[number]>
+  filters: PartnersSearch
+}) {
+  const tiers: Array<PartnerTier> = ['gold', 'silver', 'bronze']
+
+  const sections = tiers
+    .map((tier) => ({
+      tier,
+      partners: allPartners
+        .filter((partner) => (partner.tier ?? 'bronze') === tier)
+        .sort((a, b) => b.score - a.score),
+    }))
+    .filter((section) => section.partners.length > 0)
+    .sort(
+      (a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier],
+    )
+
+  let slotIndex = 0
+
+  return (
+    <div className="space-y-16">
+      {sections.map((section) => (
+        <section key={section.tier}>
+          <TierSectionHeader tier={section.tier} />
+          <div className={tierGridCols[section.tier]}>
+            {section.partners.map((partner) => {
+              const index = slotIndex++
+              return (
+                <PartnerDirectoryCard
+                  key={partner.id}
+                  filters={filters}
+                  isShowingPrevious={false}
+                  partner={partner}
+                  slotIndex={index}
+                  size={section.tier}
+                />
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
   )
 }
 
@@ -488,17 +627,24 @@ function PartnersIndexPage() {
               </p>
             )}
 
-            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-              {filteredPartners.map((partner, slotIndex) => (
-                <PartnerDirectoryCard
-                  key={partner.id}
-                  filters={search}
-                  isShowingPrevious={isShowingPrevious}
-                  partner={partner}
-                  slotIndex={slotIndex}
-                />
-              ))}
-            </div>
+            {isShowingActive && !hasLibraryFilter ? (
+              <TieredPartnerSections
+                partners={filteredPartners}
+                filters={search}
+              />
+            ) : (
+              <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                {filteredPartners.map((partner, slotIndex) => (
+                  <PartnerDirectoryCard
+                    key={partner.id}
+                    filters={search}
+                    isShowingPrevious={isShowingPrevious}
+                    partner={partner}
+                    slotIndex={slotIndex}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           <div className="text-center text-gray-600 dark:text-gray-400">
@@ -541,33 +687,6 @@ function PartnersIndexPage() {
           </a>
         </div>
 
-        <div className="text-center py-8 border-t border-gray-200 dark:border-gray-700">
-          <a
-            href="#lifetime-support-share"
-            className="anchor-heading *:scroll-my-20 *:lg:scroll-my-4"
-          >
-            <h2
-              id="lifetime-support-share"
-              className="text-2xl font-semibold mb-4"
-            >
-              Lifetime Support Share
-            </h2>
-          </a>
-          <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-xl mx-auto">
-            This chart is a percentage-based visualization of the lifetime
-            support each partner has rendered to TanStack. It is updated every 6
-            months.
-          </p>
-          <div className="flex justify-center">
-            <NetlifyImage
-              src="/images/total-support-share.png"
-              alt="Lifetime Support Share chart showing percentage-based contribution of partners to TanStack"
-              className="rounded-lg shadow-lg"
-              width={600}
-              height={706}
-            />
-          </div>
-        </div>
       </div>
       <Footer />
     </div>

--- a/src/routes/partners.index.tsx
+++ b/src/routes/partners.index.tsx
@@ -408,9 +408,7 @@ function PartnerDirectoryCard({
               alt={partner.name}
             />
           </div>
-          <h3
-            className={`text-center ${layout.titleSize} font-semibold mb-2`}
-          >
+          <h3 className={`text-center ${layout.titleSize} font-semibold mb-2`}>
             {partner.name}
           </h3>
           {partner.tagline && (
@@ -498,9 +496,7 @@ function TieredPartnerSections({
         .sort((a, b) => b.score - a.score),
     }))
     .filter((section) => section.partners.length > 0)
-    .sort(
-      (a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier],
-    )
+    .sort((a, b) => partnerTierOrder[a.tier] - partnerTierOrder[b.tier])
 
   let slotIndex = 0
 
@@ -686,7 +682,6 @@ function PartnersIndexPage() {
             Get in Touch
           </a>
         </div>
-
       </div>
       <Footer />
     </div>

--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -74,12 +74,14 @@ export const partnerTierOrder: Record<PartnerTier, number> = {
   bronze: 2,
 }
 
-const partnerTierToBuilderTier: Record<PartnerTier, ApplicationStarterPartnerTier> =
-  {
-    gold: 1,
-    silver: 2,
-    bronze: 3,
-  }
+const partnerTierToBuilderTier: Record<
+  PartnerTier,
+  ApplicationStarterPartnerTier
+> = {
+  gold: 1,
+  silver: 2,
+  bronze: 3,
+}
 
 export const partnerTierFlares: Record<
   PartnerTier,

--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -59,6 +59,75 @@ type PartnerApplicationStarterIcon = {
 
 type ApplicationStarterPartnerTier = 1 | 2 | 3
 
+export const partnerTiers = ['gold', 'silver', 'bronze'] as const
+export type PartnerTier = (typeof partnerTiers)[number]
+
+export const partnerTierLabels: Record<PartnerTier, string> = {
+  gold: 'Gold',
+  silver: 'Silver',
+  bronze: 'Bronze',
+}
+
+export const partnerTierOrder: Record<PartnerTier, number> = {
+  gold: 0,
+  silver: 1,
+  bronze: 2,
+}
+
+const partnerTierToBuilderTier: Record<PartnerTier, ApplicationStarterPartnerTier> =
+  {
+    gold: 1,
+    silver: 2,
+    bronze: 3,
+  }
+
+export const partnerTierFlares: Record<
+  PartnerTier,
+  {
+    gradientStops: string
+    iconColor: string
+    labelColor: string
+    icon: React.ReactNode
+  }
+> = {
+  gold: {
+    gradientStops:
+      'from-yellow-400 via-amber-500 to-orange-600 dark:from-yellow-300 dark:via-amber-400 dark:to-orange-400',
+    iconColor: 'text-amber-500 dark:text-amber-300',
+    labelColor: 'text-amber-600 dark:text-amber-300',
+    // 5-point star
+    icon: (
+      <svg viewBox="0 0 12 12" className="h-3 w-3 fill-current" aria-hidden>
+        <path d="M6 0.5 L7.5 4.2 L11.5 4.6 L8.5 7.2 L9.4 11.2 L6 9.2 L2.6 11.2 L3.5 7.2 L0.5 4.6 L4.5 4.2 Z" />
+      </svg>
+    ),
+  },
+  silver: {
+    gradientStops:
+      'from-slate-200 via-zinc-400 to-slate-300 dark:from-slate-300 dark:via-zinc-400 dark:to-slate-400',
+    iconColor: 'text-slate-400 dark:text-slate-300',
+    labelColor: 'text-slate-500 dark:text-slate-300',
+    // 4-point sparkle
+    icon: (
+      <svg viewBox="0 0 12 12" className="h-3 w-3 fill-current" aria-hidden>
+        <path d="M6 0 L7.2 4.8 L12 6 L7.2 7.2 L6 12 L4.8 7.2 L0 6 L4.8 4.8 Z" />
+      </svg>
+    ),
+  },
+  bronze: {
+    gradientStops:
+      'from-amber-700 via-amber-800 to-amber-950 dark:from-amber-600 dark:via-amber-800 dark:to-amber-950',
+    iconColor: 'text-amber-800 dark:text-amber-600',
+    labelColor: 'text-amber-800 dark:text-amber-600',
+    // diamond
+    icon: (
+      <svg viewBox="0 0 12 12" className="h-3 w-3 fill-current" aria-hidden>
+        <path d="M6 0.5 L11.5 6 L6 11.5 L0.5 6 Z" />
+      </svg>
+    ),
+  },
+}
+
 export function PartnerImage({
   className,
   config,
@@ -162,6 +231,7 @@ export type Partner = {
   startDate?: string
   endDate?: string
   score: number
+  tier?: PartnerTier
   brandColor?: string // Primary brand color for game elements
   tagline?: string // Short tagline for game info cards
 }
@@ -175,7 +245,6 @@ export type ApplicationStarterPartnerSuggestion = {
   iconSrc?: string
   image: Partner['image']
   label: string
-  sortOrder: number
   tags: Array<string>
   tier: ApplicationStarterPartnerTier
 }
@@ -259,6 +328,7 @@ const neon = (() => {
     libraries: ['start', 'router'],
     status: 'active' as const,
     score: 0.297,
+    tier: 'silver' as const,
     href,
     brandColor: '#00E599',
     tagline: 'Serverless Postgres',
@@ -328,12 +398,13 @@ const clerk = (() => {
     libraries: ['start', 'router'],
     status: 'active' as const,
     score: 0.286,
+    tier: 'silver' as const,
     brandColor: '#6C47FF',
     tagline: 'Authentication',
     image: {
       light: clerkLightSvg,
       dark: clerkDarkSvg,
-      scale: 0.85,
+      scale: 0.72,
     },
     llmDescription:
       'Authentication and user management platform with prebuilt UI, sessions, organizations, and MFA. Clerk has official SDKs and quickstarts for TanStack React Start and React Router.',
@@ -363,6 +434,7 @@ const workos = (() => {
     libraries: ['start', 'router'] as const,
     status: 'active' as const,
     score: 0.314,
+    tier: 'silver' as const,
     brandColor: '#6363F1',
     tagline: 'Enterprise Auth',
     applicationStarterIcon: {
@@ -400,6 +472,7 @@ const agGrid = (() => {
     libraries: ['table'] as const,
     status: 'active' as const,
     score: 0.497,
+    tier: 'silver' as const,
     href,
     brandColor: '#FF8C00',
     tagline: 'Enterprise Data Grid',
@@ -452,6 +525,7 @@ const netlify = (() => {
     libraries: ['start', 'router'],
     status: 'active' as const,
     score: 0.343,
+    tier: 'silver' as const,
     href,
     brandColor: '#00C7B7',
     tagline: 'Web Deployment',
@@ -462,6 +536,7 @@ const netlify = (() => {
     image: {
       light: netlifyLightSvg,
       dark: netlifyDarkSvg,
+      scale: 1.25,
     },
     llmDescription:
       'Deployment platform for web applications with Deploy Previews, Functions, Edge Functions, and an official TanStack Start integration guide.',
@@ -491,6 +566,7 @@ const cloudflare = (() => {
     libraries: libraries.map((l) => l.id),
     status: 'active' as const,
     score: 0.857,
+    tier: 'gold' as const,
     startDate: 'Sep 2025',
     brandColor: '#F6821F',
     tagline: 'Edge Deployment',
@@ -523,6 +599,7 @@ const sentry = (() => {
     libraries: ['start', 'router'],
     status: 'active' as const,
     score: 0.229,
+    tier: 'bronze' as const,
     href,
     brandColor: '#362D59',
     tagline: 'Error Monitoring',
@@ -554,7 +631,7 @@ const fireship = (() => {
     name: 'Fireship',
     id: 'fireship',
     libraries: [],
-    status: 'active' as const,
+    status: 'inactive' as const,
     score: 0.014,
     href,
     tagline: 'Dev Education',
@@ -610,7 +687,7 @@ const nozzle = (() => {
     name: 'Nozzle.io',
     id: 'nozzle',
     href,
-    status: 'active' as const,
+    status: 'inactive' as const,
     score: 0.014,
     tagline: 'Enterprise SEO',
     image: {
@@ -677,6 +754,7 @@ const unkey = (() => {
     libraries: ['pacer'] as const,
     status: 'active' as const,
     score: 0.051,
+    tier: 'bronze' as const,
     href,
     brandColor: '#222222',
     tagline: 'API Key Management',
@@ -716,6 +794,7 @@ const serpApi = (() => {
     libraries: libraries.map((l) => l.id),
     status: 'active' as const,
     score: 0.41,
+    tier: 'silver' as const,
     href,
     brandColor: '#6361EC',
     tagline: 'Real-time SERP API',
@@ -755,6 +834,7 @@ const electric = (() => {
     libraries: ['db'] as const,
     status: 'active' as const,
     score: 0.283,
+    tier: 'bronze' as const,
     href,
     brandColor: '#7e78db',
     tagline: 'Sync Engine',
@@ -828,6 +908,7 @@ const prisma = (() => {
     libraries: ['db', 'start'] as const,
     startDate: 'Aug 2025',
     score: 0.143,
+    tier: 'bronze' as const,
     brandColor: '#2D3748',
     tagline: 'Database ORM',
     image: {
@@ -863,6 +944,7 @@ const codeRabbit = (() => {
     libraries: libraries.map((l) => l.id),
     startDate: 'Aug 2025',
     score: 1,
+    tier: 'gold' as const,
     brandColor: '#FF6B2B',
     tagline: 'AI Code Review',
     applicationStarterPromptInstructions: [
@@ -900,6 +982,7 @@ const strapi = (() => {
     libraries: ['start', 'router'] as const,
     status: 'active' as const,
     score: 0.069,
+    tier: 'bronze' as const,
     href,
     brandColor: '#4945FF',
     tagline: 'Headless CMS',
@@ -936,6 +1019,7 @@ const powerSync = (() => {
     status: 'active' as const,
     startDate: 'Jan 2026',
     score: 0.143,
+    tier: 'bronze' as const,
     href,
     tagline: 'Offline-first Sync',
     applicationStarterPromptInstructions: [
@@ -946,6 +1030,7 @@ const powerSync = (() => {
     image: {
       light: powersyncBlackSvg,
       dark: powersyncWhiteSvg,
+      scale: 1.2,
     },
     llmDescription:
       'Sync engine that keeps backend databases in sync with embedded client-side SQLite for offline-first and realtime applications. Postgres and MongoDB are supported, with MySQL and SQL Server in beta.',
@@ -974,6 +1059,7 @@ const railway = (() => {
     libraries: libraries.map((l) => l.id),
     status: 'active' as const,
     score: 0.145,
+    tier: 'bronze' as const,
     href,
     brandColor: '#0B0D0E',
     tagline: 'Instant Deployment',
@@ -1010,6 +1096,7 @@ const openRouter = (() => {
     status: 'active' as const,
     startDate: 'Mar 2026',
     score: 0.344,
+    tier: 'silver' as const,
     brandColor: '#7C3AED',
     tagline: 'Unified LLM API',
     applicationStarterPromptInstructions: [
@@ -1020,6 +1107,7 @@ const openRouter = (() => {
     image: {
       light: openrouterBlackSvg,
       dark: openrouterWhiteSvg,
+      scale: 1.25,
     },
     llmDescription:
       'Unified API for accessing hundreds of AI models from dozens of providers through a single OpenAI-compatible endpoint, with routing, fallbacks, and privacy controls.',
@@ -1069,30 +1157,6 @@ export const partners: Partner[] = [
   vercel,
   speakeasy,
 ] as Partner[]
-
-const applicationStarterPartnerTierOrder = new Map<
-  string,
-  { sortOrder: number; tier: ApplicationStarterPartnerTier }
->([
-  ['coderabbit', { tier: 1, sortOrder: 0 }],
-  ['cloudflare', { tier: 1, sortOrder: 1 }],
-  ['aggrid', { tier: 2, sortOrder: 0 }],
-  ['supabase', { tier: 2, sortOrder: 1 }],
-  ['serpapi', { tier: 2, sortOrder: 2 }],
-  ['netlify', { tier: 2, sortOrder: 3 }],
-  ['openrouter', { tier: 2, sortOrder: 4 }],
-  ['workos', { tier: 2, sortOrder: 5 }],
-  ['clerk', { tier: 2, sortOrder: 6 }],
-  ['electric', { tier: 2, sortOrder: 7 }],
-  ['railway', { tier: 2, sortOrder: 8 }],
-  ['sentry', { tier: 3, sortOrder: 0 }],
-  ['prisma', { tier: 3, sortOrder: 1 }],
-  ['powersync', { tier: 3, sortOrder: 2 }],
-  ['neon', { tier: 3, sortOrder: 3 }],
-  ['strapi', { tier: 3, sortOrder: 4 }],
-  ['unkey', { tier: 3, sortOrder: 5 }],
-  ['uidev', { tier: 3, sortOrder: 6 }],
-])
 
 const applicationStarterBrandColorOverrides = new Map<string, string>([
   ['powersync', '#00D5FF'],
@@ -1193,19 +1257,9 @@ function normalizeApplicationStarterPartnerKey(value: string) {
 }
 
 function getApplicationStarterPartnerTier(
-  partner: Pick<Partner, 'id' | 'name'>,
-) {
-  return (
-    applicationStarterPartnerTierOrder.get(
-      normalizeApplicationStarterPartnerKey(partner.id),
-    ) ??
-    applicationStarterPartnerTierOrder.get(
-      normalizeApplicationStarterPartnerKey(partner.name),
-    ) ?? {
-      tier: 3 as const,
-      sortOrder: Number.MAX_SAFE_INTEGER,
-    }
-  )
+  partner: Pick<Partner, 'tier'>,
+): ApplicationStarterPartnerTier {
+  return partner.tier ? partnerTierToBuilderTier[partner.tier] : 3
 }
 
 function getApplicationStarterPartnerFaviconUrl(href: string) {
@@ -1294,14 +1348,13 @@ export function getInferredApplicationStarterPartnerIdsFromUserInput(
 const applicationStarterPartnerSuggestions: Array<ApplicationStarterPartnerSuggestion> =
   [...partners]
     .filter((partner) => partner.status === 'active')
-    .filter((partner) => partner.id !== 'fireship' && partner.id !== 'nozzle')
     .map((partner) => {
-      const tierConfig = getApplicationStarterPartnerTier(partner)
+      const tier = getApplicationStarterPartnerTier(partner)
       const normalizedPartnerKey = normalizeApplicationStarterPartnerKey(
         partner.id,
       )
       const iconMode: ApplicationStarterPartnerSuggestion['iconMode'] =
-        tierConfig.tier === 2
+        tier === 2
           ? (partner.applicationStarterIcon?.mode ?? 'contain')
           : undefined
 
@@ -1312,7 +1365,7 @@ const applicationStarterPartnerSuggestions: Array<ApplicationStarterPartnerSugge
         hint: `${partner.name} (${partnerCategoryLabels[partner.category]})`,
         iconMode,
         iconSrc:
-          tierConfig.tier === 2
+          tier === 2
             ? (partner.applicationStarterIcon?.src ??
               getApplicationStarterPartnerFaviconUrl(partner.href))
             : undefined,
@@ -1321,17 +1374,13 @@ const applicationStarterPartnerSuggestions: Array<ApplicationStarterPartnerSugge
         brandColor:
           applicationStarterBrandColorOverrides.get(normalizedPartnerKey) ??
           partner.brandColor,
-        ...tierConfig,
+        tier,
         score: partner.score,
       }
     })
     .sort((left, right) => {
       if (left.tier !== right.tier) {
         return left.tier - right.tier
-      }
-
-      if (left.sortOrder !== right.sortOrder) {
-        return left.sortOrder - right.sortOrder
       }
 
       return right.score - left.score


### PR DESCRIPTION
## Summary

- Replaces score-based dynamic sizing in the partner grid and right rail with a clear three-tier system (**Gold / Silver / Bronze**), retaining `score` for in-tier ordering
- Each tier gets distinct sizing, color flares (gradient bars + pill labels + metal-tone icons), and corner radii to give the partner display a polished, deliberate hierarchy on every page that renders partners
- Marks Convex / Fireship / Nozzle / Vercel / Speakeasy as inactive (no current partnership)
- Also adds the "Become a Partner" link to the rail header on every page (previously docs-only), restructures the blog index so the rail meets the page edge, and fixes a `GamVrec1` width bug that overflowed the docs sidebar

### Files

- `src/utils/partners.tsx` — adds `PartnerTier`, `partnerTierLabels/Order/Flares` (shared icons + gradients), assigns tiers, drops the standalone application-builder tier map (now derived from `partner.tier`)
- `src/components/PartnersGrid.tsx` — three-card layout, gradient L-shape with rounded TL/BR + sharp TR/BL, centered pill tier labels, mobile-responsive cascade with no breakpoint where two tiers share column count
- `src/components/RightRail.tsx` — tier grouping with per-tier max widths and a colored top bar per section, centered pill labels, desaturate + brightness-90 logos with hover restoration, hidden scrollbar, `[&>*]:shrink-0` so the rail no longer clips its content
- `src/components/DocsLayout.tsx` — drops the manual "Become a Partner" overlay (now lives in `PartnersRail`)
- `src/routes/blog.index.tsx` — restructured so the rail extends flush to the right edge and the content panel keeps its own padding
- `src/routes/blog.$.tsx` — drops redundant Nozzle/Fireship name filters (covered by `status`)
- `src/components/Gam.tsx` — `w-full max-w-[300px]` so the sidebar promo widget no longer horizontal-overflows the 280px docs rail

## Test plan

- [ ] Homepage / landing pages: partner grid renders three tier cards with clear size jumps and colored ribbons
- [ ] Docs pages: right rail renders tier groups (Gold full-width / Silver 2-up / Bronze 3-up), no horizontal overflow, scrolls when total content exceeds viewport, no visible scrollbar
- [ ] Blog index: right rail flush to the page right edge, content panel still has padding
- [ ] Blog post pages: rail content not clipped, "Become a Partner" link visible in the header
- [ ] Application builder: partner suggestions still group correctly into the existing 1/2/3 tier UI (derived from `partner.tier`)
- [ ] Mobile (<sm), sm (640–767), md, lg, xl: no two tiers share the same column count in the grid
- [ ] Light & dark mode: tier gradients (gold = warm yellow → orange, silver = slate, bronze = amber → stone-brown) read correctly
- [ ] Hovering a rail logo restores its color/brightness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partners are grouped by tier (Gold/Silver/Bronze) with visual headers and tiered layouts.
  * A "Become a Partner" link appears in the partners rail header.

* **Improvements**
  * All active partners are now shown (previous exclusions removed).
  * Partner cards and right-rail sizing use tier-driven layouts for consistency.
  * Ad component made responsive; blog and partners page spacing/layout refined.

* **Bug Fixes**
  * Removed overlay-style partner link in docs right rail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->