### PR TITLE
fix(content-cache): force sync refresh on operator invalidation

### DIFF
--- a/src/utils/github-content-cache.server.ts
+++ b/src/utils/github-content-cache.server.ts
@@ -128,6 +128,18 @@ function isFresh(staleAt: Date) {
   return staleAt.getTime() > Date.now()
 }
 
+// markGitHubContentStale / markDocsArtifactsStale set staleAt to the epoch
+// (new Date(0)) as a sentinel for "forcibly invalidated" — an admin clicked
+// the purge button or a push webhook fired. In that case we must NOT serve
+// SWR-stale: the operator's intent is "get fresh content on the very next
+// request." Natural TTL expiry (staleAt drifts past now within the normal
+// window) still SWRs as before. The row stays around so the bottom of
+// getCachedGitHubContent / getCachedDocsArtifact can still fall back to it
+// if GitHub is unreachable.
+function isForciblyStale(staleAt: Date) {
+  return staleAt.getTime() <= 0
+}
+
 function queueRefresh(key: string, fn: () => Promise<unknown>) {
   void withPendingRefresh(key, fn).catch((error) => {
     console.error(`[GitHub Cache] Failed to refresh ${key}:`, error)
@@ -253,8 +265,9 @@ async function getCachedGitHubContent<T>(opts: {
 
   const cachedRow = await readRow()
   const storedValue = opts.readStoredValue(cachedRow)
+  const forciblyStale = !!cachedRow && isForciblyStale(cachedRow.staleAt)
 
-  if (storedValue !== undefined) {
+  if (storedValue !== undefined && !forciblyStale) {
     if (cachedRow && isFresh(cachedRow.staleAt)) {
       return storedValue
     }
@@ -272,8 +285,15 @@ async function getCachedGitHubContent<T>(opts: {
   return withPendingRefresh(opts.cacheKey, async () => {
     const latestRow = await readRow()
     const latestValue = opts.readStoredValue(latestRow)
+    const latestForciblyStale =
+      !!latestRow && isForciblyStale(latestRow.staleAt)
 
-    if (latestValue !== undefined && latestRow && isFresh(latestRow.staleAt)) {
+    if (
+      latestValue !== undefined &&
+      latestRow &&
+      !latestForciblyStale &&
+      isFresh(latestRow.staleAt)
+    ) {
       return latestValue
     }
 
@@ -388,8 +408,9 @@ export async function getCachedDocsArtifact<T>(opts: {
   const cachedRow = await readRow()
   const storedValue =
     cachedRow && opts.isValue(cachedRow.payload) ? cachedRow.payload : undefined
+  const forciblyStale = !!cachedRow && isForciblyStale(cachedRow.staleAt)
 
-  if (storedValue !== undefined) {
+  if (storedValue !== undefined && !forciblyStale) {
     if (cachedRow && isFresh(cachedRow.staleAt)) {
       return storedValue
     }
@@ -408,8 +429,15 @@ export async function getCachedDocsArtifact<T>(opts: {
       latestRow && opts.isValue(latestRow.payload)
         ? latestRow.payload
         : undefined
+    const latestForciblyStale =
+      !!latestRow && isForciblyStale(latestRow.staleAt)
 
-    if (latestValue !== undefined && latestRow && isFresh(latestRow.staleAt)) {
+    if (
+      latestValue !== undefined &&
+      latestRow &&
+      !latestForciblyStale &&
+      isFresh(latestRow.staleAt)
+    ) {
       return latestValue
     }
 


### PR DESCRIPTION
## Summary

- `markGitHubContentStale` / `markDocsArtifactsStale` use `staleAt = new Date(0)` as a "force refresh on next read" sentinel — that's what the admin **Invalidate** button and the GitHub push webhook both call. The admin UI even spells out the contract: *"The next docs request for that repo will fetch fresh content from GitHub and rebuild derived artifacts."*
- The SWR readers in `getCachedGitHubContent` / `getCachedDocsArtifact` didn't honor it. When a row had positive cached content but was stale, they returned the cached value and fire-and-forgot a background refresh. On Netlify Functions that background promise is not guaranteed to land, the rendered page goes back into the CDN with stale content, and the next CDN revalidation pulls the same stale DB row — invalidation effectively never converges. Both reported symptoms (missing **Deferred Hydration** sidebar entry in Start docs and missing Astro Islands FAQ section in the guide body) trace to this single path: `config.json` and the markdown file both flow through `fetchRepoFile` → `getCachedGitHubTextFile` → `getCachedGitHubContent`.
- Add `isForciblyStale(staleAt)` that recognizes the epoch sentinel and route forcibly-stale rows past the SWR branch into `withPendingRefresh`, which awaits a fresh origin fetch synchronously. Natural TTL expiry (24h positive / 15min negative) still SWRs as before. The stale-on-origin-error fallback inside `withPendingRefresh` is preserved, so a failed GitHub call right after invalidation still returns the previously cached value instead of erroring.

## Test plan

- [ ] `pnpm test` (tsc + lint) — clean for the touched file; pre-existing warnings elsewhere are unaffected
- [ ] `pnpm run test:smoke` — passed locally (10/10) via the pre-commit hook
- [ ] Manual: in production admin, click **Invalidate** on `tanstack/router`, then load `/start/latest/docs/framework/react/deferred-hydration` (or any updated doc) — confirm the page reflects the latest GitHub content within one origin revalidation cycle (rather than perpetuating the stale render)
- [ ] Manual: confirm the **Deferred Hydration** entry appears in the Start sidebar after invalidation

## Notes / follow-up

The Netlify CDN still has its own SWR windows in front of the SSR (`max-age=600, stale-while-revalidate=3600` on latest docs pages; `max-age=300, stale-while-revalidate=300` on the config server fn). With this fix the staleness is now **bounded** — once the CDN revalidates against origin, it will pick up fresh content. Before this fix the CDN kept re-caching stale renders indefinitely. Making invalidation feel instant requires also issuing a Netlify cache purge from the admin/webhook paths — happy to follow up with that as a separate PR once we decide on the token/IAM story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation mechanism for GitHub content. Admin and webhook-triggered cache clears now properly prevent serving stale cached content, ensuring fresh data is fetched and served to users when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->