### PR TITLE
docs(blog): use createFromReadableStream for the dashboard snippet

### DIFF
--- a/src/blog/who-owns-the-tree-rsc-is-a-protocol-not-an-architecture.md
+++ b/src/blog/who-owns-the-tree-rsc-is-a-protocol-not-an-architecture.md
@@ -44,12 +44,13 @@ That works. But you just adopted a server-first architecture to render _one serv
 The inverse approach is much simpler. Keep the dashboard client-owned. Ask the server for a rendered chart fragment. Drop it into the tree wherever you want, alongside whatever client state you already have. If the chart has no interactive client regions, you don't even ship a client chunk for it.
 
 ```tsx
-import { CompositeComponent } from '@tanstack/react-start/rsc'
+import { createFromReadableStream } from '@tanstack/react-start/rsc'
 
 function Dashboard() {
-  const { data } = useSuspenseQuery({
+  const { data: chart } = useSuspenseQuery({
     queryKey: ['analytics-chart', range],
-    queryFn: () => getAnalyticsChart({ data: { range } }),
+    queryFn: async () =>
+      createFromReadableStream(await getAnalyticsChart({ data: { range } })),
   })
 
   return (
@@ -57,8 +58,8 @@ function Dashboard() {
       <Filters />
       <Tabs>
         <Tab label="Overview">
-          {/* Server-rendered, dropped into a client-owned tree */}
-          <CompositeComponent src={data.src} />
+          {/* Server-rendered output, dropped into a client-owned tree */}
+          {chart}
         </Tab>
         <Tab label="Raw">
           <ClientOnlyTable />


### PR DESCRIPTION
## Summary
- The "Why this matters" dashboard example was using `<CompositeComponent>` for what is structurally a leaf server fragment with no client-filled slots
- Switches it to the basic primitive (`createFromReadableStream`), matching the pattern from the prior `react-server-components` post
- `<CompositeComponent>` is still introduced later in the post for the slot-based case (PostPage), which is its correct home

## Test plan
- [ ] Re-read the "Why this matters" section — code now matches the surrounding prose ("ask the server for a rendered chart fragment, drop it into the tree")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post with an improved example demonstrating how to render server-driven components with streaming capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->