### PR TITLE
fix(ui): forward refs in Button so Radix asChild slots work

### DIFF
--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -30,10 +30,7 @@ type ButtonOwnProps<TElement extends React.ElementType = 'button'> = {
 
 type ButtonProps<TElement extends React.ElementType = 'button'> =
   ButtonOwnProps<TElement> &
-    Omit<
-      React.ComponentPropsWithoutRef<TElement>,
-      keyof ButtonOwnProps<TElement>
-    >
+    Omit<React.ComponentPropsWithRef<TElement>, keyof ButtonOwnProps<TElement>>
 
 type ButtonComponent = <TElement extends React.ElementType = 'button'>(
   props: ButtonProps<TElement>,
@@ -102,16 +99,22 @@ function getDefaultRounded(size: ButtonSize): ButtonRounded {
   return 'lg'
 }
 
-export const Button: ButtonComponent = ({
-  as,
-  children,
-  variant = 'primary',
-  color = 'blue',
-  size,
-  rounded,
-  className,
-  ...props
-}) => {
+type ButtonInnerProps = ButtonOwnProps & Record<string, unknown>
+
+export const Button: ButtonComponent = React.forwardRef<
+  HTMLElement,
+  ButtonInnerProps
+>(function Button(props, ref) {
+  const {
+    as,
+    children,
+    variant = 'primary',
+    color = 'blue',
+    size,
+    rounded,
+    className,
+    ...rest
+  } = props as ButtonOwnProps & Record<string, unknown>
   const Component = as || 'button'
   const resolvedSize = size ?? getDefaultSize(variant)
   const resolvedRounded = rounded ?? getDefaultRounded(resolvedSize)
@@ -126,6 +129,7 @@ export const Button: ButtonComponent = ({
   return React.createElement(
     Component,
     {
+      ref,
       className: twMerge(
         baseStyles,
         variantStyles[variant],
@@ -134,8 +138,8 @@ export const Button: ButtonComponent = ({
         colorStyles,
         className,
       ),
-      ...props,
+      ...rest,
     },
     children,
   )
-}
+}) as unknown as ButtonComponent


### PR DESCRIPTION
## Summary

- Wrap `Button` in `React.forwardRef` so refs reach the underlying DOM element when Radix `Slot` composes them onto the child.
- Switch `ButtonProps` to `ComponentPropsWithRef` so consumers' `ref={}` type-checks.

## Why

The Copy Page Dropdown on docs/blog pages had stopped appearing. DOM was being rendered, but the Radix popper wrapper was stuck at `transform: translate(0px, -200%)` — the off-screen fallback Radix uses while `isPositioned` is `false`.

Root cause: `CopyPageDropdown` is the only `<DropdownTrigger>` consumer that nests our custom `Button` (every other consumer passes a native DOM element). With a plain function component, `{...props}` spread into `React.createElement` didn't carry the ref Radix `Slot` composed via `cloneElement` onto the trigger. `PopperAnchor`'s local ref stayed null, `onAnchorChange(null)` was the only call, Floating UI's `computePosition` never ran (no reference element), and `isPositioned` stayed false forever.

Verified: dropdown now opens with real coordinates (`translate(635px, 490px)` in a 1440x900 viewport), right-aligned to the trigger and just below it.

## Test plan

- [x] `pnpm test:tsc` — clean
- [x] `pnpm test:lint` — 0 errors (10 pre-existing warnings unrelated)
- [x] Manual: opened `/blog/announcing-tanstack-query-v5`, clicked the chevron next to "Copy page" — menu renders with all 5 items in the expected position
- [ ] Sanity-check other Radix dropdowns (search modal, breadcrumb TOC, brand context menu, auth user menu) — they all use native DOM elements as triggers so should be unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Button component's ref handling capabilities and type definitions for improved component integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->