### PR TITLE
feat(partners): add dedicated Railway Gold partner landing page

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -53,6 +53,7 @@ import { Route as ShowcaseSubmitRouteImport } from './routes/showcase/submit'
 import { Route as ShowcaseIdRouteImport } from './routes/showcase/$id'
 import { Route as ShopSearchRouteImport } from './routes/shop.search'
 import { Route as ShopCartRouteImport } from './routes/shop.cart'
+import { Route as PartnersRailwayRouteImport } from './routes/partners.railway'
 import { Route as PartnersPartnerRouteImport } from './routes/partners.$partner'
 import { Route as OauthTokenRouteImport } from './routes/oauth/token'
 import { Route as OauthRegisterRouteImport } from './routes/oauth/register'
@@ -372,6 +373,11 @@ const ShopCartRoute = ShopCartRouteImport.update({
   id: '/cart',
   path: '/cart',
   getParentRoute: () => ShopRoute,
+} as any)
+const PartnersRailwayRoute = PartnersRailwayRouteImport.update({
+  id: '/railway',
+  path: '/railway',
+  getParentRoute: () => PartnersRoute,
 } as any)
 const PartnersPartnerRoute = PartnersPartnerRouteImport.update({
   id: '/$partner',
@@ -949,6 +955,7 @@ export interface FileRoutesByFullPath {
   '/oauth/register': typeof OauthRegisterRoute
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
+  '/partners/railway': typeof PartnersRailwayRoute
   '/shop/cart': typeof ShopCartRoute
   '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
@@ -1086,6 +1093,7 @@ export interface FileRoutesByTo {
   '/oauth/register': typeof OauthRegisterRoute
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
+  '/partners/railway': typeof PartnersRailwayRoute
   '/shop/cart': typeof ShopCartRoute
   '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
@@ -1230,6 +1238,7 @@ export interface FileRoutesById {
   '/oauth/register': typeof OauthRegisterRoute
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
+  '/partners/railway': typeof PartnersRailwayRoute
   '/shop/cart': typeof ShopCartRoute
   '/shop/search': typeof ShopSearchRoute
   '/showcase/$id': typeof ShowcaseIdRoute
@@ -1377,6 +1386,7 @@ export interface FileRouteTypes {
     | '/oauth/register'
     | '/oauth/token'
     | '/partners/$partner'
+    | '/partners/railway'
     | '/shop/cart'
     | '/shop/search'
     | '/showcase/$id'
@@ -1514,6 +1524,7 @@ export interface FileRouteTypes {
     | '/oauth/register'
     | '/oauth/token'
     | '/partners/$partner'
+    | '/partners/railway'
     | '/shop/cart'
     | '/shop/search'
     | '/showcase/$id'
@@ -1657,6 +1668,7 @@ export interface FileRouteTypes {
     | '/oauth/register'
     | '/oauth/token'
     | '/partners/$partner'
+    | '/partners/railway'
     | '/shop/cart'
     | '/shop/search'
     | '/showcase/$id'
@@ -2149,6 +2161,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/shop/cart'
       preLoaderRoute: typeof ShopCartRouteImport
       parentRoute: typeof ShopRoute
+    }
+    '/partners/railway': {
+      id: '/partners/railway'
+      path: '/railway'
+      fullPath: '/partners/railway'
+      preLoaderRoute: typeof PartnersRailwayRouteImport
+      parentRoute: typeof PartnersRoute
     }
     '/partners/$partner': {
       id: '/partners/$partner'
@@ -3011,11 +3030,13 @@ const BuilderRouteWithChildren =
 
 interface PartnersRouteChildren {
   PartnersPartnerRoute: typeof PartnersPartnerRoute
+  PartnersRailwayRoute: typeof PartnersRailwayRoute
   PartnersIndexRoute: typeof PartnersIndexRoute
 }
 
 const PartnersRouteChildren: PartnersRouteChildren = {
   PartnersPartnerRoute: PartnersPartnerRoute,
+  PartnersRailwayRoute: PartnersRailwayRoute,
   PartnersIndexRoute: PartnersIndexRoute,
 }
 

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -102,7 +102,7 @@ const steps: Array<{ num: string; title: string; code: string }> = [
   {
     num: '01',
     title: 'Create your TanStack app',
-    code: 'npx create-tsrouter-app my-app',
+    code: 'npx @tanstack/cli@latest create',
   },
   { num: '02', title: 'Add the Railway preset', code: "preset: 'railway'" },
   { num: '03', title: 'Deploy', code: 'railway up' },

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -1,6 +1,19 @@
 import * as React from 'react'
 import { Link, createFileRoute } from '@tanstack/react-router'
-import { ArrowUpRight, Check, Plus } from 'lucide-react'
+import {
+  ArrowUpRight,
+  Check,
+  DollarSign,
+  GitPullRequest,
+  Globe,
+  Infinity as InfinityIcon,
+  LineChart,
+  Network,
+  Plus,
+  Rocket,
+  ShieldCheck,
+  Undo2,
+} from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 import { Footer } from '~/components/Footer'
 import { Card } from '~/components/Card'
@@ -22,6 +35,8 @@ const RAILWAY_DOCS_HREF =
   'https://docs.railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
 const RAILWAY_HOME_HREF =
   'https://railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+const RAILWAY_PRICING_HREF =
+  'https://railway.com/pricing?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
 
 const CONFIG_SNIPPET = `import { defineConfig } from '@tanstack/start/config'
 
@@ -38,46 +53,48 @@ railway login
 railway up
 `
 
-const features: Array<{ icon: string; title: string; desc: string }> = [
+type FeatureIcon = React.ComponentType<{ className?: string }>
+
+const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
   {
-    icon: '🚀',
+    Icon: Rocket,
     title: 'Auto-detected config',
-    desc: 'Railway reads your TanStack code and sets the right build and run settings automatically. No YAML required.',
+    desc: 'Railway reads your TanStack code and picks the right build and run settings. No YAML to maintain.',
   },
   {
-    icon: '🔍',
-    title: 'PR preview environments',
-    desc: 'Every pull request gets its own live preview environment automatically. No surprises after merging.',
+    Icon: GitPullRequest,
+    title: 'Live PR previews',
+    desc: 'Every pull request spins up its own environment. Test routing, data, and server logic before merging.',
   },
   {
-    icon: '📊',
-    title: 'Logs, metrics & alerts',
-    desc: 'Full observability from day one. Custom alerts via Slack, Discord, or email. No third-party tools needed.',
+    Icon: LineChart,
+    title: 'Logs, metrics, and alerts',
+    desc: 'Observability is built in. Pipe custom alerts to Slack, Discord, or email without a third-party agent.',
   },
   {
-    icon: '🔗',
+    Icon: Network,
     title: '100 Gbps private networking',
-    desc: 'Services connect over private IPs at 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled automatically.',
+    desc: 'Services in a project talk over private IPs at 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled for you.',
   },
   {
-    icon: '⚡',
+    Icon: Undo2,
     title: 'One-click rollbacks',
-    desc: 'Every deploy is versioned. Roll back to any previous deployment instantly when something breaks.',
+    desc: 'Every deploy is versioned. Roll back to a previous deployment instantly when something breaks.',
   },
   {
-    icon: '💰',
+    Icon: ShieldCheck,
     title: 'Hard spending limits',
-    desc: 'The only cloud provider that lets you set hard spend caps. No surprise bills — ever. Pay by the second.',
+    desc: 'Set a hard cap on what a project can spend. Billing is per-second, so you only pay for actual compute.',
   },
   {
-    icon: '🌍',
+    Icon: Globe,
     title: 'Global regions',
-    desc: 'Run your TanStack app closer to your users. Deploy to concurrent global regions on Pro and above.',
+    desc: 'Run your app close to your users. Pro and above can deploy to multiple regions concurrently.',
   },
   {
-    icon: '♾️',
+    Icon: InfinityIcon,
     title: 'Unlimited environments',
-    desc: 'Every developer on your team ships simultaneously. Unlimited environments, no conflicts.',
+    desc: 'Spin up as many staging, preview, or branch environments as your team needs. No per-env fees.',
   },
 ]
 
@@ -235,7 +252,7 @@ const faqs: Array<{ q: string; a: string }> = [
 
 const PAGE_TITLE = 'Deploy TanStack to Railway — Official Gold Partner'
 const PAGE_DESCRIPTION =
-  'Deploy TanStack Start, Router, Query, and DB apps to Railway in minutes. One-line Railway preset, PR preview environments, managed databases, 100 Gbps private networking, and hard spending limits. Railway is a TanStack Gold sponsor.'
+  'Railway gives TanStack teams a single place to run app services, databases, and supporting infrastructure. One-line Railway preset for TanStack Start, live PR previews, 100 Gbps private networking, and hard spending limits. Pay per second for the compute you actually use.'
 
 function getFaqJsonLd() {
   return {
@@ -374,15 +391,15 @@ function RailwayPartnerPage() {
           </h1>
 
           <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
-            Railway is the all-in-one intelligent cloud platform trusted by 2M+
-            developers. Deploy your TanStack Start, Router, and Query apps with
-            zero infrastructure complexity — and pay only for what you actually
-            use.
+            Railway gives TanStack teams a single place to run app services,
+            databases, and supporting infrastructure. Deploy a TanStack Start
+            app from GitHub or the CLI — and only pay per-second for the
+            compute you actually use.
           </p>
 
           <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
-            "Services that took 1 week to configure elsewhere take 1 day to spin
-            up in Railway." — Daniel Lobaton, CTO at G2X
+            "Services that took 1 week to configure elsewhere take 1 day to
+            spin up in Railway." — Daniel Lobaton, CTO at G2X
           </p>
 
           <div className="mt-7 flex flex-wrap gap-3">
@@ -395,13 +412,16 @@ function RailwayPartnerPage() {
               size="lg"
               className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
             >
-              Start deploying free
+              Deploy free in 2 minutes
               <ArrowUpRight className="h-4 w-4" />
             </Button>
             <Button as="a" href="#how-it-works" variant="ghost" size="lg">
               See how it works
             </Button>
           </div>
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            No credit card required. $5 in trial credits on signup.
+          </p>
         </section>
 
         {/* Stats */}
@@ -431,9 +451,9 @@ function RailwayPartnerPage() {
             faster. Here's what makes it the right fit for TanStack developers.
           </p>
           <div className="mt-6 grid gap-3 sm:grid-cols-2">
-            {features.map(({ icon, title, desc }) => (
+            {features.map(({ Icon, title, desc }) => (
               <Card key={title} className="p-5 shadow-none">
-                <div className="mb-2 text-xl">{icon}</div>
+                <Icon className="mb-3 h-5 w-5 text-gray-500 dark:text-gray-400" />
                 <div className="text-sm font-semibold">{title}</div>
                 <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
                   {desc}
@@ -486,6 +506,30 @@ function RailwayPartnerPage() {
               lang="bash"
               title="terminal"
             />
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={RAILWAY_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Try the Railway preset
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={RAILWAY_DOCS_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              variant="ghost"
+            >
+              Read the deployment guide
+            </Button>
           </div>
         </section>
 
@@ -587,13 +631,41 @@ function RailwayPartnerPage() {
               </div>
             ))}
           </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={RAILWAY_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Start with $5 in credits
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={RAILWAY_PRICING_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              variant="ghost"
+            >
+              Estimate your costs
+            </Button>
+          </div>
         </section>
 
         {/* Testimonials */}
         <section className="border-t border-gray-200 py-10 dark:border-gray-800">
           <h2 className="text-2xl font-black tracking-tight md:text-3xl">
-            Teams are saving big on infrastructure
+            What teams say after switching
           </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Real teams, real bills. These are quotes from founders and
+            engineers who moved their production workloads onto Railway.
+          </p>
           <div className="mt-6 grid gap-3 sm:grid-cols-3">
             {testimonials.map(({ quote, author, role }) => (
               <Card key={author} as="figure" className="p-5 shadow-none">
@@ -608,6 +680,24 @@ function RailwayPartnerPage() {
                 </figcaption>
               </Card>
             ))}
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={RAILWAY_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Move your app to Railway
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+              <DollarSign className="h-3.5 w-3.5" />
+              Per-second billing · no credit card required
+            </span>
           </div>
         </section>
 
@@ -678,7 +768,7 @@ function RailwayPartnerPage() {
               size="lg"
               className="bg-white text-gray-950 border-white hover:bg-gray-100"
             >
-              Start deploying free
+              Deploy your TanStack app
               <ArrowUpRight className="h-4 w-4" />
             </Button>
             <Button
@@ -690,7 +780,7 @@ function RailwayPartnerPage() {
               size="lg"
               className="bg-transparent text-white border-gray-700 hover:bg-white/5"
             >
-              Read the deployment guide
+              Open the docs
             </Button>
           </div>
         </section>

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -1,0 +1,728 @@
+import * as React from 'react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import { ArrowUpRight, Check, Plus } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { CodeBlock } from '~/components/markdown/CodeBlock'
+import { seo } from '~/utils/seo'
+import { getPartnerById, PartnerImage } from '~/utils/partners'
+import { getPartnerJsonLd } from '~/utils/partner-pages'
+import { trackEvent } from '~/utils/analytics'
+
+const RAILWAY_HREF =
+  'https://railway.com/new?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+const RAILWAY_DOCS_HREF =
+  'https://docs.railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+const RAILWAY_HOME_HREF =
+  'https://railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+
+const CONFIG_SNIPPET = `import { defineConfig } from '@tanstack/start/config'
+
+export default defineConfig({
+  server: {
+    preset: 'railway', // one line
+  },
+})
+`
+
+const DEPLOY_SNIPPET = `# Deploy in 3 commands
+git init && git add . && git commit -m "init"
+railway login
+railway up
+`
+
+const features: Array<{ icon: string; title: string; desc: string }> = [
+  {
+    icon: '🚀',
+    title: 'Auto-detected config',
+    desc: 'Railway reads your TanStack code and sets the right build and run settings automatically. No YAML required.',
+  },
+  {
+    icon: '🔍',
+    title: 'PR preview environments',
+    desc: 'Every pull request gets its own live preview environment automatically. No surprises after merging.',
+  },
+  {
+    icon: '📊',
+    title: 'Logs, metrics & alerts',
+    desc: 'Full observability from day one. Custom alerts via Slack, Discord, or email. No third-party tools needed.',
+  },
+  {
+    icon: '🔗',
+    title: '100 Gbps private networking',
+    desc: 'Services connect over private IPs at 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled automatically.',
+  },
+  {
+    icon: '⚡',
+    title: 'One-click rollbacks',
+    desc: 'Every deploy is versioned. Roll back to any previous deployment instantly when something breaks.',
+  },
+  {
+    icon: '💰',
+    title: 'Hard spending limits',
+    desc: 'The only cloud provider that lets you set hard spend caps. No surprise bills — ever. Pay by the second.',
+  },
+  {
+    icon: '🌍',
+    title: 'Global regions',
+    desc: 'Run your TanStack app closer to your users. Deploy to concurrent global regions on Pro and above.',
+  },
+  {
+    icon: '♾️',
+    title: 'Unlimited environments',
+    desc: 'Every developer on your team ships simultaneously. Unlimited environments, no conflicts.',
+  },
+]
+
+const steps: Array<{ num: string; title: string; code: string }> = [
+  {
+    num: '01',
+    title: 'Create your TanStack app',
+    code: 'npx create-tsrouter-app my-app',
+  },
+  { num: '02', title: 'Add the Railway preset', code: "preset: 'railway'" },
+  { num: '03', title: 'Deploy', code: 'railway up' },
+]
+
+const pricing: Array<{
+  plan: string
+  price: string
+  note: string
+  features: Array<string>
+  highlight?: boolean
+}> = [
+  {
+    plan: 'Free',
+    price: '$0',
+    note: '30-day trial with $5 credits',
+    features: [
+      'Up to 1 vCPU / 0.5 GB RAM',
+      '0.5 GB volume storage',
+      'Community support',
+      'No credit card required',
+    ],
+  },
+  {
+    plan: 'Hobby',
+    price: '$5',
+    note: 'min/month · includes $5 credits',
+    features: [
+      'Up to 48 vCPU / 48 GB RAM',
+      'Up to 5 GB storage',
+      '7-day log history',
+      'Global regions',
+    ],
+  },
+  {
+    plan: 'Pro',
+    price: '$20',
+    note: 'min/month · includes $20 credits',
+    features: [
+      'Up to 1,000 vCPU / 1 TB RAM',
+      'Up to 1 TB storage',
+      '30-day log history',
+      'Unlimited workspace seats',
+      'Concurrent global regions',
+    ],
+    highlight: true,
+  },
+  {
+    plan: 'Enterprise',
+    price: 'Custom',
+    note: 'for teams at scale',
+    features: [
+      'Up to 2,400 vCPU / 2.4 TB RAM',
+      '90-day log history',
+      'SSO + RBAC + HIPAA BAA',
+      'Dedicated VMs',
+      'Bring your own cloud',
+    ],
+  },
+]
+
+const meteredPricing: Array<[string, string]> = [
+  ['Memory', '$0.000004 / GB·sec'],
+  ['CPU', '$0.000008 / vCPU·sec'],
+  ['Egress', '$0.05 / GB'],
+]
+
+const testimonials: Array<{ quote: string; author: string; role: string }> = [
+  {
+    quote: 'We cut our hosting costs by 75% migrating from Heroku to Railway.',
+    author: 'Dillon Chen',
+    role: 'Founder at Common',
+  },
+  {
+    quote:
+      "I've moved $4.5k/month from AWS and $1k/month from Heroku. My Railway bill is about $300/month.",
+    author: 'John Nunemaker',
+    role: 'Founder at BoxOutSports',
+  },
+  {
+    quote: 'We went from a $1,600 Heroku bill to a $300 Railway bill.',
+    author: 'Brandon Gell',
+    role: 'Head of Consulting at Every',
+  },
+]
+
+const libraries = [
+  'Start',
+  'Router',
+  'Query',
+  'Table',
+  'Form',
+  'DB',
+  'AI',
+  'Virtual',
+  'Pacer',
+  'Store',
+  'Devtools',
+  'CLI',
+]
+
+const libDetails: Array<{ label: string; desc: string }> = [
+  {
+    label: 'TanStack Start',
+    desc: 'Full SSR and streaming support with the Railway preset. Auto-configured Node runtime, zero extra config.',
+  },
+  {
+    label: 'TanStack Router',
+    desc: 'File-based routing apps deploy in SSR and SPA modes. PR previews mean every route change gets a live test environment.',
+  },
+  {
+    label: 'TanStack Query',
+    desc: "Pair with Railway-managed Postgres or Redis. Private networking keeps your server queries inside Railway's infrastructure.",
+  },
+  {
+    label: 'TanStack DB',
+    desc: "Railway's managed databases integrate with TanStack DB's sync engine via 100 Gbps private networking.",
+  },
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'Does Railway support TanStack Start SSR and streaming?',
+    a: "Yes — Railway supports server-side rendering and React streaming out of the box. TanStack Start's SSR and streaming modes work without any special configuration when using the Railway preset.",
+  },
+  {
+    q: 'Can I run a database alongside my TanStack app?',
+    a: "Absolutely. Railway lets you provision Postgres, MySQL, Redis, or MongoDB in the same project as your app. They communicate over Railway's 100 Gbps private network — no VPC setup needed.",
+  },
+  {
+    q: 'How does Railway pricing actually work?',
+    a: 'Railway charges by the second based on actual CPU and memory usage — not provisioned box sizes. The Hobby plan starts at $5/month (which includes $5 of credits). Most hobby TanStack projects run for free or under $5/month.',
+  },
+  {
+    q: 'What makes Railway different from Vercel or Render?',
+    a: 'Railway is a full-stack cloud — not just a frontend host. You can run your TanStack app server, managed databases, background workers, cron jobs, and private networking all in one project. Railway also has hard spending limits, which no other major cloud provider offers.',
+  },
+  {
+    q: 'Does Railway have PR preview environments?',
+    a: 'Yes — every pull request automatically gets its own live preview environment. For TanStack teams, this means you can test routing changes, data fetching behavior, and server logic before merging.',
+  },
+  {
+    q: 'Can I migrate an existing TanStack app to Railway?',
+    a: 'Yes — if your app runs in Node or Docker, Railway deploys it directly from GitHub with no changes required. Railway V3 is faster and cheaper than previous versions, so now is a great time to switch.',
+  },
+]
+
+const PAGE_TITLE = 'Deploy TanStack to Railway — Official Gold Partner'
+const PAGE_DESCRIPTION =
+  'Deploy TanStack Start, Router, Query, and DB apps to Railway in minutes. One-line Railway preset, PR preview environments, managed databases, 100 Gbps private networking, and hard spending limits. Railway is a TanStack Gold sponsor.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.a,
+      },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/railway')({
+  head: () => {
+    const partner = getPartnerById('railway')
+
+    return {
+      meta: seo({
+        title: PAGE_TITLE,
+        description: PAGE_DESCRIPTION,
+        keywords:
+          'deploy tanstack to railway, tanstack start railway, tanstack router railway, railway hosting, tanstack deployment, railway gold sponsor',
+        image: 'https://tanstack.com/og.png',
+      }),
+      scripts: [
+        ...(partner
+          ? [
+              {
+                type: 'application/ld+json',
+                children: JSON.stringify(getPartnerJsonLd(partner)),
+              },
+            ]
+          : []),
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify(getFaqJsonLd()),
+        },
+      ],
+    }
+  },
+  component: RailwayPartnerPage,
+})
+
+function CheckBadge() {
+  return (
+    <span className="mt-0.5 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+      <Check className="h-2.5 w-2.5" strokeWidth={3} />
+    </span>
+  )
+}
+
+function trackRailwayClick() {
+  trackEvent('partner_clicked', {
+    partner_id: 'railway',
+    placement: 'detail',
+    destination: 'external',
+    destination_host: 'railway.com',
+  })
+}
+
+function RailwayCodeExample({
+  code,
+  lang,
+  title,
+}: {
+  code: string
+  lang: string
+  title: string
+}) {
+  return (
+    <CodeBlock dataCodeTitle={title}>
+      <code className={`language-${lang}`}>{code}</code>
+    </CodeBlock>
+  )
+}
+
+function RailwayPartnerPage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'railway',
+      placement: 'detail',
+    })
+  }, [])
+
+  const partner = getPartnerById('railway')
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <nav className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <Link
+            to="/partners"
+            className="transition-colors hover:text-blue-500"
+          >
+            Partners
+          </Link>
+          <span>/</span>
+          <span className="text-gray-900 dark:text-white">Railway</span>
+        </nav>
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-10 dark:border-gray-800">
+          <div className="mb-5 flex items-center gap-4">
+            {partner ? (
+              <div className="flex h-12 w-44 items-center justify-start">
+                <PartnerImage
+                  config={partner.image}
+                  alt="Railway"
+                  className="max-h-10 w-auto"
+                />
+              </div>
+            ) : null}
+            <div>
+              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
+                Gold Sponsor · Deployment & Hosting
+              </span>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  Railway V3 — faster and cheaper
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <h1 className="text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            Ship TanStack apps
+            <br />
+            peacefully with Railway
+          </h1>
+
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            Railway is the all-in-one intelligent cloud platform trusted by 2M+
+            developers. Deploy your TanStack Start, Router, and Query apps with
+            zero infrastructure complexity — and pay only for what you actually
+            use.
+          </p>
+
+          <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
+            "Services that took 1 week to configure elsewhere take 1 day to
+            spin up in Railway." — Daniel Lobaton, CTO at G2X
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button
+              as="a"
+              href={RAILWAY_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              size="lg"
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Start deploying free
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href="#how-it-works"
+              variant="ghost"
+              size="lg"
+            >
+              See how it works
+            </Button>
+          </div>
+        </section>
+
+        {/* Stats */}
+        <section className="grid grid-cols-2 gap-x-8 gap-y-5 border-b border-gray-200 py-7 sm:flex sm:flex-wrap sm:gap-10 dark:border-gray-800">
+          {[
+            ['2M+', 'Developers on Railway'],
+            ['< 2 min', 'Time to first deploy'],
+            ['100 Gbps', 'Private networking'],
+            ['$0', 'To get started'],
+          ].map(([value, label]) => (
+            <div key={label}>
+              <div className="text-2xl font-bold tracking-tight">{value}</div>
+              <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                {label}
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {/* Features */}
+        <section className="py-10">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Why TanStack teams choose Railway
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Railway eliminates infrastructure complexity so your team ships
+            faster. Here's what makes it the right fit for TanStack developers.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {features.map(({ icon, title, desc }) => (
+              <Card key={title} className="p-5 shadow-none">
+                <div className="mb-2 text-xl">{icon}</div>
+                <div className="text-sm font-semibold">{title}</div>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section
+          id="how-it-works"
+          className="border-t border-gray-200 py-10 dark:border-gray-800"
+        >
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            From zero to deployed in 3 steps
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Railway has first-class support for TanStack Start. One config line
+            is all it takes.
+          </p>
+
+          <div className="mt-6 flex flex-col gap-3">
+            {steps.map(({ num, title, code }) => (
+              <Card
+                key={num}
+                className="flex items-start gap-5 p-4 shadow-none md:p-5"
+              >
+                <div className="min-w-[28px] pt-0.5 font-mono text-xs font-bold text-gray-400 dark:text-gray-500">
+                  {num}
+                </div>
+                <div>
+                  <div className="text-sm font-semibold">{title}</div>
+                  <code className="mt-2 inline-block rounded-md bg-gray-100 px-2.5 py-1 font-mono text-xs dark:bg-gray-800">
+                    {code}
+                  </code>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <RailwayCodeExample
+              code={CONFIG_SNIPPET}
+              lang="ts"
+              title="tanstack.config.ts"
+            />
+            <RailwayCodeExample
+              code={DEPLOY_SNIPPET}
+              lang="bash"
+              title="terminal"
+            />
+          </div>
+        </section>
+
+        {/* Library fit */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Works with every TanStack library
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            From full-stack apps with TanStack Start to lightweight React apps
+            using Router and Query — Railway deploys them all.
+          </p>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            {libraries.map((lib) => (
+              <span
+                key={lib}
+                className="rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium dark:border-gray-800 dark:bg-gray-900"
+              >
+                {lib}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {libDetails.map(({ label, desc }) => (
+              <Card key={label} className="p-4 shadow-none">
+                <div className="flex items-start gap-2">
+                  <CheckBadge />
+                  <span className="text-sm font-semibold">{label}</span>
+                </div>
+                <p className="mt-2 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* Pricing */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Pricing that scales with you
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Railway charges by the second based on actual usage — not
+            provisioned box sizes. Most TanStack hobby projects run free or
+            under $5/month.
+          </p>
+
+          <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {pricing.map(({ plan, price, note, features: pf, highlight }) => (
+              <Card
+                key={plan}
+                className={twMerge(
+                  'relative p-5 shadow-none',
+                  highlight &&
+                    'border-2 border-blue-500 dark:border-blue-400',
+                )}
+              >
+                {highlight ? (
+                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-semibold text-blue-700 dark:bg-blue-950/60 dark:text-blue-300">
+                    Most popular
+                  </span>
+                ) : null}
+                <div className="text-sm font-bold">{plan}</div>
+                <div className="mt-1 text-2xl font-bold tracking-tight">
+                  {price}
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                  {note}
+                </div>
+                <ul className="mt-4 flex flex-col gap-2">
+                  {pf.map((feat) => (
+                    <li
+                      key={feat}
+                      className="flex items-start gap-2 text-xs text-gray-600 dark:text-gray-400"
+                    >
+                      <CheckBadge />
+                      <span>{feat}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {meteredPricing.map(([key, value]) => (
+              <div
+                key={key}
+                className="rounded-lg bg-gray-50 px-4 py-3 dark:bg-gray-900"
+              >
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {key}
+                </div>
+                <div className="mt-1 font-mono text-sm font-semibold">
+                  {value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Testimonials */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Teams are saving big on infrastructure
+          </h2>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            {testimonials.map(({ quote, author, role }) => (
+              <Card key={author} as="figure" className="p-5 shadow-none">
+                <blockquote className="text-sm leading-relaxed">
+                  "{quote}"
+                </blockquote>
+                <figcaption className="mt-3">
+                  <div className="text-xs font-semibold">{author}</div>
+                  <div className="text-[11px] text-gray-500 dark:text-gray-400">
+                    {role}
+                  </div>
+                </figcaption>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Frequently asked questions
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Common questions from TanStack developers evaluating Railway.
+          </p>
+
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 flex-shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mt-6 rounded-2xl bg-gray-950 px-6 py-10 text-center md:px-10 md:py-12 dark:bg-gray-900">
+          <div className="inline-block rounded-full bg-white/5 px-3 py-1 text-[11px] text-gray-400">
+            Railway V3 — now faster and cheaper
+          </div>
+          <h2 className="mt-4 text-2xl font-black tracking-tight text-white md:text-3xl">
+            Ready to ship TanStack peacefully?
+          </h2>
+          <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-gray-400">
+            No credit card required. No surprise bills. Pay only for what you
+            use.
+          </p>
+          <p className="mt-1 text-xs text-gray-500">
+            Most customers save ~40% by switching to Railway.
+          </p>
+
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Button
+              as="a"
+              href={RAILWAY_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              size="lg"
+              className="bg-white text-gray-950 border-white hover:bg-gray-100"
+            >
+              Start deploying free
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={RAILWAY_DOCS_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={trackRailwayClick}
+              size="lg"
+              className="bg-transparent text-white border-gray-700 hover:bg-white/5"
+            >
+              Read the deployment guide
+            </Button>
+          </div>
+        </section>
+
+        <p className="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
+          Railway is a Gold-tier TanStack sponsor.{' '}
+          <Link
+            to="/partners"
+            className="underline decoration-dotted underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            Browse all TanStack partners
+          </Link>
+          .{' '}
+          <a
+            href={RAILWAY_HOME_HREF}
+            target="_blank"
+            rel="noreferrer"
+            onClick={trackRailwayClick}
+            className="underline decoration-dotted underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            railway.com
+          </a>
+        </p>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -381,8 +381,8 @@ function RailwayPartnerPage() {
           </p>
 
           <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
-            "Services that took 1 week to configure elsewhere take 1 day to
-            spin up in Railway." — Daniel Lobaton, CTO at G2X
+            "Services that took 1 week to configure elsewhere take 1 day to spin
+            up in Railway." — Daniel Lobaton, CTO at G2X
           </p>
 
           <div className="mt-7 flex flex-wrap gap-3">
@@ -398,12 +398,7 @@ function RailwayPartnerPage() {
               Start deploying free
               <ArrowUpRight className="h-4 w-4" />
             </Button>
-            <Button
-              as="a"
-              href="#how-it-works"
-              variant="ghost"
-              size="lg"
-            >
+            <Button as="a" href="#how-it-works" variant="ghost" size="lg">
               See how it works
             </Button>
           </div>
@@ -547,8 +542,7 @@ function RailwayPartnerPage() {
                 key={plan}
                 className={twMerge(
                   'relative p-5 shadow-none',
-                  highlight &&
-                    'border-2 border-blue-500 dark:border-blue-400',
+                  highlight && 'border-2 border-blue-500 dark:border-blue-400',
                 )}
               >
                 {highlight ? (

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -393,13 +393,13 @@ function RailwayPartnerPage() {
           <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
             Railway gives TanStack teams a single place to run app services,
             databases, and supporting infrastructure. Deploy a TanStack Start
-            app from GitHub or the CLI — and only pay per-second for the
-            compute you actually use.
+            app from GitHub or the CLI — and only pay per-second for the compute
+            you actually use.
           </p>
 
           <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
-            "Services that took 1 week to configure elsewhere take 1 day to
-            spin up in Railway." — Daniel Lobaton, CTO at G2X
+            "Services that took 1 week to configure elsewhere take 1 day to spin
+            up in Railway." — Daniel Lobaton, CTO at G2X
           </p>
 
           <div className="mt-7 flex flex-wrap gap-3">
@@ -663,8 +663,8 @@ function RailwayPartnerPage() {
             What teams say after switching
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
-            Real teams, real bills. These are quotes from founders and
-            engineers who moved their production workloads onto Railway.
+            Real teams, real bills. These are quotes from founders and engineers
+            who moved their production workloads onto Railway.
           </p>
           <div className="mt-6 grid gap-3 sm:grid-cols-3">
             {testimonials.map(({ quote, author, role }) => (


### PR DESCRIPTION
## Summary

Replaces the generic `/partners/$partner` template for Railway with a purpose-built landing page at `/partners/railway`, fulfilling the Gold-tier sponsorship agreement. The static file-routed `/partners/railway` takes precedence over `/partners/$partner`, so the legacy template stays untouched for every other partner.

## What's on the page

- **Hero** — Railway brand wordmark (light/dark via existing `PartnerImage`), Gold Sponsor metadata, headline, intro copy, customer quote, two CTAs
- **Stats** row — 2M+ devs, < 2 min deploy, 100 Gbps networking, $0 to start
- **8 feature cards** — auto-detect config, PR previews, observability, private networking, rollbacks, hard spend limits, regions, unlimited envs
- **3-step deploy** flow + two real **Shiki-highlighted code blocks** (`tanstack.config.ts` and terminal)
- **Library fit** — chips for every TanStack lib + deeper notes for Start / Router / Query / DB
- **4-tier pricing** — Free / Hobby / Pro (highlighted) / Enterprise + per-second metered-pricing reference card
- **3 customer testimonials** — Common, BoxOutSports, Every (public quotes with real savings figures)
- **6-question FAQ** on the existing `Collapsible` component
- **Dark CTA section** + Gold-sponsor credit footer

## Built from existing tanstack.com primitives

To stay visually and behaviorally consistent with the rest of the site, the page uses:

- `CodeBlock` (Shiki) for code snippets — fixes a hand-rolled `<pre>` that was being clobbered by the global `pre { @apply text-black }` rule in `app.css` and rendering invisible on dark backgrounds
- `Card` for every panel (feature, step, library, pricing, testimonial)
- `Button` (`as="a"`) for every CTA, with brand-tinted className overrides
- `Collapsible` / `CollapsibleTrigger` / `CollapsibleContent` for the FAQ
- `seo()` for meta tags (title, description, OG, Twitter Card)
- `PartnerImage` + existing `railway-{black,white}.svg` assets for the hero wordmark

## SEO

- Page-specific title + description targeting "deploy tanstack to railway" and related queries
- Two `application/ld+json` blocks emitted in SSR'd HTML:
  - The standard `WebPage` schema from `getPartnerJsonLd()`
  - A new `FAQPage` schema generated from the on-page FAQ — for Google rich results and AI search agents (ChatGPT / Claude / Perplexity)

## Analytics

- `partner_viewed` fires on mount with `placement: 'detail'`
- `partner_clicked` fires on every outbound Railway CTA with `destination_host: 'railway.com'`, matching the existing taxonomy in `src/utils/analytics/events.ts`

## UTM tracking

All four outbound Railway links carry `utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page`.

## Test plan

- [ ] Visit `/partners/railway` in dev — hero, stats, features, code blocks, pricing tiers, FAQ, and dark CTA all render
- [ ] Toggle theme — brand wordmark swaps black ↔ white, Shiki picks up `.aurora-x` in dark mode
- [ ] Click each FAQ question — only one open at a time, smooth grid-rows transition, Plus icon rotates to ×
- [ ] Click each outbound CTA — opens `railway.com` with the partner-page UTM intact
- [ ] View page source on the deployed preview — both `<script type="application/ld+json">` blocks present
- [ ] Confirm `partner_viewed` + `partner_clicked` events show up in GA4 DebugView with `partner_id=railway`, `placement=detail`
- [ ] Visit `/partners/netlify` to confirm the generic `/partners/\$partner` template still works for every other partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Railway partner landing page at /partners/railway with hero, stats, feature grid, setup steps, library fit, pricing (including metered tiers), testimonials, FAQ with collapsibles, CTAs, and partner footer link.
  * Page includes enhanced SEO and JSON‑LD metadata and client-side analytics tracking for page views and CTA clicks.
  * Embedded code samples for developer-focused guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->