### PR TITLE
fix: address top open issues (links, z-index, x.com URL)

### DIFF
--- a/.agents/index.md
+++ b/.agents/index.md
@@ -8,11 +8,11 @@ TanStack.com marketing site built with TanStack Start.
 - Run `pnpm test` before commits or after significant code changes, not after every tiny edit
 - Smoke tests live outside the default `pnpm test` path and are reserved for commit-hook validation
 - Don't run builds after every change. This is a visual site; assume changes work unless reported otherwise.
-- **Typesafety is paramount.** Never cast types; fix at source instead. See [typescript.md](.agents/typescript.md).
+- **Typesafety is paramount.** Never cast types; fix at source instead. See [typescript.md](./typescript.md).
 
 ## Topic Guides
 
-- [TypeScript Conventions](.agents/typescript.md): Type inference, casting rules, generic naming
-- [TanStack Patterns](.agents/tanstack-patterns.md): Loaders, server functions, environment shaking
-- [UI Style Guide](.agents/ui-style.md): Visual design principles for 2026
-- [Workflow](.agents/workflow.md): Build commands, debugging, Playwright
+- [TypeScript Conventions](./typescript.md): Type inference, casting rules, generic naming
+- [TanStack Patterns](./tanstack-patterns.md): Loaders, server functions, environment shaking
+- [UI Style Guide](./ui-style.md): Visual design principles for 2026
+- [Workflow](./workflow.md): Build commands, debugging, Playwright

--- a/src/components/DocFeedbackFloatingButton.tsx
+++ b/src/components/DocFeedbackFloatingButton.tsx
@@ -90,7 +90,7 @@ export function DocFeedbackFloatingButton({
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
     <div
       ref={buttonRef}
-      className="doc-feedback-floating-btn absolute top-0 right-0 -translate-y-full z-[100]"
+      className="doc-feedback-floating-btn absolute top-0 right-0 -translate-y-full z-30"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onClick={(e) => e.stopPropagation()}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ const footerLinks = [
   { label: '@Tan_Stack on X.com', to: 'https://x.com/tan_stack' },
   {
     label: '@TannerLinsley on X.com',
-    to: 'https://twitter.com/tannerlinsley',
+    to: 'https://x.com/tannerlinsley',
   },
   { label: 'GitHub', to: 'https://github.com/tanstack' },
   {


### PR DESCRIPTION
## Summary

- **#822** — Fix relative links in `.agents/index.md` (was `.agents/typescript.md`, now `./typescript.md`). Matches the approach in #820.
- **#730** — Drop `DocFeedbackFloatingButton` from `z-[100]` to `z-30` so the floating "+" no longer overlaps the navbar (also at `z-[100]`).
- **#281 follow-up** — Footer link labelled `@TannerLinsley on X.com` now points to `x.com` to match its label.

## Test plan

- [x] `pnpm test` (tsc + oxlint) passes
- [ ] Verify in docs that the "+" feedback button no longer covers the fixed top navbar
- [ ] Verify `.agents/index.md` links resolve correctly when viewed on GitHub
- [ ] Verify Footer X.com link clicks through to `x.com/tannerlinsley`

https://claude.ai/code/session_01TYh6hJQmzvmWMpBfg8uhdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYh6hJQmzvmWMpBfg8uhdt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links in documentation to reference resources correctly
* **Chores**
  * Adjusted floating feedback button's visual layer priority
  * Updated footer social media profile link to current platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->