### PR TITLE
feat(docs-cache): purge Netlify CDN tags on invalidation

### DIFF
--- a/src/routes/$libraryId/$version.docs.$.tsx
+++ b/src/routes/$libraryId/$version.docs.$.tsx
@@ -96,6 +96,14 @@ export const Route = createFileRoute('/$libraryId/$version/docs/$')({
     const { version, libraryId } = params
     const library = findLibrary(libraryId)
 
+    const cacheTag = library
+      ? [
+          'docs:all',
+          `docs:${library.id}`,
+          `docs:${library.id}:branch:${getBranch(library, version)}`,
+        ].join(', ')
+      : 'docs:all'
+
     const isLatestVersion =
       library &&
       (version === 'latest' ||
@@ -107,6 +115,7 @@ export const Route = createFileRoute('/$libraryId/$version/docs/$')({
         'cache-control': 'public, max-age=60, must-revalidate',
         'cdn-cache-control':
           'max-age=600, stale-while-revalidate=3600, durable',
+        'netlify-cache-tag': cacheTag,
         vary: docsContentNegotiationVaryHeader,
       }
     } else {
@@ -114,6 +123,7 @@ export const Route = createFileRoute('/$libraryId/$version/docs/$')({
         'cache-control': 'public, max-age=3600, must-revalidate',
         'cdn-cache-control':
           'max-age=86400, stale-while-revalidate=604800, durable',
+        'netlify-cache-tag': cacheTag,
         vary: docsContentNegotiationVaryHeader,
       }
     }

--- a/src/routes/api/github/webhook.ts
+++ b/src/routes/api/github/webhook.ts
@@ -53,11 +53,17 @@ export const Route = createFileRoute("/api/github/webhook")({
   server: {
     handlers: {
       POST: async ({ request }: { request: Request }) => {
-        const [{ markDocsArtifactsStale, markGitHubContentStale }, { env }] =
-          await Promise.all([
-            import("~/utils/github-content-cache.server"),
-            import("~/utils/env"),
-          ]);
+        const [
+          { markDocsArtifactsStale, markGitHubContentStale },
+          { env },
+          { libraries },
+          { purgeNetlifyTags },
+        ] = await Promise.all([
+          import("~/utils/github-content-cache.server"),
+          import("~/utils/env"),
+          import("~/libraries"),
+          import("~/utils/netlify-purge.server"),
+        ]);
         const rawBody = await request.text();
         const event = request.headers.get("x-github-event");
         const signature = request.headers.get("x-hub-signature-256");
@@ -132,12 +138,25 @@ export const Route = createFileRoute("/api/github/webhook")({
           markDocsArtifactsStale({ repo, gitRef }),
         ]);
 
+        const tags = [
+          `docs-config:${repo}:${gitRef}`,
+          ...libraries
+            .filter(
+              (library) =>
+                library.repo === repo && library.latestBranch === gitRef,
+            )
+            .map((library) => `docs:${library.id}:branch:${gitRef}`),
+        ];
+
+        const purge = await purgeNetlifyTags(tags);
+
         return Response.json({
           ok: true,
           gitRef,
           changedPathCount: changedPaths.length,
           staleArtifactCount,
           staleContentCount,
+          purge,
         });
       },
     },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -106,6 +106,11 @@ export const getTanstackDocsConfig = createServerFn({ method: 'GET' })
             'Cache-Control': 'public, max-age=0, must-revalidate',
             'Netlify-CDN-Cache-Control':
               'public, max-age=300, durable, stale-while-revalidate=300',
+            'Netlify-Cache-Tag': [
+              'docs-config:all',
+              `docs-config:${repo}`,
+              `docs-config:${repo}:${branch}`,
+            ].join(', '),
           }),
         )
 

--- a/src/utils/docs-admin.server.ts
+++ b/src/utils/docs-admin.server.ts
@@ -1,12 +1,14 @@
 import { sql } from 'drizzle-orm'
 import { db } from '~/db/client'
 import { docsArtifactCache, githubContentCache } from '~/db/schema'
+import { libraries } from '~/libraries'
 import { docsWebhookSources } from '~/utils/docs-webhook-sources'
 import { requireCapability } from './auth.server'
 import {
   markDocsArtifactsStale,
   markGitHubContentStale,
 } from './github-content-cache.server'
+import { purgeNetlifyTags } from './netlify-purge.server'
 
 function normalizeDateValue(value: Date | number | string | null | undefined) {
   if (!value) {
@@ -170,10 +172,22 @@ export async function invalidateDocsCacheAdmin(opts: {
     markDocsArtifactsStale({ repo: opts.data.repo }),
   ])
 
+  const tags = opts.data.repo
+    ? [
+        `docs-config:${opts.data.repo}`,
+        ...libraries
+          .filter((library) => library.repo === opts.data.repo)
+          .map((library) => `docs:${library.id}`),
+      ]
+    : ['docs:all', 'docs-config:all']
+
+  const purge = await purgeNetlifyTags(tags)
+
   return {
     repo: opts.data.repo ?? null,
     staleContentCount,
     staleArtifactCount,
     totalInvalidated: staleContentCount + staleArtifactCount,
+    purge,
   }
 }

--- a/src/utils/netlify-purge.server.ts
+++ b/src/utils/netlify-purge.server.ts
@@ -1,0 +1,42 @@
+import { purgeCache } from '@netlify/functions'
+import * as Sentry from '@sentry/node'
+
+export type PurgeResult =
+  | { purged: true; tags: Array<string> }
+  | {
+      purged: false
+      reason: 'no-tags' | 'no-credentials' | 'error'
+      error?: string
+    }
+
+export async function purgeNetlifyTags(
+  tags: Array<string>,
+): Promise<PurgeResult> {
+  const uniqueTags = Array.from(new Set(tags)).filter((tag) => tag.length > 0)
+
+  if (uniqueTags.length === 0) {
+    return { purged: false, reason: 'no-tags' }
+  }
+
+  // SITE_ID + NETLIFY_PURGE_API_TOKEN are auto-injected when running on
+  // Netlify. Absent locally — no-op so dev workflows still work.
+  if (!process.env.SITE_ID || !process.env.NETLIFY_PURGE_API_TOKEN) {
+    return { purged: false, reason: 'no-credentials' }
+  }
+
+  try {
+    await purgeCache({ tags: uniqueTags })
+    return { purged: true, tags: uniqueTags }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('[netlify-purge] purgeCache failed', {
+      tags: uniqueTags,
+      message,
+    })
+    Sentry.captureException(error, {
+      tags: { runtime: 'server', context: 'netlify-purge' },
+      extra: { tags: uniqueTags },
+    })
+    return { purged: false, reason: 'error', error: message }
+  }
+}


### PR DESCRIPTION
## Summary

- Attach `Netlify-Cache-Tag` headers to the docs route (`/$libraryId/$version/docs/$`) and the `getTanstackDocsConfig` server function so the CDN can be purged surgically.
- Issue `purgeCache({ tags })` from `invalidateDocsCacheAdmin` and the GitHub push webhook after the existing DB-mark calls.

## Why

The DB SWR-on-forced-stale fix only refreshes the cached GitHub content rows. The Netlify CDN still sits in front of the SSR with its own SWR windows (`max-age=600, stale-while-revalidate=3600` for latest, `86400/604800` for older versions, plus `max-age=300, stale-while-revalidate=300` on the docs config). So even after marking rows stale, an operator clicking "invalidate" — or a real push — still had to wait up to ~10 minutes for the CDN to revalidate the rendered pages. This change closes that window.

## Tag scheme

Three tiers so we can purge at any granularity:

**Docs route** — `docs:all, docs:{libraryId}, docs:{libraryId}:branch:{resolvedBranch}`
**Docs config server fn** — `docs-config:all, docs-config:{repo}, docs-config:{repo}:{branch}`

The library-level tag keys off the **resolved branch** (via `getBranch`), not the URL `version`, so a single push invalidates the `latest` / `v5` / `main` URL variants together.

## Purge behavior

- **Webhook** (`(repo, gitRef)`) → `docs-config:{repo}:{gitRef}` + `docs:{libId}:branch:{gitRef}` for each matched library.
- **Admin** with `repo` → `docs-config:{repo}` + `docs:{libId}` for each matched library.
- **Admin** without `repo` → `docs:all` + `docs-config:all`.

## Failure handling

`purgeNetlifyTags` in `src/utils/netlify-purge.server.ts` never throws:
- No-ops when `SITE_ID` or `NETLIFY_PURGE_API_TOKEN` is absent (local dev).
- Logs + sends to Sentry on error. Caller continues — DB rows are already stale and the existing SWR window will eventually catch up.
- Result is returned in the response payload (`{ purge: { purged, ... } }`) so the admin UI can surface it.

## Operational note

`NETLIFY_PURGE_API_TOKEN` and `SITE_ID` are typically auto-injected by Netlify into Functions at runtime — usually nothing to configure. If a manual purge from the admin button returns `{ purge: { purged: false, reason: 'no-credentials' } }`, generate a personal access token with `Site:Purge` scope and set it as `NETLIFY_PURGE_API_TOKEN` in the site env.

## Test plan

- [x] `pnpm test:tsc` passes
- [x] `pnpm test:lint` passes (0 errors)
- [x] `pnpm test:smoke` passes (all docs/blog routes render)
- [ ] After merge: trigger the admin "Invalidate" button and confirm the response payload includes `purge: { purged: true, tags: [...] }` and that the docs route serves a fresh response within seconds.
- [ ] After merge: push a doc change to a watched repo and confirm the webhook response shows the purge succeeded and the live page updates immediately.
- [ ] Verify the Netlify env has `NETLIFY_PURGE_API_TOKEN`; if not, mint one with `Site:Purge` scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented tag-based cache invalidation for Netlify documentation
  * GitHub webhooks now automatically purge documentation cache on commits

* **Improvements**
  * Documentation cache is now partitioned by library and branch for faster updates
  * Admin cache invalidation enhanced with more granular control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->