### PR TITLE
ci: keep autofix token read-only

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Tools
-        uses: tanstack/config/.github/setup@8f433551298bae362c0e7a356f38c7d240c05d47 # main
+        uses: tanstack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Fix formatting
         run: pnpm format
       - name: Apply fixes

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   autofix:
@@ -21,8 +21,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          # autofix-ci commits formatting fixes back to this branch.
-          persist-credentials: true
+          persist-credentials: false
       - name: Setup Tools
         uses: tanstack/config/.github/setup@8f433551298bae362c0e7a356f38c7d240c05d47 # main
       - name: Fix formatting

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Tools
-        uses: tanstack/config/.github/setup@8f433551298bae362c0e7a356f38c7d240c05d47 # main
+        uses: tanstack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Run Build
         run: pnpm build
       - name: Run Tests

--- a/.github/workflows/update-tanstack-deps.yml
+++ b/.github/workflows/update-tanstack-deps.yml
@@ -14,16 +14,16 @@ jobs:
       contents: write
     steps:
       - name: Git Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # This scheduled job commits dependency updates back to the branch.
           persist-credentials: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
## Summary
- restore the autofix workflow to read-only `GITHUB_TOKEN` permissions
- disable checkout credential persistence for the autofix job

