### PR TITLE
feat(builder): add Vercel as a deploy provider

### DIFF
--- a/src/components/ApplicationStarter.tsx
+++ b/src/components/ApplicationStarter.tsx
@@ -832,6 +832,19 @@ export function ApplicationStarter({
                                 Deploy to Railway
                               </Button>
 
+                              <Button
+                                size="sm"
+                                type="button"
+                                onClick={() => {
+                                  void openDeployDialog('vercel')
+                                }}
+                                disabled={!canUseFinalActions}
+                                className="border-black bg-black text-white hover:bg-gray-800 dark:border-white dark:bg-white dark:text-black dark:hover:bg-gray-100"
+                              >
+                                <Rocket className="h-4 w-4" />
+                                Deploy to Vercel
+                              </Button>
+
                               {!showMoreActions ? (
                                 <Button
                                   variant="secondary"

--- a/src/components/application-builder/shared.ts
+++ b/src/components/application-builder/shared.ts
@@ -9,7 +9,11 @@ import {
 } from '~/utils/application-starter'
 
 export type StarterTone = 'cyan' | 'emerald' | 'violet'
-export type StarterDeployProvider = 'cloudflare' | 'netlify' | 'railway'
+export type StarterDeployProvider =
+  | 'cloudflare'
+  | 'netlify'
+  | 'railway'
+  | 'vercel'
 export type StarterPackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn'
 export type StarterToolchain = 'biome' | 'eslint'
 

--- a/src/components/deploy/shared.ts
+++ b/src/components/deploy/shared.ts
@@ -4,7 +4,7 @@
  * Common types, constants, and validation for deploy dialogs.
  */
 
-export type DeployProvider = 'cloudflare' | 'netlify' | 'railway'
+export type DeployProvider = 'cloudflare' | 'netlify' | 'railway' | 'vercel'
 
 export type DeployState =
   | { step: 'auth-check' }
@@ -45,6 +45,12 @@ export const PROVIDER_INFO: Record<DeployProvider, ProviderInfo> = {
     color: '#9B4DCA',
     deployUrl: () =>
       `https://railway.com/new/github?utm_medium=sponsor&utm_source=oss&utm_campaign=tanstack`,
+  },
+  vercel: {
+    name: 'Vercel',
+    color: '#000000',
+    deployUrl: (owner, repo) =>
+      `https://vercel.com/new/clone?repository-url=https://github.com/${owner}/${repo}`,
   },
 }
 

--- a/src/utils/provider-config.server.ts
+++ b/src/utils/provider-config.server.ts
@@ -5,7 +5,7 @@
  * This enables 1-click deploys to Cloudflare, Netlify, Railway, etc.
  */
 
-export type DeployProvider = 'cloudflare' | 'netlify' | 'railway'
+export type DeployProvider = 'cloudflare' | 'netlify' | 'railway' | 'vercel'
 
 interface ProviderConfigResult {
   files: Record<string, string>
@@ -47,6 +47,8 @@ export function getProviderConfig(
       return getNetlifyConfig()
     case 'railway':
       return getRailwayConfig()
+    case 'vercel':
+      return getVercelConfig()
     default:
       return { files: {}, devDependencies: {} }
   }
@@ -108,6 +110,18 @@ function getRailwayConfig(): ProviderConfigResult {
     files: {},
     devDependencies: {
       nitro: 'npm:nitro-nightly@latest',
+    },
+  }
+}
+
+/**
+ * Vercel configuration (uses Nitro)
+ */
+function getVercelConfig(): ProviderConfigResult {
+  return {
+    files: {},
+    devDependencies: {
+      nitro: 'latest',
     },
   }
 }
@@ -238,6 +252,23 @@ cmd = "npx serve dist -s -l 3000"
       }
     }
 
+    case 'vercel': {
+      // Vercel auto-detects Vite SPA builds via the dist/ output directory
+      // and serves index.html for unmatched routes when configured below.
+      const vercelJson = `{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}
+`
+      return {
+        files: {
+          'vercel.json': vercelJson,
+        },
+      }
+    }
+
     default:
       return { files: {} }
   }
@@ -291,6 +322,12 @@ function updatePackageJson(
         // Railway needs node-based start script for Nitro
         pkg.scripts.build = 'vite build'
         pkg.scripts.start = 'node .output/server/index.mjs'
+        break
+
+      case 'vercel':
+        // Vercel auto-detects the build command. Nitro's Vercel preset
+        // outputs the function bundle Vercel expects.
+        pkg.scripts.build = pkg.scripts.build ?? 'vite build'
         break
     }
 
@@ -361,6 +398,22 @@ function updateViteConfig(content: string, provider: DeployProvider): string {
       result = addPluginToConfig(result, 'nitro()')
       break
     }
+
+    case 'vercel': {
+      // Add nitro import if not present
+      if (!result.includes('nitro/vite')) {
+        const lastImportIndex = findLastImportIndex(result)
+        const importStatement = `import { nitro } from 'nitro/vite'\n`
+        result =
+          result.slice(0, lastImportIndex) +
+          importStatement +
+          result.slice(lastImportIndex)
+      }
+
+      // Add nitro() to plugins array
+      result = addPluginToConfig(result, 'nitro()')
+      break
+    }
   }
 
   return result
@@ -414,6 +467,7 @@ export function generateExampleDescription(
     cloudflare: 'Cloudflare',
     netlify: 'Netlify',
     railway: 'Railway',
+    vercel: 'Vercel',
   }
 
   return `${libraryName} example: ${exampleName} (configured for ${providerNames[provider]})`


### PR DESCRIPTION
Adds **Vercel** to the builder's deploy actions, alongside Cloudflare, Netlify, and Railway. [TanStack Start has first-party support on Vercel](https://vercel.com/docs/frameworks/full-stack/tanstack-start) via the Nitro Vite plugin.

## Changes

- New "Deploy to Vercel" button next to Railway, styled black/white per Vercel's brand
- Vercel added to `DeployProvider` / `StarterDeployProvider` unions and `PROVIDER_INFO` (deploy URL: `vercel.com/new/clone?repository-url=...`)
- `provider-config.server.ts` mirrors the Railway/Nitro path, with one deviation: pins `nitro` to `latest` (stable beta) instead of `nitro-nightly`. Today's nightly hits a 508 INFINITE_LOOP_DETECTED on Vercel; the stable beta works.

## Verified

Deployed a real TanStack Start app via this exact config — build succeeded, served HTTP 200. The `vercel.com/new/clone` URL renders the expected import page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel as a new deployment provider option, enabling users to deploy directly to Vercel from the CLI
  * Vercel deployment includes automatic configuration for both static site and dynamic application projects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->