### PR TITLE
feat: improve mobile layout for the showcase submissions

### DIFF
--- a/src/routes/account/submissions.tsx
+++ b/src/routes/account/submissions.tsx
@@ -137,14 +137,17 @@ function AccountSubmissionsPage() {
               key={showcase.id}
               className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
             >
-              <div className="flex">
+              <div className="flex flex-col sm:flex-row">
                 {/* Screenshot */}
-                <div className="w-48 h-32 flex-shrink-0 bg-gray-100 dark:bg-gray-900">
+                <div className="relative w-full h-48 sm:w-48 sm:h-32 shrink-0 bg-gray-100 dark:bg-gray-900">
                   <img
                     src={showcase.screenshotUrl}
                     alt={showcase.name}
                     className="w-full h-full object-cover"
                   />
+                  <div className="absolute top-2 right-2 sm:hidden">
+                    {getStatusBadge(showcase.status)}
+                  </div>
                 </div>
 
                 {/* Content */}
@@ -158,7 +161,9 @@ function AccountSubmissionsPage() {
                         {showcase.tagline}
                       </p>
                     </div>
-                    {getStatusBadge(showcase.status)}
+                    <div className="hidden sm:block">
+                      {getStatusBadge(showcase.status)}
+                    </div>
                   </div>
 
                   {/* Libraries */}


### PR DESCRIPTION
A few layout improvements for the showcase submissions on Tanstack.com for mobile. 
Desktop stays the same as before. 

|  | Before | After |
| --- | --- | --- |
| **Mobile** | <img width="355" src="https://github.com/user-attachments/assets/4d75391a-05d9-4f8a-af66-e3634001dad5" /> | <img width="358" src="https://github.com/user-attachments/assets/97a998a8-5f18-4ab5-9474-b20b23519417" /> |
| **Desktop** | <img width="1045" src="https://github.com/user-attachments/assets/8cfabe3c-09db-4597-90ab-58b61980c6db" /> | <img width="1050" src="https://github.com/user-attachments/assets/db1eec0a-29ee-43be-8e6b-577b700fab1d" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced showcase card responsive design with improved badge positioning and layout adaptation. Status badges now display appropriately for both mobile and desktop views, with the screenshot area and card structure restructured to adapt seamlessly across different screen sizes. The layout optimization improves visual hierarchy and user experience on all devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->