### PR TITLE
Refactor docs nav into tabbed sections

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7814,6 +7814,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
@@ -14142,7 +14147,7 @@ snapshots:
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.15
+      srvx: 0.11.16
 
   hachure-fill@0.5.2: {}
 
@@ -16630,6 +16635,8 @@ snapshots:
   sqids@0.3.0: {}
 
   srvx@0.11.15: {}
+
+  srvx@0.11.16: {}
 
   stack-trace@0.0.10: {}
 

--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -862,7 +862,7 @@ export function DocsLayout({
       <div
         ref={expandedMenuRef}
         className={twMerge(
-          'w-[250px] xl:w-[300px] 2xl:w-[400px] shrink-0',
+          'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
           'flex-col overflow-hidden',
           'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
           'z-20 border-r border-gray-500/20',
@@ -896,7 +896,7 @@ export function DocsLayout({
           }
         }}
       >
-        <div className="flex-1 flex flex-col overflow-y-auto">
+        <div className="flex-1 flex flex-col overflow-y-auto min-w-[230px]">
           <div className="flex flex-col gap-1 p-4">
             <FrameworkSelect libraryId={libraryId} />
             <VersionSelect libraryId={libraryId} />
@@ -910,10 +910,10 @@ export function DocsLayout({
   )
 
   const docsTabs = (
-    <div className="border-b border-gray-500/20 bg-white/70 dark:bg-black/40 backdrop-blur-lg">
+    <div className="sticky top-[calc(var(--navbar-height)-4px)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
       <nav
         aria-label="Documentation sections"
-        className="flex items-center gap-1 overflow-x-auto px-3 md:px-6 py-2 text-sm"
+        className="flex items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabbedMenuConfig.map((tab) => {
           const target = tab.firstItem
@@ -935,14 +935,22 @@ export function DocsLayout({
               to={target.to}
               params={linkParams}
               className={twMerge(
-                'whitespace-nowrap rounded-md px-3 py-1.5 font-semibold transition-colors',
-                'hover:bg-gray-500/10',
+                'relative whitespace-nowrap py-3 font-semibold transition-colors',
                 isActive
-                  ? `bg-gray-500/10 text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
-                  : 'opacity-70 hover:opacity-100',
+                  ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                  : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
               )}
             >
               {tab.label}
+              {isActive ? (
+                <span
+                  className={twMerge(
+                    'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
+                    colorFrom,
+                    colorTo,
+                  )}
+                />
+              ) : null}
             </Link>
           )
         })}
@@ -1000,7 +1008,7 @@ export function DocsLayout({
             )}
           </div>
           {!isLandingPage && (
-            <RightRail breakpoint="md" className="md:w-[280px]">
+            <RightRail breakpoint="md" className="md:w-[220px]">
               <PartnersRail
                 analyticsPlacement="docs_rail"
                 partners={activePartners}

--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -8,6 +8,10 @@ import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClickOutside } from '~/hooks/useClickOutside'
 import { last } from '~/utils/utils'
 import type { ConfigSchema, MenuItem } from '~/utils/config'
+import {
+  getActiveDocsNavTabId,
+  getTabbedMenuConfig,
+} from '~/utils/docsNavTabs'
 import { Framework, LibraryId } from '~/libraries'
 import { frameworkOptions } from '~/libraries/frameworks'
 import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
@@ -520,6 +524,7 @@ const useMenuConfig = ({
 
       return {
         label: section.label,
+        tab: section.tab,
         children,
         collapsible: section.collapsible ?? false,
         defaultCollapsed: section.defaultCollapsed ?? false,
@@ -569,21 +574,41 @@ export function DocsLayout({
 
   const detailsRef = React.useRef<HTMLElement>(null!)
 
-  const flatMenu = React.useMemo(
-    () => menuConfig.flatMap((d) => d?.children),
-    [menuConfig],
-  )
-
-  // Filter out external links for prev/next navigation
-  const internalFlatMenu = React.useMemo(
-    () => flatMenu.filter((d) => d && !d.to.startsWith('http')),
-    [flatMenu],
-  )
-
   const docsMatch = matches.find((d) => d.pathname.includes('/docs'))
   const docsPathname = docsMatch?.pathname ?? ''
 
   const relativePathname = lastMatch.pathname.replace(docsPathname + '/', '')
+
+  const tabbedMenuConfig = React.useMemo(() => {
+    return getTabbedMenuConfig(menuConfig)
+  }, [menuConfig])
+
+  const activeTabId = React.useMemo(() => {
+    return getActiveDocsNavTabId({
+      isExample,
+      menuConfig,
+      pathname: lastMatch.pathname,
+      relativePathname,
+    })
+  }, [isExample, lastMatch.pathname, menuConfig, relativePathname])
+
+  const visibleMenuConfig = React.useMemo(() => {
+    return (
+      tabbedMenuConfig.find((tab) => tab.id === activeTabId)?.groups ??
+      menuConfig
+    )
+  }, [activeTabId, menuConfig, tabbedMenuConfig])
+
+  const flatMenu = React.useMemo(
+    () => visibleMenuConfig.flatMap((d) => d.children),
+    [visibleMenuConfig],
+  )
+
+  // Filter out external links for prev/next navigation
+  const internalFlatMenu = React.useMemo(
+    () => flatMenu.filter((d) => !d.to.startsWith('http')),
+    [flatMenu],
+  )
 
   const index = internalFlatMenu.findIndex((d) => d?.to === relativePathname)
   const prevItem = internalFlatMenu[index - 1]
@@ -600,19 +625,22 @@ export function DocsLayout({
   const activePartners = partners.filter((d) => d.status === 'active')
 
   const groupInitialOpenState = React.useMemo(() => {
-    return menuConfig.reduce<Record<string, boolean>>((acc, group, index) => {
-      const isChildActive = group.children.some((child) => child.to === _splat)
-      const key = `${index}:${String(group.label)}`
+    return visibleMenuConfig.reduce<Record<string, boolean>>(
+      (acc, group, index) => {
+        const isChildActive = group.children.some((child) => child.to === _splat)
+        const key = `${index}:${String(group.label)}`
 
-      acc[key] = isChildActive
-        ? true
-        : typeof group.defaultCollapsed !== 'undefined'
-          ? !group.defaultCollapsed
-          : false
+        acc[key] = isChildActive
+          ? true
+          : typeof group.defaultCollapsed !== 'undefined'
+            ? !group.defaultCollapsed
+            : false
 
-      return acc
-    }, {})
-  }, [menuConfig, _splat])
+        return acc
+      },
+      {},
+    )
+  }, [visibleMenuConfig, _splat])
 
   const [openGroups, setOpenGroups] = React.useState(groupInitialOpenState)
 
@@ -638,7 +666,7 @@ export function DocsLayout({
     })
   }, [groupInitialOpenState])
 
-  const menuItems = menuConfig.map((group, i) => {
+  const menuItems = visibleMenuConfig.map((group, i) => {
     const groupKey = `${i}:${String(group.label)}`
 
     const groupContent = (
@@ -808,7 +836,7 @@ export function DocsLayout({
         )}
       >
         <DocsMenuStrip
-          menuConfig={menuConfig}
+          menuConfig={visibleMenuConfig}
           activeItem={relativePathname}
           fullPathname={lastMatch.pathname}
           colorFrom={colorFrom}
@@ -835,7 +863,7 @@ export function DocsLayout({
       <div
         ref={expandedMenuRef}
         className={twMerge(
-          'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
+          'w-[250px] xl:w-[300px] 2xl:w-[400px] shrink-0',
           'flex-col overflow-hidden',
           'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
           'z-20 border-r border-gray-500/20',
@@ -882,6 +910,47 @@ export function DocsLayout({
     </>
   )
 
+  const docsTabs = (
+    <div className="border-b border-gray-500/20 bg-white/70 dark:bg-black/40 backdrop-blur-lg">
+      <nav
+        aria-label="Documentation sections"
+        className="flex items-center gap-1 overflow-x-auto px-3 md:px-6 py-2 text-sm"
+      >
+        {tabbedMenuConfig.map((tab) => {
+          const target = tab.firstItem
+          const isActive = tab.id === activeTabId
+
+          if (!target) {
+            return null
+          }
+
+          const linkParams =
+            !target.to.startsWith('/') || target.to.includes('/$libraryId')
+              ? ({ libraryId, version } as never)
+              : undefined
+
+          return (
+            <Link
+              key={tab.id}
+              from="/$libraryId/$version/docs"
+              to={target.to}
+              params={linkParams}
+              className={twMerge(
+                'whitespace-nowrap rounded-md px-3 py-1.5 font-semibold transition-colors',
+                'hover:bg-gray-500/10',
+                isActive
+                  ? `bg-gray-500/10 text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                  : 'opacity-70 hover:opacity-100',
+              )}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+
   return (
     <WidthToggleContext.Provider value={{ isFullWidth, setIsFullWidth }}>
       <DocNavigationContext.Provider
@@ -907,12 +976,14 @@ export function DocsLayout({
           <div
             className={twMerge(
               'flex flex-col max-w-full min-w-0 flex-1 min-h-0 relative',
-              !isLandingPage && 'px-4 md:px-8',
             )}
           >
+            {docsTabs}
             <div
               className={twMerge(
                 `max-w-full min-w-0 flex flex-col justify-center w-full`,
+
+                !isLandingPage && 'px-4 md:px-8',
 
                 !isLandingPage &&
                   !isExample &&

--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -8,10 +8,7 @@ import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClickOutside } from '~/hooks/useClickOutside'
 import { last } from '~/utils/utils'
 import type { ConfigSchema, MenuItem } from '~/utils/config'
-import {
-  getActiveDocsNavTabId,
-  getTabbedMenuConfig,
-} from '~/utils/docsNavTabs'
+import { getActiveDocsNavTabId, getTabbedMenuConfig } from '~/utils/docsNavTabs'
 import { Framework, LibraryId } from '~/libraries'
 import { frameworkOptions } from '~/libraries/frameworks'
 import { DocsCalloutQueryGG } from '~/components/DocsCalloutQueryGG'
@@ -627,7 +624,9 @@ export function DocsLayout({
   const groupInitialOpenState = React.useMemo(() => {
     return visibleMenuConfig.reduce<Record<string, boolean>>(
       (acc, group, index) => {
-        const isChildActive = group.children.some((child) => child.to === _splat)
+        const isChildActive = group.children.some(
+          (child) => child.to === _splat,
+        )
         const key = `${index}:${String(group.label)}`
 
         acc[key] = isChildActive

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -12,10 +12,16 @@ import { getActiveDocsNavTabId, getTabbedMenuConfig } from '~/utils/docsNavTabs'
 import { Framework, LibraryId } from '~/libraries'
 import { frameworkOptions } from '~/libraries/frameworks'
 import { twMerge } from 'tailwind-merge'
-import { partners, PartnerImage, type Partner } from '~/utils/partners'
+import {
+  partners,
+  PartnerImage,
+  partnerTiers,
+  type Partner,
+  type PartnerTier,
+} from '~/utils/partners'
 import {
   getPartnerPlacementAnalyticsMetadata,
-  getPartnersForPlacement,
+  getPartnerTierGroupsForPlacement,
   type PartnerPlacementContext,
 } from '~/utils/partner-placement'
 import { usePartnerPlacementContext } from '~/utils/usePartnerPlacementContext'
@@ -31,8 +37,30 @@ import { trackEvent, useTrackedImpression } from '~/utils/analytics'
 // Number of days a doc page is flagged as "New"/"Updated" in the sidebar.
 const RECENCY_WINDOW_DAYS = 7
 const RECENCY_WINDOW_MS = RECENCY_WINDOW_DAYS * 24 * 60 * 60 * 1000
+const docsPartnerTierWeights: Record<PartnerTier, number> = {
+  gold: 3,
+  silver: 2,
+  bronze: 1,
+}
 
 type DocRecency = 'new' | 'updated' | null
+type DocsPartner = {
+  category: Partner['category']
+  score: Partner['score']
+  tier?: Partner['tier']
+  id: string
+  name: string
+  href: string
+  image: Parameters<typeof PartnerImage>[0]['config']
+}
+type DocsPartnerTierGroup = {
+  tier: PartnerTier
+  partners: Array<DocsPartner>
+}
+type DocsPartnerScrollSlot = {
+  partner: DocsPartner
+  slotIndex: number
+}
 
 // Determine whether a doc page should show a recency pill, based on the
 // maintainer-supplied `addedAt` / `updatedAt` dates in the repo's docs/config.json.
@@ -97,152 +125,79 @@ function DocRecencyPill({
   )
 }
 
-// Mobile partners strip - inline in the docs toggle bar
-function MobilePartnersStrip({
+function DocsPartnerSlot({
+  orderPlacementContext,
   partners,
-  placementContext,
-  enabled = true,
 }: {
-  partners: Array<{
-    category: Partner['category']
-    score: Partner['score']
-    tier?: Partner['tier']
-    id: string
-    name: string
-    href: string
-    image: Parameters<typeof PartnerImage>[0]['config']
-  }>
-  placementContext: PartnerPlacementContext
-  enabled?: boolean
+  orderPlacementContext: PartnerPlacementContext
+  partners: Array<DocsPartner>
 }) {
-  const innerRef = React.useRef<HTMLDivElement>(null)
-  const [isHovered, setIsHovered] = React.useState(false)
-  const scrollPositionRef = React.useRef(0)
-  const hasStartedRef = React.useRef(false)
+  const tierGroups = React.useMemo(
+    () => getPartnerTierGroupsForPlacement(partners, orderPlacementContext),
+    [partners, orderPlacementContext],
+  )
+  const activeSlot = useDocsPartnerScrollSlot(tierGroups)
+  const { displayedSlot, flipState } = useFlippingDocsPartnerSlot(activeSlot)
 
-  React.useEffect(() => {
-    const inner = innerRef.current
-    if (!inner) return
-    if (!enabled) return
-
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
-    // The strip is mobile-only (md:hidden), so don't run the rAF loop on md+
-    // where it isn't painted.
-    const isDesktop = window.matchMedia('(min-width: 768px)')
-
-    let animationId: number
-    let timeoutId: ReturnType<typeof setTimeout>
-    const scrollSpeed = 0.15
-    const startDelay = 4000
-
-    const animate = () => {
-      if (!isHovered && inner) {
-        scrollPositionRef.current += scrollSpeed
-        if (scrollPositionRef.current >= inner.scrollWidth / 2) {
-          scrollPositionRef.current = 0
-        }
-        inner.style.transform = `translateX(${-scrollPositionRef.current}px)`
-      }
-      animationId = requestAnimationFrame(animate)
-    }
-
-    const start = () => {
-      if (reduceMotion.matches || isDesktop.matches) return
-      if (!hasStartedRef.current) {
-        timeoutId = setTimeout(() => {
-          hasStartedRef.current = true
-          animationId = requestAnimationFrame(animate)
-        }, startDelay)
-      } else {
-        animationId = requestAnimationFrame(animate)
-      }
-    }
-
-    const stop = () => {
-      clearTimeout(timeoutId)
-      cancelAnimationFrame(animationId)
-    }
-
-    const restart = () => {
-      stop()
-      start()
-    }
-
-    isDesktop.addEventListener('change', restart)
-    reduceMotion.addEventListener('change', restart)
-    start()
-
-    return () => {
-      isDesktop.removeEventListener('change', restart)
-      reduceMotion.removeEventListener('change', restart)
-      stop()
-    }
-  }, [isHovered, enabled])
+  if (!displayedSlot) {
+    return null
+  }
 
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      <div
-        className="relative flex-1 overflow-hidden min-w-0"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onTouchStart={() => setIsHovered(true)}
-        onTouchEnd={() => setIsHovered(false)}
-      >
-        <div className="overflow-hidden">
-          <div
-            ref={innerRef}
-            className="flex items-center gap-4 w-max py-1 will-change-transform"
-          >
-            {/* Duplicate partners for seamless loop */}
-            {[...partners, ...partners].map((partner, i) => (
-              <MobilePartnerLink
-                key={`${partner.id}-${i}`}
-                index={i}
-                isDuplicate={i >= partners.length}
-                placementContext={placementContext}
-                partner={partner}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
+    <div className="docs-partner-slot ml-auto flex shrink-0 items-stretch border-l border-gray-500/20 pl-2 pr-3 md:hidden">
+      <DocsPartnerSlotLink
+        key={`${displayedSlot.partner.id}:${displayedSlot.slotIndex}`}
+        flipState={flipState}
+        orderPlacementContext={orderPlacementContext}
+        partner={displayedSlot.partner}
+        slotIndex={displayedSlot.slotIndex}
+      />
     </div>
   )
 }
 
-function MobilePartnerLink({
-  index,
-  isDuplicate,
-  placementContext,
+function DocsPartnerSlotLink({
+  flipState,
+  orderPlacementContext,
   partner,
+  slotIndex,
 }: {
-  index: number
-  isDuplicate: boolean
-  placementContext: PartnerPlacementContext
-  partner: {
-    category: Partner['category']
-    score: Partner['score']
-    tier?: Partner['tier']
-    id: string
-    name: string
-    href: string
-    image: Parameters<typeof PartnerImage>[0]['config']
-  }
+  flipState: DocsPartnerFlipState
+  orderPlacementContext: PartnerPlacementContext
+  partner: DocsPartner
+  slotIndex: number
 }) {
   const analyticsMetadata = getPartnerPlacementAnalyticsMetadata(
     partner,
-    placementContext,
+    orderPlacementContext,
   )
   const ref = useTrackedImpression<'partner_viewed', HTMLAnchorElement>({
-    enabled: !isDuplicate,
     event: 'partner_viewed',
     props: {
       partner_id: partner.id,
       placement: 'docs_strip',
       ...analyticsMetadata,
-      slot_index: index,
+      slot_index: slotIndex,
     },
   })
+  const compactImageConfig = getCompactPartnerImageConfig(partner.image)
+
+  const onClick = () => {
+    let destinationHost: string | undefined
+    try {
+      destinationHost = new URL(partner.href).host
+    } catch {
+      // Bad/relative href — track without host rather than dropping.
+    }
+    trackEvent('partner_clicked', {
+      partner_id: partner.id,
+      placement: 'docs_strip',
+      destination: 'external',
+      destination_host: destinationHost,
+      ...analyticsMetadata,
+      slot_index: slotIndex,
+    })
+  }
 
   return (
     <a
@@ -250,167 +205,273 @@ function MobilePartnerLink({
       href={partner.href}
       target="_blank"
       rel="noreferrer"
-      className="shrink-0 flex items-center opacity-50 hover:opacity-100 transition-opacity"
-      onClick={(event) => {
-        event.stopPropagation()
-
-        if (isDuplicate) {
-          return
-        }
-
-        let destinationHost: string | undefined
-        try {
-          destinationHost = new URL(partner.href).host
-        } catch {
-          // Bad/relative href — track without host rather than dropping.
-        }
-        trackEvent('partner_clicked', {
-          partner_id: partner.id,
-          placement: 'docs_strip',
-          destination: 'external',
-          destination_host: destinationHost,
-          ...analyticsMetadata,
-          slot_index: index,
-        })
-      }}
+      aria-label={`${partner.name} partner`}
+      className={twMerge(
+        'docs-partner-slot-link flex h-full shrink-0 items-center justify-center opacity-80 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current',
+      )}
+      data-flip-state={flipState}
+      onClick={onClick}
     >
-      <div className="h-4 flex items-center [&_img]:h-full [&_img]:w-auto [&_div]:h-full">
-        <PartnerImage config={partner.image} alt={partner.name} />
+      <div className="flex h-5 max-w-full shrink items-center justify-center [&>div]:!w-auto [&>div]:h-full [&>div]:max-w-full [&_img]:h-full [&_img]:max-w-full [&_img]:w-auto">
+        <PartnerImage
+          className="h-full w-auto object-contain"
+          config={compactImageConfig}
+          alt={partner.name}
+        />
       </div>
     </a>
   )
 }
 
-// Component for the collapsed menu strip showing box indicators
-// Minimap style: boxes with flex height filling available vertical space
-function DocsMenuStrip({
-  menuConfig,
-  activeItem,
-  fullPathname,
-  colorFrom,
-  colorTo,
-  frameworkLogo,
-  version,
-  onHover,
-  onClick,
-}: {
-  menuConfig: MenuItem[]
-  activeItem: string | undefined
-  fullPathname: string
-  colorFrom: string
-  colorTo: string
-  frameworkLogo: string | undefined
-  version: string
-  onHover: () => void
-  onClick: () => void
-}) {
-  // Flatten all menu items with section markers
-  const itemsWithSections: Array<{
-    to?: string
-    label: React.ReactNode
-    isSection: boolean
-  }> = []
-  menuConfig.forEach((group) => {
-    itemsWithSections.push({ label: group.label, isSection: true })
-    group.children?.forEach((child) => {
-      itemsWithSections.push({
-        to: child.to,
-        label: child.label,
-        isSection: false,
-      })
-    })
-  })
+function useDocsPartnerScrollSlot(tierGroups: Array<DocsPartnerTierGroup>) {
+  const [slot, setSlot] = React.useState(() =>
+    getDocsPartnerScrollSlot(tierGroups, 0),
+  )
 
-  // Check if a menu item path matches the current location
-  const isItemActive = (itemTo: string | undefined): boolean => {
-    if (!itemTo) return false
+  React.useEffect(() => {
+    let animationFrame: number | undefined
 
-    // External links are never active
-    if (itemTo.startsWith('http')) return false
-
-    // Standard relative path comparison
-    if (itemTo === activeItem) return true
-
-    // Handle special menu items with different path formats
-    // ".." means we're on the library home page (no /docs suffix in pathname)
-    if (itemTo === '..') {
-      // Active when on the library version index (e.g., /query/latest but not /query/latest/docs/...)
-      return fullPathname.match(/^\/[^/]+\/[^/]+\/?$/) !== null
-    }
-
-    // "./framework" means we're on the frameworks index page
-    if (itemTo === './framework') {
-      return (
-        fullPathname.includes('/docs/framework') &&
-        !fullPathname.match(/\/docs\/framework\/[^/]+/)
+    const update = () => {
+      animationFrame = undefined
+      const nextSlot = getDocsPartnerScrollSlot(
+        tierGroups,
+        getPageScrollProgress(),
+      )
+      setSlot((previousSlot) =>
+        areDocsPartnerSlotsEqual(previousSlot, nextSlot)
+          ? previousSlot
+          : nextSlot,
       )
     }
 
-    // Handle absolute paths like "/$libraryId/$version/docs/contributors"
-    if (itemTo.includes('/$libraryId')) {
-      const pathSuffix = itemTo.split('/docs/')[1]
-      if (pathSuffix && fullPathname.includes(`/docs/${pathSuffix}`)) {
-        return true
+    const requestUpdate = () => {
+      if (animationFrame !== undefined) {
+        return
+      }
+      animationFrame = window.requestAnimationFrame(update)
+    }
+
+    update()
+    window.addEventListener('scroll', requestUpdate, { passive: true })
+    window.addEventListener('resize', requestUpdate)
+
+    let resizeObserver: ResizeObserver | undefined
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(requestUpdate)
+      resizeObserver.observe(document.documentElement)
+      if (document.body) {
+        resizeObserver.observe(document.body)
       }
     }
 
-    return false
+    return () => {
+      if (animationFrame !== undefined) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+      window.removeEventListener('scroll', requestUpdate)
+      window.removeEventListener('resize', requestUpdate)
+      resizeObserver?.disconnect()
+    }
+  }, [tierGroups])
+
+  return slot
+}
+
+type DocsPartnerFlipState = 'idle' | 'out' | 'in'
+
+function useFlippingDocsPartnerSlot(
+  activeSlot: DocsPartnerScrollSlot | undefined,
+) {
+  const [displayedSlot, setDisplayedSlot] = React.useState(activeSlot)
+  const [flipState, setFlipState] = React.useState<DocsPartnerFlipState>('idle')
+  const displayedSlotRef = React.useRef(displayedSlot)
+
+  React.useEffect(() => {
+    displayedSlotRef.current = displayedSlot
+  }, [displayedSlot])
+
+  React.useEffect(() => {
+    const currentDisplayedSlot = displayedSlotRef.current
+
+    if (areDocsPartnerSlotsEqual(currentDisplayedSlot, activeSlot)) {
+      return
+    }
+
+    if (!activeSlot) {
+      setDisplayedSlot(undefined)
+      setFlipState('idle')
+      return
+    }
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches
+
+    if (!currentDisplayedSlot || prefersReducedMotion) {
+      setDisplayedSlot(activeSlot)
+      setFlipState('idle')
+      return
+    }
+
+    setFlipState('out')
+    const timeout = window.setTimeout(() => {
+      setDisplayedSlot(activeSlot)
+      setFlipState('in')
+    }, 120)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [activeSlot])
+
+  React.useEffect(() => {
+    if (
+      flipState !== 'in' ||
+      !areDocsPartnerSlotsEqual(displayedSlot, activeSlot)
+    ) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      setFlipState('idle')
+    }, 160)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [activeSlot, displayedSlot, flipState])
+
+  return { displayedSlot, flipState }
+}
+
+function getDocsPartnerScrollSlot(
+  tierGroups: Array<DocsPartnerTierGroup>,
+  progress: number,
+): DocsPartnerScrollSlot | undefined {
+  const availableGroups = partnerTiers
+    .map((tier) => tierGroups.find((group) => group.tier === tier))
+    .filter((group): group is DocsPartnerTierGroup => {
+      return Boolean(group && group.partners.length > 0)
+    })
+
+  if (!availableGroups.length) {
+    return undefined
   }
 
-  return (
-    <button
-      type="button"
-      className="flex flex-col gap-2 py-2 px-2 cursor-pointer h-full w-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gray-400/50"
-      onPointerEnter={onHover}
-      onFocus={onHover}
-      onClick={onClick}
-      aria-label="Open documentation menu"
-    >
-      {/* FrameworkSelect + VersionSelect icons */}
-      <div className="flex flex-col gap-2 shrink-0">
-        <div className="flex items-center justify-center">
-          <span className="flex items-center justify-center w-6 h-6">
-            {frameworkLogo ? (
-              <img src={frameworkLogo} alt="" className="w-4 h-4" />
-            ) : (
-              <Menu className="w-3.5 h-3.5 opacity-60" />
-            )}
-          </span>
-        </div>
-        <div className="flex items-center justify-center">
-          <span className="flex items-center justify-center px-1 py-0.5 text-[9px] font-medium opacity-60 border border-gray-500/30 rounded">
-            {version}
-          </span>
-        </div>
-      </div>
-
-      {/* Minimap: flex-height boxes filling remaining space */}
-      <div className="flex-1 flex flex-col gap-1 min-h-0">
-        {itemsWithSections.map((item, index) => {
-          const isActive = !item.isSection && isItemActive(item.to)
-
-          return (
-            <div
-              key={index}
-              className={twMerge(
-                'flex-1 min-h-[4px] max-h-[9px] min-w-[20px] rounded-sm',
-                item.isSection
-                  ? 'w-full bg-current opacity-15'
-                  : isActive
-                    ? `ml-2 w-[calc(100%-0.5rem)] bg-linear-to-r ${colorFrom} ${colorTo}`
-                    : 'ml-2 w-[calc(100%-0.5rem)] bg-current opacity-[0.06]',
-              )}
-              title={
-                typeof item.label === 'string'
-                  ? item.label
-                  : `Item ${index + 1}`
-              }
-            />
-          )
-        })}
-      </div>
-    </button>
+  const totalWeight = availableGroups.reduce(
+    (total, group) => total + docsPartnerTierWeights[group.tier],
+    0,
   )
+  const normalizedProgress = clampProgress(progress)
+  let progressStart = 0
+  let slotIndexOffset = 0
+
+  for (const [groupIndex, group] of availableGroups.entries()) {
+    const tierShare = docsPartnerTierWeights[group.tier] / totalWeight
+    const progressEnd = progressStart + tierShare
+    const isLastGroup = groupIndex === availableGroups.length - 1
+
+    if (normalizedProgress < progressEnd || isLastGroup) {
+      const localProgress = clampProgress(
+        (normalizedProgress - progressStart) / tierShare,
+      )
+      const partnerIndex = Math.min(
+        group.partners.length - 1,
+        Math.floor(localProgress * group.partners.length),
+      )
+
+      return {
+        partner: group.partners[partnerIndex],
+        slotIndex: slotIndexOffset + partnerIndex,
+      }
+    }
+
+    progressStart = progressEnd
+    slotIndexOffset += group.partners.length
+  }
+
+  return undefined
+}
+
+function getPageScrollProgress() {
+  const documentElement = document.documentElement
+  const body = document.body
+  const totalHeight = Math.max(
+    documentElement.scrollHeight,
+    body?.scrollHeight ?? 0,
+  )
+  const viewportHeight = window.innerHeight || documentElement.clientHeight
+  // scrollY tops out at totalHeight - viewportHeight; using that range keeps
+  // the final partner reachable when the viewport bottom hits the page bottom.
+  const scrollableHeight = Math.max(0, totalHeight - viewportHeight)
+
+  if (scrollableHeight === 0) {
+    return 0
+  }
+
+  const scrollTop = Math.min(
+    Math.max(window.scrollY || documentElement.scrollTop, 0),
+    scrollableHeight,
+  )
+
+  return scrollTop / scrollableHeight
+}
+
+function clampProgress(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.min(Math.max(value, 0), 1)
+}
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(false)
+
+  React.useEffect(() => {
+    const mediaQueryList = window.matchMedia(query)
+    const updateMatches = () => {
+      setMatches(mediaQueryList.matches)
+    }
+
+    updateMatches()
+    mediaQueryList.addEventListener('change', updateMatches)
+
+    return () => {
+      mediaQueryList.removeEventListener('change', updateMatches)
+    }
+  }, [query])
+
+  return matches
+}
+
+function areDocsPartnerSlotsEqual(
+  left: DocsPartnerScrollSlot | undefined,
+  right: DocsPartnerScrollSlot | undefined,
+) {
+  return (
+    left?.partner.id === right?.partner.id &&
+    left?.slotIndex === right?.slotIndex
+  )
+}
+
+function getCompactPartnerImageConfig(
+  image: Parameters<typeof PartnerImage>[0]['config'],
+): Parameters<typeof PartnerImage>[0]['config'] {
+  if (!image.scale) {
+    return image
+  }
+
+  if ('light' in image) {
+    return {
+      light: image.light,
+      dark: image.dark,
+    }
+  }
+
+  return {
+    src: image.src,
+  }
 }
 
 // Helper to get text color class from framework badge
@@ -781,6 +842,11 @@ export function LibraryLayout({
   const isNpmStats = matches.some((d) => d.pathname.includes('/docs/npm-stats'))
 
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
+  const mobileMenuDialogRef = React.useRef<HTMLDivElement>(null)
+  const mobileMenuToggleId = 'docs-mobile-menu-toggle'
+  const closeMobileMenu = React.useCallback(() => {
+    setMobileMenuOpen(false)
+  }, [])
 
   const docsMatch = matches.find((d) => d.pathname.includes('/docs'))
   const docsPathname = docsMatch?.pathname ?? ''
@@ -788,17 +854,17 @@ export function LibraryLayout({
   const relativePathname = lastMatch.pathname.replace(docsPathname + '/', '')
 
   React.useEffect(() => {
-    setMobileMenuOpen(false)
-  }, [lastMatch.pathname])
+    closeMobileMenu()
+  }, [closeMobileMenu, lastMatch.pathname])
 
   React.useEffect(() => {
     if (!mobileMenuOpen) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setMobileMenuOpen(false)
+      if (e.key === 'Escape') closeMobileMenu()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [mobileMenuOpen])
+  }, [closeMobileMenu, mobileMenuOpen])
 
   const tabbedMenuConfig = React.useMemo(() => {
     return getTabbedMenuConfig(menuConfig)
@@ -835,23 +901,17 @@ export function LibraryLayout({
   const prevItem = internalFlatMenu[index - 1]
   const nextItem = internalFlatMenu[index + 1]
 
-  // Get current framework's logo for the preview strip
-  const currentFramework = useCurrentFramework(frameworks)
-  const currentFrameworkOption = frameworkOptions.find(
-    (f) => f.value === currentFramework.framework,
-  )
-
   const [isFullWidth, setIsFullWidth] = useLocalStorage('docsFullWidth', false)
 
-  const activePartners = partners.filter((d) => d.status === 'active')
-  const docsStripPlacementContext = usePartnerPlacementContext({
-    orderStrategy: 'tier-rotated',
-    surface: 'docs_strip',
-  })
-  const docsStripPartners = getPartnersForPlacement(
-    activePartners,
-    docsStripPlacementContext,
+  const activePartners = React.useMemo(
+    () => partners.filter((d) => d.status === 'active'),
+    [],
   )
+  const docsPartnerOrderContext = usePartnerPlacementContext({
+    orderStrategy: 'tier-rotated',
+    surface: 'docs_rail',
+  })
+  const shouldShowDocsPartnerSlot = useMediaQuery('(max-width: 767.98px)')
 
   const groupInitialOpenState = React.useMemo(() => {
     return visibleMenuConfig.reduce<Record<string, boolean>>(
@@ -971,9 +1031,7 @@ export function LibraryLayout({
                 ) : isHomeLink ? (
                   <Link
                     to={libraryHomePath}
-                    onClick={() => {
-                      detailsRef.current.removeAttribute('open')
-                    }}
+                    onClick={closeMobileMenu}
                     className="relative"
                   >
                     <div
@@ -1003,9 +1061,7 @@ export function LibraryLayout({
                       framework: frameworkDocsTarget.framework,
                       _splat: frameworkDocsTarget.splat,
                     }}
-                    onClick={() => {
-                      detailsRef.current.removeAttribute('open')
-                    }}
+                    onClick={closeMobileMenu}
                     preload="intent"
                     activeOptions={{
                       exact: true,
@@ -1025,9 +1081,7 @@ export function LibraryLayout({
                       framework: frameworkDocsTarget.framework,
                       _splat: frameworkDocsTarget.splat,
                     }}
-                    onClick={() => {
-                      detailsRef.current.removeAttribute('open')
-                    }}
+                    onClick={closeMobileMenu}
                     preload="intent"
                     activeOptions={{
                       exact: true,
@@ -1043,9 +1097,7 @@ export function LibraryLayout({
                     from="/$libraryId/$version/docs"
                     to={child.to}
                     params={linkParams}
-                    onClick={() => {
-                      setMobileMenuOpen(false)
-                    }}
+                    onClick={closeMobileMenu}
                     preload="intent"
                     activeOptions={{
                       exact: true,
@@ -1083,22 +1135,34 @@ export function LibraryLayout({
   })
 
   const smallMenu = (
-    <div className="md:hidden">
-      {mobileMenuOpen ? (
-        <button
-          type="button"
-          aria-label="Close documentation menu"
-          className="fixed inset-x-0 bottom-0 top-[var(--navbar-height)] z-40 bg-black/30 backdrop-blur-sm"
-          onClick={() => setMobileMenuOpen(false)}
-        />
-      ) : null}
+    <div className="min-[900px]:hidden">
+      <input
+        id={mobileMenuToggleId}
+        type="checkbox"
+        aria-label="Documentation menu"
+        aria-controls="docs-mobile-menu"
+        checked={mobileMenuOpen}
+        data-docs-mobile-menu-toggle
+        className="sr-only"
+        onChange={(event) => {
+          setMobileMenuOpen(event.currentTarget.checked)
+        }}
+      />
+      <label
+        htmlFor={mobileMenuToggleId}
+        aria-label="Close documentation menu"
+        data-docs-mobile-backdrop
+        className="fixed inset-x-0 bottom-0 top-[var(--navbar-height)] z-40 bg-black/30 backdrop-blur-sm"
+      />
       <div
+        ref={mobileMenuDialogRef}
         id="docs-mobile-menu"
         role="dialog"
         aria-modal="true"
         aria-label="Documentation navigation"
-        hidden={!mobileMenuOpen}
-        className="fixed inset-x-0 top-[var(--navbar-height)] z-50
+        data-docs-mobile-menu
+        tabIndex={-1}
+        className="fixed inset-x-0 top-[var(--navbar-height)] z-50 m-0 w-full max-w-none p-0 min-[900px]:hidden
         max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto
         bg-white dark:bg-black/95 backdrop-blur-lg border-b border-gray-500/20 shadow-xl"
       >
@@ -1107,8 +1171,9 @@ export function LibraryLayout({
           <button
             type="button"
             aria-label="Close menu"
-            className="p-1 rounded-md hover:bg-gray-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
-            onClick={() => setMobileMenuOpen(false)}
+            aria-controls="docs-mobile-menu"
+            className="p-1 rounded-md hover:bg-gray-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current cursor-pointer"
+            onClick={closeMobileMenu}
           >
             <X className="w-5 h-5" />
           </button>
@@ -1128,6 +1193,16 @@ export function LibraryLayout({
   // State and timer for auto-hide behavior (similar to Navbar)
   const [showLargeMenu, setShowLargeMenu] = React.useState(false)
   const leaveTimer = React.useRef<NodeJS.Timeout | undefined>(undefined)
+  const largeMenuTriggerRef = React.useRef<HTMLButtonElement>(null)
+  const largeMenuClickOutsideRefs = React.useMemo(
+    () => [largeMenuTriggerRef],
+    [],
+  )
+
+  const openLargeMenu = React.useCallback(() => {
+    clearTimeout(leaveTimer.current)
+    setShowLargeMenu(true)
+  }, [])
 
   // Close menu when clicking outside (only on sm-xl screens where it's an overlay)
   const expandedMenuRef = useClickOutside<HTMLDivElement>({
@@ -1136,58 +1211,26 @@ export function LibraryLayout({
       typeof window !== 'undefined' &&
       window.innerWidth < 1280,
     onClickOutside: () => setShowLargeMenu(false),
+    additionalRefs: largeMenuClickOutsideRefs,
   })
 
   const largeMenu = (
     <>
-      {/* Collapsed strip - visible on md to xl, hidden on xl+. Lower z-index so expanded menu covers it */}
-      <div
-        className={twMerge(
-          'hidden md:flex xl:hidden flex-col overflow-hidden',
-          'sticky top-[var(--navbar-height)] h-[calc(100dvh-var(--navbar-height))]',
-          'z-10 border-r border-gray-500/20',
-          'bg-white/50 dark:bg-black/30',
-          'w-10',
-        )}
-      >
-        <DocsMenuStrip
-          menuConfig={visibleMenuConfig}
-          activeItem={relativePathname}
-          fullPathname={lastMatch.pathname}
-          colorFrom={colorFrom}
-          colorTo={colorTo}
-          frameworkLogo={currentFrameworkOption?.logo}
-          version={version}
-          onHover={() => {
-            if (window.innerWidth < 1280) {
-              // Only auto-show on lg screens, not xl+
-              clearTimeout(leaveTimer.current)
-              setShowLargeMenu(true)
-            }
-          }}
-          onClick={() => {
-            if (window.innerWidth < 1280) {
-              clearTimeout(leaveTimer.current)
-              setShowLargeMenu(true)
-            }
-          }}
-        />
-      </div>
-
       {/* Expanded menu - always visible on xl+, toggleable overlay on md-xl */}
       <div
+        id="docs-desktop-menu"
+        data-docs-desktop-menu
         ref={expandedMenuRef}
         className={twMerge(
           'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
           'flex-col overflow-hidden',
-          'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
+          'h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height))] top-[calc(var(--navbar-height)+var(--docs-tabs-height))]',
           'border-r border-gray-500/20',
           'transition-all duration-300',
-          // Hidden on smallest screens, flex on md+
-          'hidden md:flex',
-          // On md to xl: fixed overlay that slides in from left-0 (covers the strip).
-          // z-40 keeps the sliding overlay above the docs tab bar (z-30).
-          'md:fixed md:left-0 md:z-40 md:bg-white md:dark:bg-black/95 md:backdrop-blur-lg md:shadow-xl',
+          // Hidden on smallest screens, flex once the main navbar switches to desktop.
+          'hidden min-[900px]:flex',
+          // On narrow desktop to xl: fixed overlay that slides in from left-0 beneath the docs tab bar.
+          'min-[900px]:fixed min-[900px]:left-0 min-[900px]:z-40 min-[900px]:bg-white min-[900px]:dark:bg-black/95 min-[900px]:backdrop-blur-lg min-[900px]:shadow-xl',
           // On xl+: sticky positioning sitting inline below tabs, no overlay styling
           'xl:sticky xl:z-20 xl:bg-transparent xl:dark:bg-transparent xl:backdrop-blur-none xl:shadow-none',
           // Slide animation for md-xl screens (off-screen by default, slides in when shown)
@@ -1227,83 +1270,116 @@ export function LibraryLayout({
   )
 
   const docsTabs = (
-    <div className="sticky top-[calc(var(--navbar-height)-1px)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
+    <div className="sticky top-[var(--navbar-height)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
       <div className="flex items-stretch">
-        <button
-          type="button"
+        <label
+          htmlFor={mobileMenuToggleId}
+          role="button"
+          tabIndex={0}
           aria-label="Documentation menu"
-          aria-expanded={mobileMenuOpen}
+          aria-expanded={mobileMenuOpen ? true : undefined}
           aria-controls="docs-mobile-menu"
-          onClick={() => setMobileMenuOpen((open) => !open)}
-          className="md:hidden flex items-center gap-1.5 shrink-0 px-3 border-r border-gray-500/20 text-slate-600 dark:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              setMobileMenuOpen((prev) => !prev)
+            }
+          }}
+          data-docs-mobile-trigger
+          className="min-[900px]:hidden flex items-center gap-1.5 shrink-0 px-3 border-r border-gray-500/20 text-slate-600 dark:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
         >
-          {mobileMenuOpen ? (
-            <X className="w-4 h-4" />
-          ) : (
-            <Menu className="w-4 h-4" />
-          )}
+          <Menu className="w-4 h-4" data-docs-mobile-closed-icon />
+          <X className="w-4 h-4" data-docs-mobile-open-icon />
+          <span className="text-xs font-medium max-[479.98px]:sr-only">
+            Menu
+          </span>
+        </label>
+        <button
+          ref={largeMenuTriggerRef}
+          type="button"
+          aria-label="Open documentation menu"
+          aria-expanded={showLargeMenu}
+          aria-controls="docs-desktop-menu"
+          onPointerEnter={(event) => {
+            if (event.pointerType === 'touch') return
+            openLargeMenu()
+          }}
+          onPointerDown={openLargeMenu}
+          onMouseEnter={openLargeMenu}
+          onFocus={openLargeMenu}
+          onClick={openLargeMenu}
+          data-docs-menu-trigger
+          className="hidden min-[900px]:flex xl:hidden items-center gap-1 shrink-0 px-2 border-r border-gray-500/20 text-xs font-medium text-slate-600 dark:text-slate-300 min-[1120px]:gap-1.5 min-[1120px]:px-3 min-[1120px]:text-[13px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
+        >
+          <Menu className="w-4 h-4" />
           <span className="text-xs font-medium">Menu</span>
         </button>
-        <nav
-          aria-label="Documentation sections"
-          className="flex flex-1 items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        >
-          {tabbedMenuConfig.map((tab) => {
-            const target = tab.firstItem
-            const isActive = tab.id === activeTabId
+        <div className="relative flex min-w-0 flex-1 items-stretch">
+          <nav
+            aria-label="Documentation sections"
+            className="flex min-w-0 flex-1 items-stretch gap-3 overflow-x-auto px-3 text-xs min-[1120px]:gap-6 min-[1120px]:px-6 min-[1120px]:text-[13px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
+            {tabbedMenuConfig.map((tab) => {
+              const target = tab.firstItem
+              const isActive = tab.id === activeTabId
 
-            if (!target) {
-              return null
-            }
+              if (!target) {
+                return null
+              }
 
-            const linkParams =
-              !target.to.startsWith('/') || target.to.includes('/$libraryId')
-                ? ({ libraryId, version } as never)
-                : undefined
+              const linkParams =
+                !target.to.startsWith('/') || target.to.includes('/$libraryId')
+                  ? ({ libraryId, version } as never)
+                  : undefined
 
-            return (
-              <Link
-                key={tab.id}
-                from="/$libraryId/$version/docs"
-                to={target.to}
-                params={linkParams}
-                aria-current={isActive ? 'page' : undefined}
-                className={twMerge(
-                  'relative whitespace-nowrap py-3 font-semibold transition-colors',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current rounded-sm',
-                  isActive
-                    ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
-                    : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
-                )}
-              >
-                {tab.label}
-                {isActive ? (
-                  <span
-                    aria-hidden="true"
-                    className={twMerge(
-                      'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
-                      colorFrom,
-                      colorTo,
-                    )}
-                  />
-                ) : null}
-              </Link>
-            )
-          })}
-        </nav>
-      </div>
-      {activePartners.length ? (
-        <div className="md:hidden flex items-center gap-2 px-3 py-1 border-t border-gray-500/10">
-          <span className="text-[9px] uppercase tracking-wide font-medium text-gray-400 dark:text-gray-500 shrink-0">
-            Partners
-          </span>
-          <MobilePartnersStrip
-            partners={docsStripPartners}
-            placementContext={docsStripPlacementContext}
-            enabled
+              return (
+                <Link
+                  key={tab.id}
+                  from="/$libraryId/$version/docs"
+                  to={target.to}
+                  params={linkParams}
+                  activeOptions={{
+                    exact: true,
+                    includeHash: false,
+                    includeSearch: false,
+                  }}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={twMerge(
+                    'relative whitespace-nowrap py-3 font-semibold transition-colors',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current rounded-sm',
+                    isActive
+                      ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                      : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
+                  )}
+                >
+                  {tab.label}
+                  {isActive ? (
+                    <span
+                      aria-hidden="true"
+                      className={twMerge(
+                        'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
+                        colorFrom,
+                        colorTo,
+                      )}
+                    />
+                  ) : null}
+                </Link>
+              )
+            })}
+          </nav>
+          <div
+            aria-hidden="true"
+            data-docs-tabs-scroll-fade
+            className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-r from-white/0 to-white/95 dark:from-black/0 dark:to-black/90 min-[640px]:w-10"
           />
         </div>
-      ) : null}
+        {shouldShowDocsPartnerSlot && activePartners.length ? (
+          <DocsPartnerSlot
+            orderPlacementContext={docsPartnerOrderContext}
+            partners={activePartners}
+          />
+        ) : null}
+      </div>
     </div>
   )
 
@@ -1321,53 +1397,60 @@ export function LibraryLayout({
         }}
       >
         <div
+          data-docs-layout
+          data-docs-menu-open={showLargeMenu ? 'true' : undefined}
           className={`
            md:min-h-[calc(100dvh-var(--navbar-height))]
-           flex flex-col md:flex-row
-          w-full transition-all duration-300
+           flex flex-col
+          w-full transition-all duration-300 [--docs-tabs-height:41px] min-[1120px]:[--docs-tabs-height:42px]
           [overflow-x:clip]`}
         >
           {smallMenu}
-          {largeMenu}
-          <div
-            className={twMerge(
-              'flex flex-col max-w-full min-w-0 flex-1 min-h-0 relative',
-            )}
-            style={{ '--docs-tabs-height': '45px' } as React.CSSProperties}
-          >
-            {docsTabs}
+          {docsTabs}
+          <div className="flex flex-col md:flex-row flex-1 min-h-0">
+            {largeMenu}
             <div
               className={twMerge(
-                `max-w-full min-w-0 flex flex-col justify-center w-full`,
-
-                !isLandingPage && 'px-4 md:px-8',
-
-                !isLandingPage &&
-                  !isExample &&
-                  !isNpmStats &&
-                  !isFullWidth &&
-                  'mx-auto w-[900px]',
+                'flex flex-col max-w-full min-w-0 flex-1 min-h-0 relative',
               )}
             >
-              {children}
+              <div
+                className={twMerge(
+                  `max-w-full min-w-0 flex flex-col justify-center w-full`,
+
+                  !isLandingPage && 'px-4 md:px-8',
+
+                  !isLandingPage &&
+                    !isExample &&
+                    !isNpmStats &&
+                    !isFullWidth &&
+                    'mx-auto w-[900px]',
+                )}
+              >
+                {children}
+              </div>
+              {!isLandingPage && (
+                <div className="pt-8 md:pt-12">
+                  <Footer />
+                </div>
+              )}
             </div>
             {!isLandingPage && (
-              <div className="pt-8 md:pt-12">
-                <Footer />
-              </div>
+              <RightRail
+                breakpoint="md"
+                className="md:w-[220px]"
+                stickyOffset="docs-tabs"
+              >
+                <PartnersRail
+                  analyticsPlacement="docs_rail"
+                  partners={activePartners}
+                />
+                <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
+                  <RecentPostsWidget />
+                </div>
+              </RightRail>
             )}
           </div>
-          {!isLandingPage && (
-            <RightRail breakpoint="md" className="md:w-[220px]">
-              <PartnersRail
-                analyticsPlacement="docs_rail"
-                partners={activePartners}
-              />
-              <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
-                <RecentPostsWidget />
-              </div>
-            </RightRail>
-          )}
         </div>
       </DocNavigationContext.Provider>
     </WidthToggleContext.Provider>

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -8,6 +8,10 @@ import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClickOutside } from '~/hooks/useClickOutside'
 import { last } from '~/utils/utils'
 import type { ConfigSchema, MenuItem } from '~/utils/config'
+import {
+  getActiveDocsNavTabId,
+  getTabbedMenuConfig,
+} from '~/utils/docsNavTabs'
 import { Framework, LibraryId } from '~/libraries'
 import { frameworkOptions } from '~/libraries/frameworks'
 import { twMerge } from 'tailwind-merge'
@@ -722,6 +726,7 @@ const useMenuConfig = ({
 
       return {
         label: section.label,
+        tab: section.tab,
         children,
         collapsible: section.collapsible ?? false,
         defaultCollapsed: section.defaultCollapsed ?? false,
@@ -771,21 +776,41 @@ export function LibraryLayout({
 
   const detailsRef = React.useRef<HTMLElement>(null!)
 
-  const flatMenu = React.useMemo(
-    () => menuConfig.flatMap((d) => d?.children),
-    [menuConfig],
-  )
-
-  // Filter out external links for prev/next navigation
-  const internalFlatMenu = React.useMemo(
-    () => flatMenu.filter((d) => d && !d.to.startsWith('http')),
-    [flatMenu],
-  )
-
   const docsMatch = matches.find((d) => d.pathname.includes('/docs'))
   const docsPathname = docsMatch?.pathname ?? ''
 
   const relativePathname = lastMatch.pathname.replace(docsPathname + '/', '')
+
+  const tabbedMenuConfig = React.useMemo(() => {
+    return getTabbedMenuConfig(menuConfig)
+  }, [menuConfig])
+
+  const activeTabId = React.useMemo(() => {
+    return getActiveDocsNavTabId({
+      isExample,
+      menuConfig,
+      pathname: lastMatch.pathname,
+      relativePathname,
+    })
+  }, [isExample, lastMatch.pathname, menuConfig, relativePathname])
+
+  const visibleMenuConfig = React.useMemo(() => {
+    return (
+      tabbedMenuConfig.find((tab) => tab.id === activeTabId)?.groups ??
+      menuConfig
+    )
+  }, [activeTabId, menuConfig, tabbedMenuConfig])
+
+  const flatMenu = React.useMemo(
+    () => visibleMenuConfig.flatMap((d) => d.children),
+    [visibleMenuConfig],
+  )
+
+  // Filter out external links for prev/next navigation
+  const internalFlatMenu = React.useMemo(
+    () => flatMenu.filter((d) => !d.to.startsWith('http')),
+    [flatMenu],
+  )
 
   const index = internalFlatMenu.findIndex((d) => d?.to === relativePathname)
   const prevItem = internalFlatMenu[index - 1]
@@ -810,19 +835,22 @@ export function LibraryLayout({
   )
 
   const groupInitialOpenState = React.useMemo(() => {
-    return menuConfig.reduce<Record<string, boolean>>((acc, group, index) => {
-      const isChildActive = group.children.some((child) => child.to === _splat)
-      const key = `${index}:${String(group.label)}`
+    return visibleMenuConfig.reduce<Record<string, boolean>>(
+      (acc, group, index) => {
+        const isChildActive = group.children.some((child) => child.to === _splat)
+        const key = `${index}:${String(group.label)}`
 
-      acc[key] = isChildActive
-        ? true
-        : typeof group.defaultCollapsed !== 'undefined'
-          ? !group.defaultCollapsed
-          : false
+        acc[key] = isChildActive
+          ? true
+          : typeof group.defaultCollapsed !== 'undefined'
+            ? !group.defaultCollapsed
+            : false
 
-      return acc
-    }, {})
-  }, [menuConfig, _splat])
+        return acc
+      },
+      {},
+    )
+  }, [visibleMenuConfig, _splat])
 
   const [openGroups, setOpenGroups] = React.useState(groupInitialOpenState)
 
@@ -850,7 +878,7 @@ export function LibraryLayout({
 
   const libraryHomePath = `/${libraryId}/${version}`
 
-  const menuItems = menuConfig.map((group, i) => {
+  const menuItems = visibleMenuConfig.map((group, i) => {
     const groupKey = `${i}:${String(group.label)}`
 
     const groupContent = (
@@ -1098,7 +1126,7 @@ export function LibraryLayout({
         )}
       >
         <DocsMenuStrip
-          menuConfig={menuConfig}
+          menuConfig={visibleMenuConfig}
           activeItem={relativePathname}
           fullPathname={lastMatch.pathname}
           colorFrom={colorFrom}
@@ -1125,7 +1153,7 @@ export function LibraryLayout({
       <div
         ref={expandedMenuRef}
         className={twMerge(
-          'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
+          'w-[250px] xl:w-[300px] 2xl:w-[400px] shrink-0',
           'flex-col overflow-hidden',
           'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
           'z-20 border-r border-gray-500/20',
@@ -1172,6 +1200,47 @@ export function LibraryLayout({
     </>
   )
 
+  const docsTabs = (
+    <div className="border-b border-gray-500/20 bg-white/70 dark:bg-black/40 backdrop-blur-lg">
+      <nav
+        aria-label="Documentation sections"
+        className="flex items-center gap-1 overflow-x-auto px-3 md:px-6 py-2 text-sm"
+      >
+        {tabbedMenuConfig.map((tab) => {
+          const target = tab.firstItem
+          const isActive = tab.id === activeTabId
+
+          if (!target) {
+            return null
+          }
+
+          const linkParams =
+            !target.to.startsWith('/') || target.to.includes('/$libraryId')
+              ? ({ libraryId, version } as never)
+              : undefined
+
+          return (
+            <Link
+              key={tab.id}
+              from="/$libraryId/$version/docs"
+              to={target.to}
+              params={linkParams}
+              className={twMerge(
+                'whitespace-nowrap rounded-md px-3 py-1.5 font-semibold transition-colors',
+                'hover:bg-gray-500/10',
+                isActive
+                  ? `bg-gray-500/10 text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                  : 'opacity-70 hover:opacity-100',
+              )}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+
   return (
     <WidthToggleContext.Provider value={{ isFullWidth, setIsFullWidth }}>
       <DocNavigationContext.Provider
@@ -1197,12 +1266,14 @@ export function LibraryLayout({
           <div
             className={twMerge(
               'flex flex-col max-w-full min-w-0 flex-1 min-h-0 relative',
-              !isLandingPage && 'px-4 md:px-8',
             )}
           >
+            {docsTabs}
             <div
               className={twMerge(
                 `max-w-full min-w-0 flex flex-col justify-center w-full`,
+
+                !isLandingPage && 'px-4 md:px-8',
 
                 !isLandingPage &&
                   !isExample &&

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -8,10 +8,7 @@ import { useLocalStorage } from '~/utils/useLocalStorage'
 import { useClickOutside } from '~/hooks/useClickOutside'
 import { last } from '~/utils/utils'
 import type { ConfigSchema, MenuItem } from '~/utils/config'
-import {
-  getActiveDocsNavTabId,
-  getTabbedMenuConfig,
-} from '~/utils/docsNavTabs'
+import { getActiveDocsNavTabId, getTabbedMenuConfig } from '~/utils/docsNavTabs'
 import { Framework, LibraryId } from '~/libraries'
 import { frameworkOptions } from '~/libraries/frameworks'
 import { twMerge } from 'tailwind-merge'
@@ -837,7 +834,9 @@ export function LibraryLayout({
   const groupInitialOpenState = React.useMemo(() => {
     return visibleMenuConfig.reduce<Record<string, boolean>>(
       (acc, group, index) => {
-        const isChildActive = group.children.some((child) => child.to === _splat)
+        const isChildActive = group.children.some(
+          (child) => child.to === _splat,
+        )
         const key = `${index}:${String(group.label)}`
 
         acc[key] = isChildActive

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ChevronLeft, ChevronRight, Menu } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Menu, X } from 'lucide-react'
 import { GithubIcon } from '~/components/icons/GithubIcon'
 import { DiscordIcon } from '~/components/icons/DiscordIcon'
 import { YouTubeIcon } from '~/components/icons/YouTubeIcon'
@@ -101,7 +101,7 @@ function DocRecencyPill({
 function MobilePartnersStrip({
   partners,
   placementContext,
-  onLabelClick,
+  enabled = true,
 }: {
   partners: Array<{
     category: Partner['category']
@@ -113,7 +113,7 @@ function MobilePartnersStrip({
     image: Parameters<typeof PartnerImage>[0]['config']
   }>
   placementContext: PartnerPlacementContext
-  onLabelClick?: () => void
+  enabled?: boolean
 }) {
   const innerRef = React.useRef<HTMLDivElement>(null)
   const [isHovered, setIsHovered] = React.useState(false)
@@ -123,16 +123,21 @@ function MobilePartnersStrip({
   React.useEffect(() => {
     const inner = innerRef.current
     if (!inner) return
+    if (!enabled) return
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+    // The strip is mobile-only (md:hidden), so don't run the rAF loop on md+
+    // where it isn't painted.
+    const isDesktop = window.matchMedia('(min-width: 768px)')
 
     let animationId: number
     let timeoutId: ReturnType<typeof setTimeout>
-    const scrollSpeed = 0.15 // pixels per frame
-    const startDelay = 4000 // wait 4 seconds before starting (first time only)
+    const scrollSpeed = 0.15
+    const startDelay = 4000
 
     const animate = () => {
       if (!isHovered && inner) {
         scrollPositionRef.current += scrollSpeed
-        // Reset when we've scrolled past the first set
         if (scrollPositionRef.current >= inner.scrollWidth / 2) {
           scrollPositionRef.current = 0
         }
@@ -141,37 +146,41 @@ function MobilePartnersStrip({
       animationId = requestAnimationFrame(animate)
     }
 
-    if (!hasStartedRef.current) {
-      timeoutId = setTimeout(() => {
-        hasStartedRef.current = true
+    const start = () => {
+      if (reduceMotion.matches || isDesktop.matches) return
+      if (!hasStartedRef.current) {
+        timeoutId = setTimeout(() => {
+          hasStartedRef.current = true
+          animationId = requestAnimationFrame(animate)
+        }, startDelay)
+      } else {
         animationId = requestAnimationFrame(animate)
-      }, startDelay)
-    } else {
-      animationId = requestAnimationFrame(animate)
+      }
     }
 
-    return () => {
+    const stop = () => {
       clearTimeout(timeoutId)
       cancelAnimationFrame(animationId)
     }
-  }, [isHovered])
+
+    const restart = () => {
+      stop()
+      start()
+    }
+
+    isDesktop.addEventListener('change', restart)
+    reduceMotion.addEventListener('change', restart)
+    start()
+
+    return () => {
+      isDesktop.removeEventListener('change', restart)
+      reduceMotion.removeEventListener('change', restart)
+      stop()
+    }
+  }, [isHovered, enabled])
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events
-    <div
-      className="flex-1 flex items-center gap-2 min-w-0"
-      onClick={(e) => e.preventDefault()}
-    >
-      <button
-        type="button"
-        className="text-[9px] uppercase tracking-wide font-medium text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 shrink-0"
-        onClick={(e) => {
-          e.stopPropagation()
-          onLabelClick?.()
-        }}
-      >
-        Partners
-      </button>
+    <div className="flex items-center gap-2 min-w-0">
       <div
         className="relative flex-1 overflow-hidden min-w-0"
         onMouseEnter={() => setIsHovered(true)}
@@ -771,12 +780,25 @@ export function LibraryLayout({
 
   const isNpmStats = matches.some((d) => d.pathname.includes('/docs/npm-stats'))
 
-  const detailsRef = React.useRef<HTMLElement>(null!)
+  const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
 
   const docsMatch = matches.find((d) => d.pathname.includes('/docs'))
   const docsPathname = docsMatch?.pathname ?? ''
 
   const relativePathname = lastMatch.pathname.replace(docsPathname + '/', '')
+
+  React.useEffect(() => {
+    setMobileMenuOpen(false)
+  }, [lastMatch.pathname])
+
+  React.useEffect(() => {
+    if (!mobileMenuOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileMenuOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [mobileMenuOpen])
 
   const tabbedMenuConfig = React.useMemo(() => {
     return getTabbedMenuConfig(menuConfig)
@@ -1022,7 +1044,7 @@ export function LibraryLayout({
                     to={child.to}
                     params={linkParams}
                     onClick={() => {
-                      detailsRef.current.removeAttribute('open')
+                      setMobileMenuOpen(false)
                     }}
                     preload="intent"
                     activeOptions={{
@@ -1061,33 +1083,37 @@ export function LibraryLayout({
   })
 
   const smallMenu = (
-    <div
-      className="md:hidden bg-white/50 sticky top-[var(--navbar-height)]
-    max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto z-20 dark:bg-black/60 backdrop-blur-lg"
-    >
-      <details
-        ref={detailsRef as any}
-        id="docs-details"
-        className="border-b border-gray-500/20"
+    <div className="md:hidden">
+      {mobileMenuOpen ? (
+        <button
+          type="button"
+          aria-label="Close documentation menu"
+          className="fixed inset-x-0 bottom-0 top-[var(--navbar-height)] z-40 bg-black/30 backdrop-blur-sm"
+          onClick={() => setMobileMenuOpen(false)}
+        />
+      ) : null}
+      <div
+        id="docs-mobile-menu"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Documentation navigation"
+        hidden={!mobileMenuOpen}
+        className="fixed inset-x-0 top-[var(--navbar-height)] z-50
+        max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto
+        bg-white dark:bg-black/95 backdrop-blur-lg border-b border-gray-500/20 shadow-xl"
       >
-        <summary className="py-2 px-4 flex gap-2 items-center">
-          <div className="flex gap-2 items-center shrink-0 pr-2">
-            <Menu className="cursor-pointer" />
-            Docs
-          </div>
-          <div className="w-px h-6 bg-gray-300 dark:bg-gray-600 shrink-0" />
-          <MobilePartnersStrip
-            partners={docsStripPartners}
-            placementContext={docsStripPlacementContext}
-            onLabelClick={() => {
-              const details = detailsRef.current as HTMLDetailsElement | null
-              if (details) {
-                details.open = !details.open
-              }
-            }}
-          />
-        </summary>
-        <div className="flex flex-col gap-4 p-4 overflow-y-auto border-t border-gray-500/20 bg-white/20 text-lg dark:bg-black/20">
+        <div className="flex items-center justify-between py-2 px-4 border-b border-gray-500/20">
+          <span className="font-bold">Docs</span>
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="p-1 rounded-md hover:bg-gray-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="flex flex-col gap-4 p-4 text-lg">
           <div className="flex flex-col gap-1">
             <FrameworkSelect libraryId={libraryId} />
             <VersionSelect libraryId={libraryId} />
@@ -1095,7 +1121,7 @@ export function LibraryLayout({
           <SearchButton />
           {menuItems}
         </div>
-      </details>
+      </div>
     </div>
   )
 
@@ -1201,11 +1227,27 @@ export function LibraryLayout({
   )
 
   const docsTabs = (
-    <div className="sticky top-[calc(var(--navbar-height)-4px)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
-      <nav
-        aria-label="Documentation sections"
-        className="flex items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      >
+    <div className="sticky top-[calc(var(--navbar-height)-1px)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
+      <div className="flex items-stretch">
+        <button
+          type="button"
+          aria-label="Documentation menu"
+          aria-expanded={mobileMenuOpen}
+          aria-controls="docs-mobile-menu"
+          onClick={() => setMobileMenuOpen((open) => !open)}
+          className="md:hidden flex items-center gap-1.5 shrink-0 px-3 border-r border-gray-500/20 text-slate-600 dark:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current"
+        >
+          {mobileMenuOpen ? (
+            <X className="w-4 h-4" />
+          ) : (
+            <Menu className="w-4 h-4" />
+          )}
+          <span className="text-xs font-medium">Menu</span>
+        </button>
+        <nav
+          aria-label="Documentation sections"
+          className="flex flex-1 items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
         {tabbedMenuConfig.map((tab) => {
           const target = tab.firstItem
           const isActive = tab.id === activeTabId
@@ -1248,7 +1290,20 @@ export function LibraryLayout({
             </Link>
           )
         })}
-      </nav>
+        </nav>
+      </div>
+      {activePartners.length ? (
+        <div className="md:hidden flex items-center gap-2 px-3 py-1 border-t border-gray-500/10">
+          <span className="text-[9px] uppercase tracking-wide font-medium text-gray-400 dark:text-gray-500 shrink-0">
+            Partners
+          </span>
+          <MobilePartnersStrip
+            partners={docsStripPartners}
+            placementContext={docsStripPlacementContext}
+            enabled
+          />
+        </div>
+      ) : null}
     </div>
   )
 

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -1248,48 +1248,48 @@ export function LibraryLayout({
           aria-label="Documentation sections"
           className="flex flex-1 items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
-        {tabbedMenuConfig.map((tab) => {
-          const target = tab.firstItem
-          const isActive = tab.id === activeTabId
+          {tabbedMenuConfig.map((tab) => {
+            const target = tab.firstItem
+            const isActive = tab.id === activeTabId
 
-          if (!target) {
-            return null
-          }
+            if (!target) {
+              return null
+            }
 
-          const linkParams =
-            !target.to.startsWith('/') || target.to.includes('/$libraryId')
-              ? ({ libraryId, version } as never)
-              : undefined
+            const linkParams =
+              !target.to.startsWith('/') || target.to.includes('/$libraryId')
+                ? ({ libraryId, version } as never)
+                : undefined
 
-          return (
-            <Link
-              key={tab.id}
-              from="/$libraryId/$version/docs"
-              to={target.to}
-              params={linkParams}
-              aria-current={isActive ? 'page' : undefined}
-              className={twMerge(
-                'relative whitespace-nowrap py-3 font-semibold transition-colors',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current rounded-sm',
-                isActive
-                  ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
-                  : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
-              )}
-            >
-              {tab.label}
-              {isActive ? (
-                <span
-                  aria-hidden="true"
-                  className={twMerge(
-                    'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
-                    colorFrom,
-                    colorTo,
-                  )}
-                />
-              ) : null}
-            </Link>
-          )
-        })}
+            return (
+              <Link
+                key={tab.id}
+                from="/$libraryId/$version/docs"
+                to={target.to}
+                params={linkParams}
+                aria-current={isActive ? 'page' : undefined}
+                className={twMerge(
+                  'relative whitespace-nowrap py-3 font-semibold transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current rounded-sm',
+                  isActive
+                    ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                    : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
+                )}
+              >
+                {tab.label}
+                {isActive ? (
+                  <span
+                    aria-hidden="true"
+                    className={twMerge(
+                      'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
+                      colorFrom,
+                      colorTo,
+                    )}
+                  />
+                ) : null}
+              </Link>
+            )
+          })}
         </nav>
       </div>
       {activePartners.length ? (

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -1155,14 +1155,15 @@ export function LibraryLayout({
           'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
           'flex-col overflow-hidden',
           'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
-          'z-20 border-r border-gray-500/20',
+          'border-r border-gray-500/20',
           'transition-all duration-300',
           // Hidden on smallest screens, flex on md+
           'hidden md:flex',
-          // On md to xl: fixed overlay that slides in from left-0 (covers the strip)
-          'md:fixed md:left-0 md:bg-white md:dark:bg-black/95 md:backdrop-blur-lg md:shadow-xl',
-          // On xl+: sticky positioning, no overlay styling
-          'xl:sticky xl:bg-transparent xl:dark:bg-transparent xl:backdrop-blur-none xl:shadow-none',
+          // On md to xl: fixed overlay that slides in from left-0 (covers the strip).
+          // z-40 keeps the sliding overlay above the docs tab bar (z-30).
+          'md:fixed md:left-0 md:z-40 md:bg-white md:dark:bg-black/95 md:backdrop-blur-lg md:shadow-xl',
+          // On xl+: sticky positioning sitting inline below tabs, no overlay styling
+          'xl:sticky xl:z-20 xl:bg-transparent xl:dark:bg-transparent xl:backdrop-blur-none xl:shadow-none',
           // Slide animation for md-xl screens (off-screen by default, slides in when shown)
           // On xl+: always visible (no translate)
           !showLargeMenu && 'md:-translate-x-full xl:translate-x-0',
@@ -1224,8 +1225,10 @@ export function LibraryLayout({
               from="/$libraryId/$version/docs"
               to={target.to}
               params={linkParams}
+              aria-current={isActive ? 'page' : undefined}
               className={twMerge(
                 'relative whitespace-nowrap py-3 font-semibold transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-current rounded-sm',
                 isActive
                   ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
                   : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
@@ -1234,6 +1237,7 @@ export function LibraryLayout({
               {tab.label}
               {isActive ? (
                 <span
+                  aria-hidden="true"
                   className={twMerge(
                     'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
                     colorFrom,

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -1152,7 +1152,7 @@ export function LibraryLayout({
       <div
         ref={expandedMenuRef}
         className={twMerge(
-          'w-[250px] xl:w-[300px] 2xl:w-[400px] shrink-0',
+          'max-w-[250px] xl:max-w-[300px] 2xl:max-w-[400px]',
           'flex-col overflow-hidden',
           'h-[calc(100dvh-var(--navbar-height))] top-[var(--navbar-height)]',
           'z-20 border-r border-gray-500/20',
@@ -1186,7 +1186,7 @@ export function LibraryLayout({
           }
         }}
       >
-        <div className="flex-1 flex flex-col overflow-y-auto">
+        <div className="flex-1 flex flex-col overflow-y-auto min-w-[230px]">
           <div className="flex flex-col gap-1 p-4">
             <FrameworkSelect libraryId={libraryId} />
             <VersionSelect libraryId={libraryId} />
@@ -1200,10 +1200,10 @@ export function LibraryLayout({
   )
 
   const docsTabs = (
-    <div className="border-b border-gray-500/20 bg-white/70 dark:bg-black/40 backdrop-blur-lg">
+    <div className="sticky top-[calc(var(--navbar-height)-4px)] z-30 border-b border-gray-500/20 bg-white/90 dark:bg-black/80 backdrop-blur-lg">
       <nav
         aria-label="Documentation sections"
-        className="flex items-center gap-1 overflow-x-auto px-3 md:px-6 py-2 text-sm"
+        className="flex items-stretch gap-6 overflow-x-auto px-3 md:px-6 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabbedMenuConfig.map((tab) => {
           const target = tab.firstItem
@@ -1225,14 +1225,22 @@ export function LibraryLayout({
               to={target.to}
               params={linkParams}
               className={twMerge(
-                'whitespace-nowrap rounded-md px-3 py-1.5 font-semibold transition-colors',
-                'hover:bg-gray-500/10',
+                'relative whitespace-nowrap py-3 font-semibold transition-colors',
                 isActive
-                  ? `bg-gray-500/10 text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
-                  : 'opacity-70 hover:opacity-100',
+                  ? `text-transparent bg-clip-text bg-linear-to-r ${colorFrom} ${colorTo}`
+                  : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100',
               )}
             >
               {tab.label}
+              {isActive ? (
+                <span
+                  className={twMerge(
+                    'absolute left-0 right-0 -bottom-px h-[3px] rounded-t-full bg-linear-to-r',
+                    colorFrom,
+                    colorTo,
+                  )}
+                />
+              ) : null}
             </Link>
           )
         })}
@@ -1290,7 +1298,7 @@ export function LibraryLayout({
             )}
           </div>
           {!isLandingPage && (
-            <RightRail breakpoint="md" className="md:w-[280px]">
+            <RightRail breakpoint="md" className="md:w-[220px]">
               <PartnersRail
                 analyticsPlacement="docs_rail"
                 partners={activePartners}

--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -1274,6 +1274,7 @@ export function LibraryLayout({
             className={twMerge(
               'flex flex-col max-w-full min-w-0 flex-1 min-h-0 relative',
             )}
+            style={{ '--docs-tabs-height': '45px' } as React.CSSProperties}
           >
             {docsTabs}
             <div

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -471,7 +471,14 @@ export function Navbar({ children }: { children: React.ReactNode }) {
         : null
 
     resizeObserver?.observe(container)
-    window.addEventListener('resize', scheduleContainerHeightUpdate)
+    let lastWidth = window.innerWidth
+    const onResize = () => {
+      if (window.innerWidth === lastWidth) return
+      lastWidth = window.innerWidth
+      scheduleContainerHeightUpdate()
+    }
+
+    window.addEventListener('resize', onResize)
 
     return () => {
       if (animationFrameId !== null) {
@@ -479,7 +486,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
       }
 
       resizeObserver?.disconnect()
-      window.removeEventListener('resize', scheduleContainerHeightUpdate)
+      window.removeEventListener('resize', onResize)
     }
   }, [])
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -143,8 +143,9 @@ type NavigationLibrary = LibrarySlim & {
 
 type LibraryGroupId = keyof typeof librariesByGroup
 
-const DESKTOP_NAV_CLASS = 'hidden min-[960px]:flex'
-const MOBILE_NAV_CLASS = 'min-[960px]:hidden'
+const DESKTOP_NAV_CLASS = 'hidden min-[900px]:flex'
+const MOBILE_NAV_CLASS = 'min-[900px]:hidden'
+const DESKTOP_SOCIAL_CLASS = 'hidden min-[1120px]:flex'
 const LIBRARY_MENU_GROUP_IDS: readonly LibraryGroupId[] = [
   'framework',
   'state',
@@ -649,12 +650,12 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     <div
       className={twMerge(
         'w-full p-2 fixed top-0 z-[100] bg-white/90 dark:bg-black/90 backdrop-blur-lg',
-        'flex items-center justify-between gap-3',
+        'flex items-center justify-between gap-2 min-[1120px]:gap-3',
         'border-b border-gray-500/20',
       )}
       ref={containerRef}
     >
-      <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="flex min-w-0 flex-1 items-center gap-2 min-[1120px]:gap-3">
         <div className="flex items-center gap-2 font-black text-xl uppercase min-w-0">
           <React.Suspense fallback={<LogoSection title={Title} />}>
             <LazyBrandContextMenu
@@ -695,7 +696,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
       </div>
 
       <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
-        <div className={DESKTOP_NAV_CLASS}>{socialLinks}</div>
+        <div className={DESKTOP_SOCIAL_CLASS}>{socialLinks}</div>
         <ThemeToggle />
         <NavbarCartButton />
         <SearchButton iconOnly />
@@ -815,7 +816,7 @@ function DesktopNavTrigger({
   onResetDismissed: () => void
 }) {
   const triggerClassName = twMerge(
-    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-[13px] font-medium',
+    'ts-mega-trigger inline-flex items-center gap-1 rounded-md px-2 py-2 text-xs font-medium min-[1120px]:gap-1.5 min-[1120px]:px-3 min-[1120px]:text-[13px]',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
   )
@@ -1453,7 +1454,12 @@ function MenuItemLink({
           ) : null}
         </span>
         {item.description ? (
-          <span className="mt-0.5 block text-sm leading-5 text-gray-600 dark:text-gray-400">
+          <span
+            className={twMerge(
+              'mt-0.5 block text-gray-600 dark:text-gray-400',
+              variant === 'desktop' ? 'text-xs leading-4' : 'text-sm leading-5',
+            )}
+          >
             {item.description}
           </span>
         ) : null}

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -34,28 +34,45 @@ type RightRailProps = {
   children: React.ReactNode
   className?: string
   breakpoint?: 'sm' | 'md'
+  stickyOffset?: 'navbar' | 'docs-tabs'
 }
 
 export function RightRail({
   children,
   className,
   breakpoint = 'sm',
+  stickyOffset = 'navbar',
 }: RightRailProps) {
+  const stickyTopClass =
+    stickyOffset === 'docs-tabs'
+      ? breakpoint === 'md'
+        ? 'md:top-[calc(var(--navbar-height)+var(--docs-tabs-height,0px))]'
+        : 'sm:top-[calc(var(--navbar-height)+var(--docs-tabs-height,0px))]'
+      : breakpoint === 'md'
+        ? 'md:top-[var(--navbar-height)]'
+        : 'sm:top-[var(--navbar-height)]'
+  const stickyMaxHeightClass =
+    stickyOffset === 'docs-tabs'
+      ? breakpoint === 'md'
+        ? 'md:max-h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height,0px))]'
+        : 'sm:max-h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height,0px))]'
+      : breakpoint === 'md'
+        ? 'md:max-h-[calc(100dvh-var(--navbar-height))]'
+        : 'sm:max-h-[calc(100dvh-var(--navbar-height))]'
   const wrapperBreakpointClass =
     breakpoint === 'md'
-      ? 'w-full md:w-[300px] shrink-0 md:sticky md:top-[var(--navbar-height)] hidden md:block'
-      : 'w-full sm:w-[300px] shrink-0 sm:sticky sm:top-[var(--navbar-height)] hidden sm:block'
+      ? 'w-full md:w-[300px] shrink-0 md:sticky hidden md:block'
+      : 'w-full sm:w-[300px] shrink-0 sm:sticky hidden sm:block'
 
-  const innerBreakpointClass =
-    breakpoint === 'md'
-      ? 'md:sticky md:top-[var(--navbar-height)] md:max-h-[calc(100dvh-var(--navbar-height))]'
-      : 'sm:sticky sm:top-[var(--navbar-height)] sm:max-h-[calc(100dvh-var(--navbar-height))]'
+  const innerBreakpointClass = breakpoint === 'md' ? 'md:sticky' : 'sm:sticky'
 
   return (
-    <div className={twMerge(wrapperBreakpointClass, className)}>
+    <div className={twMerge(wrapperBreakpointClass, stickyTopClass, className)}>
       <div
         className={twMerge(
           innerBreakpointClass,
+          stickyTopClass,
+          stickyMaxHeightClass,
           'ml-auto flex flex-col gap-4 pb-4 max-w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0',
         )}
       >

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -41,7 +41,9 @@ export function Toc({
     })
   }, [headings, currentFramework])
   return (
-    <nav className="flex flex-col sticky top-[var(--navbar-height)] max-h-[calc(100dvh-var(--navbar-height))] overflow-hidden">
+    <nav
+      className="flex flex-col sticky top-[calc(var(--navbar-height)+var(--docs-tabs-height,0px))] max-h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height,0px))] overflow-hidden"
+    >
       <div className="py-1">
         <h3 className="text-[.8em] lg:text-[.825em] xl:text-[.875em] 2xl:text-[.9em] font-bold">
           On this page

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -41,9 +41,7 @@ export function Toc({
     })
   }, [headings, currentFramework])
   return (
-    <nav
-      className="flex flex-col sticky top-[calc(var(--navbar-height)+var(--docs-tabs-height,0px))] max-h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height,0px))] overflow-hidden"
-    >
+    <nav className="flex flex-col sticky top-[calc(var(--navbar-height)+var(--docs-tabs-height,0px))] max-h-[calc(100dvh-var(--navbar-height)-var(--docs-tabs-height,0px))] overflow-hidden">
       <div className="py-1">
         <h3 className="text-[.8em] lg:text-[.825em] xl:text-[.875em] 2xl:text-[.9em] font-bold">
           On this page

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -160,18 +160,19 @@ button {
 }
 
 .ts-mega-dropdown {
+  --ts-mega-dropdown-x: 0;
   position: absolute;
   left: -1rem;
   top: 100%;
   z-index: 90;
   width: max-content;
   min-width: var(--ts-primary-nav-target-width, 0px);
-  max-width: min(calc(100vw - 1rem), 70rem);
+  max-width: min(calc(100vw - 2rem), 70rem);
   padding-top: 1rem;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transform: translate3d(0, -8px, 0) scale(0.985);
+  transform: translate3d(var(--ts-mega-dropdown-x), -8px, 0) scale(0.985);
   transform-origin: 50% 0;
   transition:
     opacity 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
@@ -186,7 +187,7 @@ button {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
-  transform: translate3d(0, 0, 0) scale(1);
+  transform: translate3d(var(--ts-mega-dropdown-x), 0, 0) scale(1);
   transition-delay: 0s;
 }
 
@@ -242,13 +243,127 @@ button {
     inset 0 -1px 0 rgb(255 255 255 / 0.04);
 }
 
-@media (max-width: 1280px) {
+@media (min-width: 900px) and (max-width: 1119.98px) {
   .ts-mega-dropdown {
+    --ts-mega-dropdown-x: -50%;
+    position: fixed;
+    right: auto;
+    left: 50%;
+    top: calc(var(--navbar-height) - 0.625rem);
+    width: max-content;
+    min-width: var(--ts-primary-nav-target-width, 0px);
     max-width: calc(100vw - 2rem);
+    padding-top: calc(1rem + 0.625rem);
+  }
+
+  .ts-mega-dropdown-panel {
+    width: max-content;
+    min-width: var(--ts-primary-nav-target-width, 0px);
+    max-width: calc(100vw - 2rem);
+    overflow-x: auto;
   }
 }
 
-@media (min-width: 960px) {
+[data-docs-mobile-backdrop],
+[data-docs-mobile-menu],
+[data-docs-mobile-open-icon] {
+  display: none;
+}
+
+.docs-partner-slot {
+  perspective: 18rem;
+}
+
+.docs-partner-slot-link {
+  backface-visibility: hidden;
+  transform-origin: 50% 50%;
+  transform-style: preserve-3d;
+}
+
+.docs-partner-slot-link[data-flip-state='out'] {
+  animation: docs-partner-flip-out 120ms cubic-bezier(0.36, 0, 0.66, -0.56) both;
+}
+
+.docs-partner-slot-link[data-flip-state='in'] {
+  animation: docs-partner-flip-in 160ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes docs-partner-flip-out {
+  from {
+    opacity: 0.8;
+    transform: rotateX(0deg);
+  }
+
+  to {
+    opacity: 0;
+    transform: rotateX(-90deg);
+  }
+}
+
+@keyframes docs-partner-flip-in {
+  from {
+    opacity: 0;
+    transform: rotateX(90deg);
+  }
+
+  to {
+    opacity: 0.8;
+    transform: rotateX(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-partner-slot-link[data-flip-state='out'],
+  .docs-partner-slot-link[data-flip-state='in'] {
+    animation: none;
+  }
+}
+
+@media (max-width: 639.98px) {
+  .docs-partner-slot-link {
+    max-width: 30vw;
+  }
+}
+
+@media (max-width: 899.98px) {
+  [data-docs-layout]:has([data-docs-mobile-menu-toggle]:checked)
+    [data-docs-mobile-backdrop],
+  [data-docs-layout]:has([data-docs-mobile-menu-toggle]:checked)
+    [data-docs-mobile-menu] {
+    display: block;
+  }
+
+  [data-docs-layout]:has([data-docs-mobile-menu-toggle]:checked)
+    [data-docs-mobile-closed-icon] {
+    display: none;
+  }
+
+  [data-docs-layout]:has([data-docs-mobile-menu-toggle]:checked)
+    [data-docs-mobile-open-icon] {
+    display: block;
+  }
+}
+
+@media (min-width: 900px) {
+  [data-docs-mobile-backdrop],
+  [data-docs-mobile-menu] {
+    display: none !important;
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1279.98px) {
+  [data-docs-layout]:has([data-docs-menu-trigger]:is(:hover, :focus, :active))
+    [data-docs-desktop-menu],
+  [data-docs-layout]:has([data-docs-desktop-menu]:hover)
+    [data-docs-desktop-menu],
+  [data-docs-layout][data-docs-menu-open='true'] [data-docs-desktop-menu] {
+    --tw-translate-x: 0 !important;
+    translate: 0 0 !important;
+    transform: translateX(0) !important;
+  }
+}
+
+@media (min-width: 900px) {
   body:has(
       .ts-mega-trigger-wrap:not([data-menu-dismissed='true']):hover
         > .ts-mega-dropdown

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,29 +3,36 @@ import {
   fetchRepoFile,
   isRecoverableGitHubContentError,
 } from './documents.server'
+import { docsNavTabIds, type DocsNavTabId } from './docsNavTabs'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeaders } from '@tanstack/react-start/server'
 
 export type MenuItem = {
   label: string | React.ReactNode
+  tab?: DocsNavTabId
   children: {
     label: string | React.ReactNode
     to: string
     badge?: string
+    tab?: DocsNavTabId
   }[]
   collapsible?: boolean
   defaultCollapsed?: boolean
 }
 
+const tabSchema = v.optional(v.picklist(docsNavTabIds))
+
 const configSchema = v.object({
   sections: v.array(
     v.object({
       label: v.string(),
+      tab: tabSchema,
       children: v.array(
         v.object({
           label: v.string(),
           to: v.string(),
           badge: v.optional(v.string()),
+          tab: tabSchema,
         }),
       ),
       frameworks: v.optional(
@@ -37,6 +44,7 @@ const configSchema = v.object({
                 label: v.string(),
                 to: v.string(),
                 badge: v.optional(v.string()),
+                tab: tabSchema,
               }),
             ),
           }),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,11 +3,13 @@ import {
   fetchRepoFile,
   isRecoverableGitHubContentError,
 } from './documents.server'
+import { docsNavTabIds, type DocsNavTabId } from './docsNavTabs'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeaders } from '@tanstack/react-start/server'
 
 export type MenuItem = {
   label: string | React.ReactNode
+  tab?: DocsNavTabId
   children: {
     label: string | React.ReactNode
     to: string
@@ -16,15 +18,19 @@ export type MenuItem = {
     addedAt?: string
     /** ISO date string marking when the page was last meaningfully updated. Drives the "Updated" sidebar pill. */
     updatedAt?: string
+    tab?: DocsNavTabId
   }[]
   collapsible?: boolean
   defaultCollapsed?: boolean
 }
 
+const tabSchema = v.optional(v.picklist(docsNavTabIds))
+
 const configSchema = v.object({
   sections: v.array(
     v.object({
       label: v.string(),
+      tab: tabSchema,
       children: v.array(
         v.object({
           label: v.string(),
@@ -32,6 +38,7 @@ const configSchema = v.object({
           badge: v.optional(v.string()),
           addedAt: v.optional(v.string()),
           updatedAt: v.optional(v.string()),
+          tab: tabSchema,
         }),
       ),
       frameworks: v.optional(
@@ -45,6 +52,7 @@ const configSchema = v.object({
                 badge: v.optional(v.string()),
                 addedAt: v.optional(v.string()),
                 updatedAt: v.optional(v.string()),
+                tab: tabSchema,
               }),
             ),
           }),

--- a/src/utils/docsNavTabs.ts
+++ b/src/utils/docsNavTabs.ts
@@ -146,7 +146,10 @@ export function getActiveDocsNavTabId({
     return getDocsNavTabId(activeGroup, activeChild)
   }
 
-  if (pathname.includes('/docs/api/') || pathname.includes('/docs/reference/')) {
+  if (
+    pathname.includes('/docs/api/') ||
+    pathname.includes('/docs/reference/')
+  ) {
     return 'api'
   }
 

--- a/src/utils/docsNavTabs.ts
+++ b/src/utils/docsNavTabs.ts
@@ -40,6 +40,7 @@ function getFallbackDocsNavTabId(
     searchText.includes('contributors') ||
     searchText.includes('npm-stats') ||
     searchText.includes('npm stats') ||
+    searchText.includes('blog') ||
     searchText.includes('github') ||
     searchText.includes('discord') ||
     searchText.includes('youtube')
@@ -91,6 +92,16 @@ export function getDocsNavTabId(
   return child.tab ?? group.tab ?? getFallbackDocsNavTabId(group, child)
 }
 
+// A tab's `firstItem` is the destination clicked when the user activates the
+// tab. It must point at real docs content, never a utility/special target like
+// `..` (library home), `./framework` (framework picker), or external links.
+function isDocsTabTarget(to: string) {
+  if (to.startsWith('http')) return false
+  if (to === '..' || to === './framework') return false
+  if (to.startsWith('/')) return to.includes('/docs/')
+  return true
+}
+
 export function getTabbedMenuConfig(menuConfig: MenuItem[]) {
   return docsNavTabs
     .map((tab) => {
@@ -109,15 +120,51 @@ export function getTabbedMenuConfig(menuConfig: MenuItem[]) {
         })
         .filter((group): group is MenuItem => group !== undefined)
 
+      const children = groups.flatMap((group) => group.children)
+
       return {
         ...tab,
         groups,
-        firstItem: groups
-          .flatMap((group) => group.children)
-          .find((child) => !child.to.startsWith('http')),
+        firstItem:
+          children.find((child) => isDocsTabTarget(child.to)) ??
+          children.find((child) => !child.to.startsWith('http')),
       }
     })
     .filter((tab) => tab.groups.length)
+}
+
+// Matches a menu child's `to` against the current pathname, handling the
+// special/absolute internal paths used by the Menu group (e.g. `..`,
+// `./framework`, `/$libraryId/$version/docs/...`) in addition to plain
+// relative doc paths.
+function isChildPathMatch({
+  childTo,
+  pathname,
+  relativePathname,
+}: {
+  childTo: string
+  pathname: string
+  relativePathname: string
+}) {
+  if (childTo === relativePathname) return true
+
+  if (childTo === '..') {
+    return /^\/[^/]+\/[^/]+\/?$/.test(pathname)
+  }
+
+  if (childTo === './framework') {
+    return (
+      pathname.includes('/docs/framework') &&
+      !/\/docs\/framework\/[^/]+/.test(pathname)
+    )
+  }
+
+  if (childTo.includes('/$libraryId/$version/docs/')) {
+    const suffix = childTo.split('/docs/')[1]
+    return Boolean(suffix) && pathname.includes(`/docs/${suffix}`)
+  }
+
+  return false
 }
 
 export function getActiveDocsNavTabId({
@@ -136,10 +183,12 @@ export function getActiveDocsNavTabId({
   }
 
   const activeGroup = menuConfig.find((group) =>
-    group.children.some((child) => child.to === relativePathname),
+    group.children.some((child) =>
+      isChildPathMatch({ childTo: child.to, pathname, relativePathname }),
+    ),
   )
-  const activeChild = activeGroup?.children.find(
-    (child) => child.to === relativePathname,
+  const activeChild = activeGroup?.children.find((child) =>
+    isChildPathMatch({ childTo: child.to, pathname, relativePathname }),
   )
 
   if (activeGroup && activeChild) {

--- a/src/utils/docsNavTabs.ts
+++ b/src/utils/docsNavTabs.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import type { MenuItem } from './config'
 
 export const docsNavTabIds = [
+  'home',
   'get-started',
   'tutorial',
   'guides',
@@ -13,6 +14,7 @@ export const docsNavTabIds = [
 export type DocsNavTabId = (typeof docsNavTabIds)[number]
 
 export const docsNavTabs: Array<{ id: DocsNavTabId; label: string }> = [
+  { id: 'home', label: 'Home' },
   { id: 'get-started', label: 'Get Started' },
   { id: 'tutorial', label: 'Tutorial' },
   { id: 'guides', label: 'Guides' },
@@ -33,6 +35,15 @@ function getFallbackDocsNavTabId(
   const childLabel = getLabelText(child.label).toLowerCase()
   const to = child.to.toLowerCase()
   const searchText = `${groupLabel} ${childLabel} ${to}`
+
+  if (
+    child.to === '..' ||
+    child.to === './framework' ||
+    childLabel === 'home' ||
+    childLabel === 'frameworks'
+  ) {
+    return 'home'
+  }
 
   if (
     child.to.startsWith('http') ||
@@ -71,13 +82,11 @@ function getFallbackDocsNavTabId(
     groupLabel.includes('get started') ||
     groupLabel.includes('getting started') ||
     groupLabel.includes('overview') ||
-    childLabel === 'home' ||
-    childLabel === 'frameworks' ||
+    childLabel === 'overview' ||
     searchText.includes('installation') ||
     searchText.includes('quick-start') ||
     searchText.includes('quick start') ||
-    searchText.includes('introduction') ||
-    searchText.includes('overview')
+    searchText.includes('introduction')
   ) {
     return 'get-started'
   }

--- a/src/utils/docsNavTabs.ts
+++ b/src/utils/docsNavTabs.ts
@@ -1,0 +1,166 @@
+import type { ReactNode } from 'react'
+import type { MenuItem } from './config'
+
+export const docsNavTabIds = [
+  'get-started',
+  'tutorial',
+  'guides',
+  'api',
+  'examples',
+  'community',
+] as const
+
+export type DocsNavTabId = (typeof docsNavTabIds)[number]
+
+export const docsNavTabs: Array<{ id: DocsNavTabId; label: string }> = [
+  { id: 'get-started', label: 'Get Started' },
+  { id: 'tutorial', label: 'Tutorial' },
+  { id: 'guides', label: 'Guides' },
+  { id: 'api', label: 'API' },
+  { id: 'examples', label: 'Examples' },
+  { id: 'community', label: 'Community' },
+]
+
+function getLabelText(label: ReactNode) {
+  return typeof label === 'string' ? label : ''
+}
+
+function getFallbackDocsNavTabId(
+  group: MenuItem,
+  child: MenuItem['children'][number],
+): DocsNavTabId {
+  const groupLabel = getLabelText(group.label).toLowerCase()
+  const childLabel = getLabelText(child.label).toLowerCase()
+  const to = child.to.toLowerCase()
+  const searchText = `${groupLabel} ${childLabel} ${to}`
+
+  if (
+    child.to.startsWith('http') ||
+    searchText.includes('community') ||
+    searchText.includes('contributors') ||
+    searchText.includes('npm-stats') ||
+    searchText.includes('npm stats') ||
+    searchText.includes('github') ||
+    searchText.includes('discord') ||
+    searchText.includes('youtube')
+  ) {
+    return 'community'
+  }
+
+  if (searchText.includes('example')) {
+    return 'examples'
+  }
+
+  if (
+    to.includes('/api/') ||
+    to.startsWith('api/') ||
+    to.includes('/reference/') ||
+    to.startsWith('reference/') ||
+    groupLabel.includes('api') ||
+    groupLabel.includes('reference')
+  ) {
+    return 'api'
+  }
+
+  if (searchText.includes('tutorial')) {
+    return 'tutorial'
+  }
+
+  if (
+    groupLabel.includes('get started') ||
+    groupLabel.includes('getting started') ||
+    groupLabel.includes('overview') ||
+    childLabel === 'home' ||
+    childLabel === 'frameworks' ||
+    searchText.includes('installation') ||
+    searchText.includes('quick-start') ||
+    searchText.includes('quick start') ||
+    searchText.includes('introduction') ||
+    searchText.includes('overview')
+  ) {
+    return 'get-started'
+  }
+
+  return 'guides'
+}
+
+export function getDocsNavTabId(
+  group: MenuItem,
+  child: MenuItem['children'][number],
+) {
+  return child.tab ?? group.tab ?? getFallbackDocsNavTabId(group, child)
+}
+
+export function getTabbedMenuConfig(menuConfig: MenuItem[]) {
+  return docsNavTabs
+    .map((tab) => {
+      const groups = menuConfig
+        .map((group) => {
+          const children = group.children.filter((child) => {
+            return getDocsNavTabId(group, child) === tab.id
+          })
+
+          return children.length
+            ? {
+                ...group,
+                children,
+              }
+            : undefined
+        })
+        .filter((group): group is MenuItem => group !== undefined)
+
+      return {
+        ...tab,
+        groups,
+        firstItem: groups
+          .flatMap((group) => group.children)
+          .find((child) => !child.to.startsWith('http')),
+      }
+    })
+    .filter((tab) => tab.groups.length)
+}
+
+export function getActiveDocsNavTabId({
+  isExample,
+  menuConfig,
+  pathname,
+  relativePathname,
+}: {
+  isExample: boolean
+  menuConfig: MenuItem[]
+  pathname: string
+  relativePathname: string
+}) {
+  if (isExample) {
+    return 'examples'
+  }
+
+  const activeGroup = menuConfig.find((group) =>
+    group.children.some((child) => child.to === relativePathname),
+  )
+  const activeChild = activeGroup?.children.find(
+    (child) => child.to === relativePathname,
+  )
+
+  if (activeGroup && activeChild) {
+    return getDocsNavTabId(activeGroup, activeChild)
+  }
+
+  if (pathname.includes('/docs/api/') || pathname.includes('/docs/reference/')) {
+    return 'api'
+  }
+
+  if (pathname.includes('/docs/tutorial')) {
+    return 'tutorial'
+  }
+
+  if (
+    pathname.includes('/docs/community') ||
+    pathname.includes('/docs/contributors') ||
+    pathname.includes('/docs/npm-stats')
+  ) {
+    return 'community'
+  }
+
+  return 'get-started'
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ import path from 'node:path'
 
 const isDev = process.env.NODE_ENV !== 'production'
 const shouldUseRedact = process.env.DISABLE_REDACT !== 'true'
+const localRedactPackageRoot = process.env.LOCAL_REDACT_PACKAGE_ROOT
 const shouldUseSentryPlugin =
   process.env.NODE_ENV === 'production' &&
   Boolean(process.env.SENTRY_AUTH_TOKEN)
@@ -242,7 +243,19 @@ export default defineConfig({
     },
   },
   plugins: [
-    ...(shouldUseRedact ? [redact()] : []),
+    ...(shouldUseRedact
+      ? [
+          redact(
+            localRedactPackageRoot
+              ? {
+                  packageRoots: {
+                    '@tanstack/redact': localRedactPackageRoot,
+                  },
+                }
+              : undefined,
+          ),
+        ]
+      : []),
     ...(isDev
       ? [
           tanstackDevtools({


### PR DESCRIPTION
Add docs-level navigation tabs for getting started, tutorials, guides, API, examples, and community links. Extract tab grouping logic out of `DocsLayout` and add optional config metadata for explicit tab assignment while preserving fallback classification for existing docs configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sticky horizontal docs tabs above content linking to each section and highlighting the active tab.
  * Docs navigation and sidebar now group content by tab so sidebar, prev/next, and collapsed menu reflect the selected tab.
  * Mobile docs navigation replaced with a fixed dialog-style menu; tapping sidebar links closes the mobile menu. Mobile partners strip can be disabled.

* **Style**
  * Adjusted sidebar widths, right-rail sizing, TOC offsets, layout spacing, and overlay stacking to accommodate the tabs bar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->