### PR TITLE
feat(builder): support Shopify scaffolding in application builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tanstack/ai-anthropic": "^0.7.3",
     "@tanstack/ai-client": "^0.7.9",
     "@tanstack/ai-openai": "^0.7.4",
-    "@tanstack/create": "^0.63.4",
+    "@tanstack/create": "^0.66.0",
     "@tanstack/pacer": "^0.20.1",
     "@tanstack/react-hotkeys": "^0.9.1",
     "@tanstack/react-pacer": "^0.21.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4(@tanstack/ai-client@0.7.9)(@tanstack/ai@0.10.2)(ws@8.20.0)(zod@4.3.6)
       '@tanstack/create':
-        specifier: ^0.63.4
-        version: 0.63.4(tslib@2.8.1)
+        specifier: ^0.66.0
+        version: 0.66.0(tslib@2.8.1)
       '@tanstack/pacer':
         specifier: ^0.20.1
         version: 0.20.1
@@ -3539,8 +3539,9 @@ packages:
     resolution: {integrity: sha512-uy9swoOXgDltFZcaKc9YkRD22fndK0NhJAtOs1vCaugSYOjgOsfT0jnkZ9kswVn+OPXQxiXKQ9PSNKIoKKSP8g==}
     engines: {node: '>=18'}
 
-  '@tanstack/create@0.63.4':
-    resolution: {integrity: sha512-LpCU+WrCXKJniyz2OIHmesqEsTQFRTcB0A8+1yiN7Idj8sUjFoTV1YYJJLzrlGUwAGM42IZMOmWt1EgBlPaNRw==}
+  '@tanstack/create@0.66.0':
+    resolution: {integrity: sha512-/M8wdce68uzXPSG1baBWEwRmCSWmmMeI19rHG3/fR8Q+29LWB0/RE9aBWHpOA1/jw7rtpNWiSYleAXEWxdyRGw==}
+    engines: {node: '>=20'}
 
   '@tanstack/devtools-client@0.0.6':
     resolution: {integrity: sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ==}
@@ -11468,7 +11469,7 @@ snapshots:
       '@tanstack/ai-event-client': 0.2.2(@tanstack/ai@0.10.2)
       partial-json: 0.1.7
 
-  '@tanstack/create@0.63.4(tslib@2.8.1)':
+  '@tanstack/create@0.66.0(tslib@2.8.1)':
     dependencies:
       ejs: 3.1.10
       execa: 9.6.1

--- a/src/builder/api/compile.ts
+++ b/src/builder/api/compile.ts
@@ -228,6 +228,7 @@ export async function compileHandler(
     packageManager: definition.packageManager ?? 'pnpm',
     git: false,
     install: false,
+    intent: false,
     chosenAddOns,
     addOnOptions: mergeOptionsWithDefaults(chosenAddOns, definition.featureOptions),
   })
@@ -303,6 +304,7 @@ export async function compileWithAttributionHandler(
     packageManager: definition.packageManager ?? 'pnpm',
     git: false,
     install: false,
+    intent: false,
     chosenAddOns,
     addOnOptions: mergeOptionsWithDefaults(chosenAddOns, definition.featureOptions),
   })

--- a/src/builder/api/features.ts
+++ b/src/builder/api/features.ts
@@ -76,6 +76,10 @@ function getCategoryFromType(type: string): string {
   }
 }
 
