### PR TITLE
docs(blog): publish Who Owns the Tree post

### DIFF
--- a/src/blog/who-owns-the-tree.md
+++ b/src/blog/who-owns-the-tree.md
@@ -1,7 +1,7 @@
 ---
 title: 'Who Owns the Tree? RSC as a Protocol, Not an Architecture'
 published: 2026-04-28
-draft: true
+draft: false
 excerpt: RSC is usually framed as a single architecture where the server owns the tree. But it's also a protocol, and the protocol supports more than one composition model. The overlooked question is who owns the tree.
 authors:
   - Tanner Linsley


### PR DESCRIPTION
## Summary
- Flips `draft: true` → `draft: false` on `src/blog/who-owns-the-tree.md` so the post becomes visible on the blog index.

## Test plan
- [ ] Post appears on `/blog`
- [ ] Old slugs (`rsc-is-a-protocol-before-it-is-an-architecture`, `who-owns-the-tree-rsc-is-a-protocol-not-an-architecture`) redirect to `/blog/who-owns-the-tree`