### PR TITLE
feat: add @tanstack/ai-{framework} package naming for AI library

### DIFF
--- a/src/routes/$libraryId/$version.docs.framework.index.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.index.tsx
@@ -26,6 +26,10 @@ function getPackageName(
   if (frameworkValue === 'angular' && libraryId === 'query') {
     return `@tanstack/angular-query-experimental`
   }
+  // For AI library use @tanstack/ai-{framework} (e.g. @tanstack/ai-react)
+  if (libraryId === "ai") {
+    return `@tanstack/ai-${frameworkValue}`;
+  }
   // For other frameworks, use {framework}-{libraryId} pattern (e.g., @tanstack/react-table)
   return `@tanstack/${frameworkValue}-${libraryId}`
 }


### PR DESCRIPTION
This PR adds proper package naming for the TanStack AI library, using the @tanstack/ai-{framework} pattern (e.g., @tanstack/ai-react, @tanstack/ai-svelte) instead of the standard @tanstack/{framework}-{libraryId} pattern.