### PR TITLE
chore(blog): drop redundant date/author meta lines from postmortem

### DIFF
--- a/src/blog/npm-supply-chain-compromise-postmortem.md
+++ b/src/blog/npm-supply-chain-compromise-postmortem.md
@@ -6,8 +6,6 @@ authors:
   - Tanner Linsley
 ---
 
-**Date of incident:** 2026-05-11
-**Authors:** Tanner Linsley
 **Last updated:** 2026-05-11
 
 ## TL;DR


### PR DESCRIPTION
Frontmatter already carries the published date and author; the inline lines just duplicate them. Leaves the 'Last updated' line since it can drift independently.