### PR TITLE
Fix StackBlitz embed isolation

### DIFF
--- a/src/components/InteractiveSandbox.tsx
+++ b/src/components/InteractiveSandbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { stackBlitzIframeProps } from '~/utils/stackblitz-embed'
 
 interface InteractiveSandboxProps {
   isActive: boolean
@@ -17,6 +18,8 @@ export function InteractiveSandbox({
   libraryName,
   embedEditor,
 }: InteractiveSandboxProps) {
+  const isStackBlitz = embedEditor === 'stackblitz'
+
   return (
     <div
       className={`absolute inset-0 ${
@@ -25,8 +28,9 @@ export function InteractiveSandbox({
       aria-hidden={!isActive}
     >
       <iframe
-        src={embedEditor === 'codesandbox' ? codeSandboxUrl : stackBlitzUrl}
+        src={isStackBlitz ? stackBlitzUrl : codeSandboxUrl}
         title={`${libraryName} | ${examplePath}`}
+        {...(isStackBlitz ? stackBlitzIframeProps : {})}
         sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
         className="w-full h-full min-h-[80dvh] overflow-hidden shadow-lg bg-white dark:bg-black"
       />

--- a/src/components/StackBlitzEmbed.tsx
+++ b/src/components/StackBlitzEmbed.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useIsDark } from '~/hooks/useIsDark'
+import { stackBlitzIframeProps } from '~/utils/stackblitz-embed'
 
 type StackBlitzEmbedProps = {
   repo: string
@@ -32,6 +33,7 @@ export function StackBlitzEmbed({
       title={title || `${repo}: ${examplePath}`}
       key={`${examplePath}-${themeParam}`}
       src={src}
+      {...stackBlitzIframeProps}
       sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
       className="shadow-lg"
       loading="lazy"

--- a/src/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
@@ -24,6 +24,7 @@ import {
   ExampleDeployDialog,
   type DeployProvider,
 } from '~/components/ExampleDeployDialog'
+import { stackBlitzEmbedHeaders } from '~/utils/stackblitz-embed'
 
 const renderedFileQueryOptions = (
   repo: string,
@@ -136,6 +137,7 @@ export const Route = createFileRoute(
       }),
     }
   },
+  headers: () => stackBlitzEmbedHeaders,
   staleTime: 1000 * 60 * 5, // 5 minutes
 })
 

--- a/src/routes/-library-landing.tsx
+++ b/src/routes/-library-landing.tsx
@@ -9,12 +9,17 @@ import { getTanstackDocsConfig } from '~/utils/config'
 import { fetchLandingCodeExample } from '~/utils/landing-code-example.functions'
 import { seo } from '~/utils/seo'
 import { ogImageUrl } from '~/utils/og'
+import { stackBlitzEmbedHeaders } from '~/utils/stackblitz-embed'
 
 export type LandingComponentProps = {
   landingCodeExampleRsc?: ReactNode
 }
 
 type LandingComponent = ComponentType<LandingComponentProps>
+
+type LibraryLandingPageOptions = {
+  hasStackBlitzEmbed?: boolean
+}
 
 type StaticLandingRoutePath =
   | '/ai/$version/'
@@ -108,6 +113,7 @@ export function createLibraryLandingPage<TId extends StaticLandingRoutePath>(
   routePath: TId,
   libraryId: LibraryId,
   LandingComponent: LandingComponent,
+  options: LibraryLandingPageOptions = {},
 ) {
   const library = getLibrary(libraryId)
   const routeApi = getRouteApi(routePath)
@@ -181,6 +187,9 @@ export function createLibraryLandingPage<TId extends StaticLandingRoutePath>(
         noindex: library.visible === false,
       }),
     }),
+    ...(options.hasStackBlitzEmbed
+      ? { headers: () => stackBlitzEmbedHeaders }
+      : {}),
     staticData: {
       Title: () => (
         <LibraryNavbarTitle libraryId={libraryId} routePath={routePath} />

--- a/src/routes/form.$version.index.tsx
+++ b/src/routes/form.$version.index.tsx
@@ -3,5 +3,7 @@ import FormLanding from '~/components/landing/FormLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/form/$version/')(
-  createLibraryLandingPage('/form/$version/', 'form', FormLanding),
+  createLibraryLandingPage('/form/$version/', 'form', FormLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/routes/query.$version.index.tsx
+++ b/src/routes/query.$version.index.tsx
@@ -3,5 +3,7 @@ import QueryLanding from '~/components/landing/QueryLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/query/$version/')(
-  createLibraryLandingPage('/query/$version/', 'query', QueryLanding),
+  createLibraryLandingPage('/query/$version/', 'query', QueryLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/routes/ranger.$version.index.tsx
+++ b/src/routes/ranger.$version.index.tsx
@@ -3,5 +3,7 @@ import RangerLanding from '~/components/landing/RangerLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/ranger/$version/')(
-  createLibraryLandingPage('/ranger/$version/', 'ranger', RangerLanding),
+  createLibraryLandingPage('/ranger/$version/', 'ranger', RangerLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/routes/router.$version.index.tsx
+++ b/src/routes/router.$version.index.tsx
@@ -3,5 +3,7 @@ import RouterLanding from '~/components/landing/RouterLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/router/$version/')(
-  createLibraryLandingPage('/router/$version/', 'router', RouterLanding),
+  createLibraryLandingPage('/router/$version/', 'router', RouterLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/routes/table.$version.index.tsx
+++ b/src/routes/table.$version.index.tsx
@@ -3,5 +3,7 @@ import TableLanding from '~/components/landing/TableLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/table/$version/')(
-  createLibraryLandingPage('/table/$version/', 'table', TableLanding),
+  createLibraryLandingPage('/table/$version/', 'table', TableLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/routes/virtual.$version.index.tsx
+++ b/src/routes/virtual.$version.index.tsx
@@ -3,5 +3,7 @@ import VirtualLanding from '~/components/landing/VirtualLanding'
 import { createLibraryLandingPage } from './-library-landing'
 
 export const Route = createFileRoute('/virtual/$version/')(
-  createLibraryLandingPage('/virtual/$version/', 'virtual', VirtualLanding),
+  createLibraryLandingPage('/virtual/$version/', 'virtual', VirtualLanding, {
+    hasStackBlitzEmbed: true,
+  }),
 )

--- a/src/utils/stackblitz-embed.ts
+++ b/src/utils/stackblitz-embed.ts
@@ -1,0 +1,13 @@
+import type { IframeHTMLAttributes } from 'react'
+
+export const stackBlitzEmbedHeaders = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'credentialless',
+} as const
+
+export const stackBlitzIframeProps = {
+  allow: 'cross-origin-isolated',
+  credentialless: '',
+} as IframeHTMLAttributes<HTMLIFrameElement> & {
+  credentialless: string
+}


### PR DESCRIPTION
## Summary
- add StackBlitz iframe isolation props for embedded projects
- send COOP/COEP headers on docs example pages and StackBlitz-backed landing pages
- keep isolation scoped so unrelated landing pages are not affected

## Testing
- node scripts/build-content-collections.mjs
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/oxlint --type-aware --disable-nested-config
- ./node_modules/.bin/vite build
- curl -I local built routes to confirm StackBlitz pages include COOP/COEP and /start/latest does not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled StackBlitz embed support across library landing pages for form, query, ranger, router, table, and virtual libraries
  * Enhanced embedded iframe security with improved cross-origin policies for StackBlitz embeds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/tanstack.com/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->