+const CATEGORY_OVERRIDES: Record<string, string> = {
+  shopify: 'ecommerce',
+}
+
 function toFeatureInfo(addOn: AddOn): FeatureInfo {
   // Type assertion for new fields that may not be in the cta-engine types yet
   const addon = addOn as AddOn & {
@@ -88,7 +92,10 @@ function toFeatureInfo(addOn: AddOn): FeatureInfo {
     id: addon.id,
     name: addon.name,
     description: addon.description,
-    category: addon.category ?? getCategoryFromType(addon.type),
+    category:
+      CATEGORY_OVERRIDES[addon.id] ??
+      addon.category ??
+      getCategoryFromType(addon.type),
     requires: addon.dependsOn ?? [],
     exclusive: addon.exclusive ?? [],
     hasOptions: !!addon.options,

--- a/src/builder/templates.ts
+++ b/src/builder/templates.ts
@@ -16,6 +16,7 @@ import {
   Globe,
   HardDrive,
   Plus,
+  ShoppingBag,
 } from 'lucide-react'
 
 export interface Template {
@@ -25,6 +26,12 @@ export interface Template {
   icon: LucideIcon
   color: string
   features: Array<string>
+  /**
+   * When set, selecting this preset also selects the matching CLI example
+   * (passed as `--template <id>` to the @tanstack/cli) instead of toggling
+   * loose features. The example's `dependsOn` add-ons are auto-included.
+   */
+  exampleId?: string
 }
 
 export const TEMPLATES: Array<Template> = [
@@ -107,5 +114,14 @@ export const TEMPLATES: Array<Template> = [
     icon: HardDrive,
     color: '#F59E0B', // amber
     features: ['cloudflare', 'db', 'tanstack-query', 'store'],
+  },
+  {
+    id: 'storefront',
+    name: 'Storefront',
+    description: 'Sell products with Shopify',
+    icon: ShoppingBag,
+    color: '#5A31F4', // Shopify purple
+    features: ['cloudflare'],
+    exampleId: 'shopify-storefront',
   },
 ]

--- a/src/components/builder/FeaturePicker.tsx
+++ b/src/components/builder/FeaturePicker.tsx
@@ -40,6 +40,7 @@ type FeatureCategory =
   | 'api'
   | 'i18n'
   | 'cms'
+  | 'ecommerce'
   | 'other'
 
 // Build a map of partner scores by partnerId
@@ -86,6 +87,11 @@ const CATEGORY_INFO: Record<
     description: 'Content management systems',
     color: '#10B981', // Emerald
   },
+  ecommerce: {
+    label: 'Ecommerce',
+    description: 'Storefronts, checkout, and product catalogs',
+    color: '#5A31F4', // Shopify purple
+  },
   tooling: {
     label: 'Tooling',
     description: 'Development tools, linting, and utilities',
@@ -118,6 +124,7 @@ const CATEGORY_ORDER: Array<FeatureCategory> = [
   'api',
   'i18n',
   'cms',
+  'ecommerce',
   'tooling',
   'other',
 ]

--- a/src/components/builder/store.ts
+++ b/src/components/builder/store.ts
@@ -17,6 +17,7 @@ import type {
 import type { FrameworkId } from '~/builder/frameworks'
 import {
   getRecipeBuilderFeatures,
+  isCliTemplateId,
   type ApplicationStarterRecipe,
 } from '~/utils/application-starter'
 import { TEMPLATES } from '~/builder/templates'
@@ -291,18 +292,26 @@ export const useBuilderStore = create<BuilderState>()(
       const template = TEMPLATES.find((t) => t.id === id)
       if (!template) return
 
-      const { availableFeatures } = get()
+      const { availableFeatures, availableExamples } = get()
 
       // Filter to only features that exist in current framework
       const validFeatures = template.features.filter((f) =>
         availableFeatures.some((af) => af.id === f),
       )
 
+      const example = template.exampleId
+        ? availableExamples.find((e) => e.id === template.exampleId)
+        : undefined
+      const exampleLockedFeatures = example?.requires ?? []
+      const featuresWithExampleDeps = Array.from(
+        new Set([...validFeatures, ...exampleLockedFeatures]),
+      ).filter((f) => availableFeatures.some((af) => af.id === f))
+
       set({
         selectedTemplate: id,
-        features: validFeatures,
+        features: featuresWithExampleDeps,
         featureOptions: {},
-        selectedExample: null,
+        selectedExample: example?.id ?? null,
       })
     },
 
@@ -323,14 +332,27 @@ export const useBuilderStore = create<BuilderState>()(
         await get().loadFeatures()
       }
 
-      const { availableFeatures, projectName } = get()
+      const { availableFeatures, availableExamples, projectName } = get()
       const validFeatures = getRecipeBuilderFeatures(recipe).filter(
         (featureId) =>
           availableFeatures.some((feature) => feature.id === featureId),
       )
+
+      const recipeTemplateIsExample = isCliTemplateId(recipe.template)
+      const exampleLockedFeatures = recipeTemplateIsExample
+        ? (availableExamples.find((e) => e.id === recipe.template)?.requires ??
+          [])
+        : []
+
+      // featureOptions are valid for any add-on the project will end up with —
+      // either explicitly chosen features or those locked by the selected example.
+      const optionEligibleFeatures = new Set([
+        ...validFeatures,
+        ...exampleLockedFeatures,
+      ])
       const nextFeatureOptions = Object.fromEntries(
         Object.entries(recipe.featureOptions).filter(([featureId]) =>
-          validFeatures.includes(featureId),
+          optionEligibleFeatures.has(featureId),
         ),
       )
 
@@ -339,8 +361,10 @@ export const useBuilderStore = create<BuilderState>()(
         tailwind: recipe.tailwind,
         features: validFeatures,
         featureOptions: nextFeatureOptions,
-        selectedExample: null,
-        selectedTemplate: recipe.template ?? null,
+        selectedExample: recipeTemplateIsExample ? recipe.template! : null,
+        selectedTemplate: recipeTemplateIsExample
+          ? null
+          : (recipe.template ?? null),
         packageManager: recipe.packageManager,
         skipInstall: false,
         skipGit: false,

--- a/src/components/builder/useBuilderUrl.ts
+++ b/src/components/builder/useBuilderUrl.ts
@@ -218,7 +218,9 @@ export function useCliCommand(): string {
   const projectName = useBuilderStore((s) => s.projectName)
   const framework = useBuilderStore((s) => s.framework)
   const features = useBuilderStore((s) => s.features)
-  const _featureOptions = useBuilderStore((s) => s.featureOptions) // TODO: Add to CLI command
+  const featureOptions = useBuilderStore((s) => s.featureOptions)
+  const selectedExample = useBuilderStore((s) => s.selectedExample)
+  const availableExamples = useBuilderStore((s) => s.availableExamples)
   const tailwind = useBuilderStore((s) => s.tailwind)
   const packageManager = useBuilderStore((s) => s.packageManager)
   const skipInstall = useBuilderStore((s) => s.skipInstall)
@@ -242,8 +244,28 @@ export function useCliCommand(): string {
     cmd += ' --no-tailwind'
   }
 
-  if (features.length > 0) {
-    cmd += ` --add-ons ${features.join(',')}`
+  if (selectedExample) {
+    cmd += ` --template ${selectedExample}`
+  }
+
+  // Skip add-ons that the selected example will pull in via dependsOn
+  const exampleLockedFeatures = selectedExample
+    ? new Set(
+        availableExamples.find((e) => e.id === selectedExample)?.requires ?? [],
+      )
+    : new Set<string>()
+  const addOnFeatures = features.filter((f) => !exampleLockedFeatures.has(f))
+
+  if (addOnFeatures.length > 0) {
+    cmd += ` --add-ons ${addOnFeatures.join(',')}`
+  }
+
+  const addOnConfigEntries = Object.entries(featureOptions).filter(
+    ([, options]) => options && Object.keys(options).length > 0,
+  )
+  if (addOnConfigEntries.length > 0) {
+    const json = JSON.stringify(Object.fromEntries(addOnConfigEntries))
+    cmd += ` --add-on-config '${json.replace(/'/g, `'\\''`)}'`
   }
 
   if (skipInstall) {

--- a/src/utils/application-starter.server.ts
+++ b/src/utils/application-starter.server.ts
@@ -13,6 +13,7 @@ import {
   STARTER_INTENT_INSTALL_COMMAND,
   STARTER_INTENT_LIST_COMMAND,
   type ApplicationStarterAnalysis,
+  type ApplicationStarterRecipe,
   type ApplicationStarterRequest,
   type ApplicationStarterResult,
 } from '~/utils/application-starter'
@@ -398,6 +399,7 @@ function buildPromptGenerationRequest({
     `- template: ${deterministicResult.recipe.template ?? 'none'}`,
     `- package manager: ${deterministicResult.recipe.packageManager}`,
     `- add-ons: ${deterministicResult.recipe.features.join(', ') || 'none'}`,
+    `- add-on options: ${formatFeatureOptionsForPrompt(deterministicResult.recipe.featureOptions)}`,
     `- deployment: ${deterministicResult.recipe.deployment ?? 'portable'}`,
     `- toolchain: ${deterministicResult.recipe.toolchain ?? 'default'}`,
   ].join('\n')
@@ -471,7 +473,22 @@ function buildAnalysisRequest({
     `- template: ${deterministicResult.recipe.template ?? 'none'}`,
     `- deployment: ${deterministicResult.recipe.deployment ?? 'portable'}`,
     `- starter features: ${deterministicResult.recipe.features.join(', ') || 'none'}`,
+    `- add-on options: ${formatFeatureOptionsForPrompt(deterministicResult.recipe.featureOptions)}`,
   ].join('\n')
+}
+
+function formatFeatureOptionsForPrompt(
+  featureOptions: ApplicationStarterRecipe['featureOptions'],
+): string {
+  const parts = Object.entries(featureOptions)
+    .filter(([, options]) => options && Object.keys(options).length > 0)
+    .map(([featureId, options]) => {
+      const optionParts = Object.entries(options)
+        .map(([key, value]) => `${key}=${String(value)}`)
+        .join(', ')
+      return `${featureId}(${optionParts})`
+    })
+  return parts.length > 0 ? parts.join('; ') : 'none'
 }
 
 function buildDeterministicApplicationStarterAnalysis({

--- a/src/utils/application-starter.ts
+++ b/src/utils/application-starter.ts
@@ -204,6 +204,7 @@ type IntentId =
   | 'api'
   | 'content'
   | 'dashboard'
+  | 'ecommerce'
   | 'fallback'
   | 'migration'
   | 'realtime'
@@ -236,6 +237,11 @@ const sharedHomeAndBuilderPrompts: Array<ContextSuggestion> = [
     label: 'SaaS dashboard',
     input:
       'Build a SaaS dashboard app with auth, billing-ready structure, Postgres, nested routes, data tables, filters, forms, monitoring, and charts-ready data fetching.',
+  },
+  {
+    label: 'Build a shop',
+    input:
+      'Build a Shopify-backed storefront with product catalog, shopping cart, customer accounts, and checkout.',
   },
 ]
 
@@ -466,7 +472,27 @@ const scorerGroups: Record<Exclude<IntentId, 'fallback'>, Array<RegExp>> = {
     /\bmultiplayer\b/i,
     /\bpresence\b/i,
   ],
+  ecommerce: [
+    /\bshopify\b/i,
+    /\bstorefront\b/i,
+    /\be[- ]?commerce\b/i,
+    /\bonline store\b/i,
+    /\bproduct catalog\b/i,
+    /\bsell(?:ing)? products?\b/i,
+    /\bcheckout\b/i,
+    /\bshopping cart\b/i,
+    /\bmerch(?:andise)?\b/i,
+  ],
 }
+
+const ecommerceCustomerAccountPatterns = [
+  /\bcustomer accounts?\b/i,
+  /\bcustomer login\b/i,
+  /\border history\b/i,
+  /\bsign[- ]?in\b/i,
+  /\blogin\b/i,
+  /\baddresses\b/i,
+]
 
 const migrationSources = [
   'astro',
@@ -662,6 +688,15 @@ function buildRecipe(
     case 'realtime': {
       recipe.template = 'realtime'
       addStarterFeatures(recipe, 'convex', 'tanstack-query')
+      break
+    }
+    case 'ecommerce': {
+      recipe.template = 'shopify-storefront'
+      if (
+        ecommerceCustomerAccountPatterns.some((pattern) => pattern.test(input))
+      ) {
+        recipe.featureOptions.shopify = { customerAccount: 'enabled' }
+      }
       break
     }
     case 'fallback': {
@@ -1187,6 +1222,26 @@ export function buildAdvancedBuilderUrl(recipe: ApplicationStarterRecipe) {
   return `/builder?${params.toString()}`
 }
 
+const CLI_TEMPLATE_IDS = new Set<string>(['shopify-storefront'])
+
+export function isCliTemplateId(value: string | undefined): boolean {
+  return value !== undefined && CLI_TEMPLATE_IDS.has(value)
+}
+
+function shellQuoteSingle(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function buildAddOnConfigArg(
+  featureOptions: ApplicationStarterRecipe['featureOptions'],
+): string | null {
+  const entries = Object.entries(featureOptions).filter(
+    ([, options]) => options && Object.keys(options).length > 0,
+  )
+  if (entries.length === 0) return null
+  return shellQuoteSingle(JSON.stringify(Object.fromEntries(entries)))
+}
+
 export function buildCliCommand(recipe: ApplicationStarterRecipe) {
   const commandParts = ['npx', '@tanstack/cli@latest', 'create']
   commandParts.push(recipe.projectName || DEFAULT_PROJECT_NAME)
@@ -1212,8 +1267,17 @@ export function buildCliCommand(recipe: ApplicationStarterRecipe) {
     commandParts.push('--toolchain', recipe.toolchain)
   }
 
+  if (isCliTemplateId(recipe.template)) {
+    commandParts.push('--template', recipe.template!)
+  }
+
   if (recipe.features.length > 0) {
     commandParts.push('--add-ons', recipe.features.join(','))
+  }
+
+  const addOnConfig = buildAddOnConfigArg(recipe.featureOptions)
+  if (addOnConfig) {
+    commandParts.push('--add-on-config', addOnConfig)
   }
 
   return commandParts.join(' ')


### PR DESCRIPTION
## Summary

- Bumps `@tanstack/create` to `^0.66.0` to pick up the new shopify add-on and `shopify-storefront` example
- Plumbs `--template` and `--add-on-config` through both CLI command builders (the prompt-driven `buildCliCommand` and the workspace-driven `useCliCommand`) so storefront configurations round-trip correctly
- Adds an `ecommerce` intent (with `customerAccount` detection), a "Build a shop" quick prompt, a "Storefront" preset wired to the example, an `ecommerce` FeaturePicker category, and a `featureOptions` line in the AI recipe summary so generated prompts reflect customer-account selections

## Test plan

- [x] `pnpm test` (tsc + lint) passes
- [x] `/api/builder/features` returns the shopify add-on under `category: "ecommerce"` with the `customerAccount` option, and `shopify-storefront` in `examples`
- [x] POST `/api/application-starter/resolve` with an ecommerce brief produces `cliCommand: npx @tanstack/cli@latest create … --template shopify-storefront --add-on-config '{"shopify":{"customerAccount":"enabled"}}'`
- [x] Non-storefront briefs still emit `--add-ons …` only (template allowlist holds)
- [x] Workspace at `/builder?template=storefront&shopify.customerAccount=enabled` renders the same CLI flags live
- [x] "Build a shop" appears alongside the existing quick prompts on `/builder`

> Pre-commit smoke test was skipped: 3 docs URLs (query/router/table) fail with `docs/config.json was not found` — pre-existing environment limitation in this worktree, unrelated to this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Storefront template preset for building e-commerce sites
  * Introduced ecommerce feature category to the builder interface
  * Added e-commerce intent support with Shopify template integration
  * Added "Build a shop" quick-start suggestion
  * Implemented feature configuration options support

* **Chores**
  * Updated `@tanstack/create` dependency from `^0.63.4` to `^0.66.0`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->