### PR TITLE
Audit landing page examples against docs

### DIFF
--- a/src/components/landing/AiLanding.tsx
+++ b/src/components/landing/AiLanding.tsx
@@ -264,7 +264,7 @@ export default function AiLanding({
             <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
               A useful AI layer has to cross clients, servers, providers, tools,
               streaming events, approvals, and observability. AI keeps those
-              seams explicit so teams can swap pieces without rewriting the
+              boundaries explicit so teams can swap pieces without rewriting the
               product.
             </p>
           </div>
@@ -888,11 +888,15 @@ function RuntimePanel() {
     <div className="min-w-0 rounded-lg border border-pink-200 bg-white p-4 dark:border-pink-900 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-pink-100 dark:bg-black">
         <p className="font-mono leading-6">
-          agent.run({'{'} provider, model, tools {'}'})
+          const {'{'} messages, addToolApprovalResponse {'}'} = useChat({'{'}
           <br />
-          stream.on(&quot;tool.call&quot;, requestApproval)
+          &nbsp;&nbsp;connection: fetchServerSentEvents(&quot;/api/chat&quot;),
           <br />
-          devtools.record(event)
+          &nbsp;&nbsp;tools,
+          <br />
+          &nbsp;&nbsp;devtools: {'{'} name: &quot;Support Chat&quot; {'}'}
+          <br />
+          {'}'})
         </p>
       </div>
 

--- a/src/components/landing/CliLanding.tsx
+++ b/src/components/landing/CliLanding.tsx
@@ -28,7 +28,7 @@ import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptB
 const library = getLibrary('cli')
 const cliAgentPrompt = [
   'Use TanStack CLI for a TanStack project workflow.',
-  'Show how the CLI, MCP server, Builder, docs search, and modular integrations can scaffold or modify a TanStack Start app with auth, database, styling, deployment, and package-specific best practices.',
+  'Show how the CLI, Builder, docs search, and modular integrations can scaffold or modify a TanStack Start app with auth, database, styling, deployment, and package-specific best practices.',
   'Keep generated changes inspectable and grounded in TanStack docs instead of relying on generic framework assumptions.',
 ].join(' ')
 
@@ -38,8 +38,8 @@ const heroProof = [
     value: 'project commands and generated changes',
   },
   {
-    label: 'MCP',
-    value: 'docs search and agent context',
+    label: 'Docs',
+    value: 'search, fetch, and introspect',
   },
   {
     label: 'Builder',
@@ -48,10 +48,10 @@ const heroProof = [
 ]
 
 const commandRows = [
-  ['search docs', 'router loaders'],
-  ['add integration', 'auth + database'],
-  ['scaffold start', 'Cloudflare target'],
-  ['export builder', 'checked project plan'],
+  ['search-docs', '"router loaders" --library router'],
+  ['create', 'my-app --add-ons clerk,drizzle'],
+  ['libraries', '--group state --json'],
+  ['ecosystem', '--category database --json'],
 ]
 
 const featureCards = [
@@ -61,8 +61,8 @@ const featureCards = [
     icon: <Terminal size={18} />,
   },
   {
-    title: 'MCP turns docs into agent context.',
-    body: 'Connect assistants to TanStack documentation so generated work can reference current docs and package-specific conventions.',
+    title: 'CLI introspection turns docs into agent context.',
+    body: 'Use JSON commands for docs, libraries, add-ons, and ecosystem data so generated work can reference current TanStack conventions.',
     icon: <Bot size={18} />,
   },
   {
@@ -80,7 +80,7 @@ const featureCards = [
 const workflowSteps = [
   {
     label: 'Discover',
-    body: 'Search docs, examples, packages, and integrations through CLI or MCP.',
+    body: 'Search docs, examples, packages, and integrations through direct CLI commands.',
   },
   {
     label: 'Choose',
@@ -110,8 +110,8 @@ const builderOutputs = [
     value: 'routes, server fns, env, deploy config',
   },
   {
-    label: 'agent prompt',
-    value: 'copyable implementation brief',
+    label: 'CLI config',
+    value: '.tanstack.json and chosen add-ons',
   },
 ]
 
@@ -127,7 +127,7 @@ export default function CliLanding({
         <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-10 lg:max-w-[80rem] lg:grid-cols-[0.84fr_1.16fr] lg:items-start lg:py-12 xl:max-w-[92rem]">
           <div className="min-w-0 max-w-full sm:max-w-3xl">
             <SectionKicker icon={<Terminal size={14} />}>
-              CLI, MCP, and Builder
+              CLI, add-ons, and Builder
             </SectionKicker>
 
             <div className="mt-4 flex flex-wrap items-start gap-x-3 gap-y-2">
@@ -146,9 +146,9 @@ export default function CliLanding({
             </p>
 
             <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-700 dark:text-zinc-300 sm:text-lg">
-              CLI brings together commands, MCP docs access, modular
+              CLI brings together project commands, docs search, modular
               integrations, and the Builder so TanStack Start apps can be
-              scaffolded and customized with the same context the docs use.
+              scaffolded and customized with current TanStack context.
             </p>
 
             <LibraryDownloadsMicro
@@ -241,7 +241,7 @@ export default function CliLanding({
             <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
               The Builder turns app intent into a readable stack brief: TanStack
               libraries, partner integrations, deployment target, generated
-              files, and an agent-ready prompt.
+              files, and CLI-ready configuration.
             </p>
           </div>
 
@@ -319,10 +319,7 @@ export default function CliLanding({
 function CliWorkbenchPanel() {
   const [activeCommandIndex, setActiveCommandIndex] = React.useState(0)
   const activeCommand = commandRows[activeCommandIndex] ?? commandRows[0]
-  const activeCommandPreview = `npx @tanstack/cli ${activeCommand[0].replace(
-    ' ',
-    '-',
-  )} "${activeCommand[1]}"`
+  const activeCommandPreview = `npx @tanstack/cli ${activeCommand[0]} ${activeCommand[1]}`
 
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-indigo-200 bg-white p-4 shadow-sm shadow-indigo-950/5 dark:border-indigo-900 dark:bg-zinc-950">
@@ -339,11 +336,11 @@ function CliWorkbenchPanel() {
 
       <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-sm text-indigo-100 dark:bg-black">
         <p className="font-mono leading-6">
-          npx @tanstack/cli mcp
+          npx @tanstack/cli create --list-add-ons --json
           <br />
           {activeCommandPreview}
           <br />
-          npx @tanstack/cli build-plan
+          npx @tanstack/cli doc query framework/react/overview --json
         </p>
       </div>
 

--- a/src/components/landing/ConfigLanding.tsx
+++ b/src/components/landing/ConfigLanding.tsx
@@ -29,8 +29,8 @@ import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptB
 const library = getLibrary('config')
 const configAgentPrompt = [
   'Set up TanStack Config for a TypeScript package.',
-  'Use the opinionated lint, build, test, versioning, changelog, publishing, and package-quality defaults while keeping project-specific configuration minimal and explicit.',
-  'Show how the package should produce publint-friendly output, stable npm releases, and repeatable local/CI workflows.',
+  'Use the opinionated ESLint, Vite package build, CI/CD, package structure, and publish defaults while keeping project-specific configuration minimal and explicit.',
+  'Show how the package should produce publint-friendly output, Changesets-backed releases, and repeatable local/CI workflows.',
 ].join(' ')
 
 const heroProof = [
@@ -40,11 +40,11 @@ const heroProof = [
   },
   {
     label: 'Validate',
-    value: 'lint, tests, publint-friendly checks',
+    value: 'ESLint, tests, package checks',
   },
   {
     label: 'Release',
-    value: 'versioning, changelogs, npm + GitHub',
+    value: 'Changesets, npm + GitHub',
   },
 ]
 
@@ -52,14 +52,14 @@ const releaseRows = [
   ['typecheck', 'passed'],
   ['lint', 'passed'],
   ['package exports', 'verified'],
-  ['changelog', 'generated'],
+  ['changesets', 'ready'],
   ['npm publish', 'ready'],
 ]
 
 const featureCards = [
   {
     title: 'Opinionated where packages are repetitive.',
-    body: 'Linting, building, testing, formatting, publishing, and release hygiene should not become bespoke work in every package repo.',
+    body: 'Linting, package builds, CI tasks, publishing, and release hygiene should not become bespoke work in every package repo.',
     icon: <ClipboardCheck size={18} />,
   },
   {
@@ -69,7 +69,7 @@ const featureCards = [
   },
   {
     title: 'Publishing rules stay visible.',
-    body: 'Exports, changelogs, package metadata, versioning, and npm release behavior can be reviewed as part of the same workflow.',
+    body: 'Exports, package metadata, release branches, and npm publish behavior can be reviewed as part of the same workflow.',
     icon: <PackageCheck size={18} />,
   },
   {
@@ -94,7 +94,7 @@ const pipelineSteps = [
   },
   {
     label: 'Publish',
-    body: 'Version, changelog, tag, and publish through a repeatable release path.',
+    body: 'Version, tag, and publish through a repeatable release path.',
   },
 ]
 
@@ -108,8 +108,8 @@ const auditSignals = [
     value: 'package shape checked',
   },
   {
-    label: 'changes',
-    value: 'changelog generated',
+    label: 'changesets',
+    value: 'versioning ready',
   },
   {
     label: 'release',
@@ -142,8 +142,8 @@ export default function ConfigLanding({
 
             <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-700 dark:text-zinc-300 sm:text-lg">
               Config is the opinionated toolchain TanStack uses to keep
-              JavaScript packages linted, built, tested, versioned,
-              changelogged, and published with minimal per-package ceremony.
+              JavaScript packages linted, built, tested in CI, versioned with
+              Changesets, and published with minimal per-package ceremony.
             </p>
 
             <LibraryDownloadsMicro
@@ -190,9 +190,9 @@ export default function ConfigLanding({
             </h2>
             <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
               Every library needs the same boring promises: exports resolve,
-              types ship, tests pass, changelogs make sense, and npm publishes
-              what consumers expect. Config turns that repetition into shared
-              defaults.
+              types ship, tests pass, release branches are configured, and npm
+              publishes what consumers expect. Config turns that repetition into
+              shared defaults.
             </p>
           </div>
 
@@ -234,7 +234,7 @@ export default function ConfigLanding({
             </h2>
             <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
               The consumer sees your package boundary: exports, module formats,
-              types, metadata, changelog, and version. Config keeps that
+              types, metadata, release branch, and version. Config keeps that
               boundary part of the workflow.
             </p>
           </div>
@@ -345,13 +345,13 @@ function ReleasePanel() {
 
       <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-sm text-zinc-100 dark:bg-black">
         <p className="font-mono leading-6">
-          pnpm lint
+          vite build &amp;&amp; publint --strict
           <br />
-          pnpm test
+          nx affected
           <br />
-          pnpm build --verify {completedCount}/{releaseRows.length}
+          changesets {completedCount}/{releaseRows.length}
           <br />
-          pnpm release{' '}
+          publish config: branchConfigs, packages, npm, github{' '}
           {completedCount === releaseRows.length ? '--ready' : '--blocked'}
         </p>
       </div>
@@ -432,7 +432,7 @@ function AuditPanel() {
           <br />
           dist/index.d.ts
           <br />
-          CHANGELOG.md
+          .changeset/*.md
         </p>
       </div>
     </div>

--- a/src/components/landing/DbLanding.tsx
+++ b/src/components/landing/DbLanding.tsx
@@ -574,13 +574,17 @@ function SyncPanel() {
     <div className="min-w-0 rounded-lg border border-orange-200 bg-white p-4 dark:border-orange-900 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-orange-100 dark:bg-black">
         <p className="font-mono leading-6">
-          liveQuery({'{'} projects, issues, members {'}'})
+          useLiveQuery((q) =&gt;
           <br />
-          &nbsp;&nbsp;.where(({`{`} issue, project {`}`}) =&gt; issue.projectId
-          === project.id)
+          &nbsp;&nbsp;q.from({'{'} issue: issuesCollection {'}'})
           <br />
-          &nbsp;&nbsp;.orderBy(({`{`} issue {`}`}) =&gt; issue.updatedAt,
-          &quot;desc&quot;)
+          &nbsp;&nbsp;&nbsp;&nbsp;.join({'{'} project: projectsCollection {'}'},
+          ({`{`} issue, project {`}`}) =&gt;
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eq(issue.projectId, project.id))
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;.orderBy(({`{`} issue {`}`}) =&gt;
+          issue.updatedAt, &quot;desc&quot;))
         </p>
       </div>
 

--- a/src/components/landing/DevtoolsLanding.tsx
+++ b/src/components/landing/DevtoolsLanding.tsx
@@ -31,7 +31,7 @@ const library = getLibrary('devtools')
 const devtoolsAgentPrompt = [
   'Add TanStack Devtools to a TypeScript app.',
   'Use the unified devtools shell to host TanStack panels and any custom product devtools, keeping the panel lightweight, framework-friendly, and available during development without coupling product code to one library-specific inspector.',
-  'Include examples for mounting built-in panels and registering a custom panel with useful runtime state.',
+  'Include examples for mounting built-in panels and product-specific panels through the plugins array.',
 ].join(' ')
 
 const heroProof = [
@@ -45,7 +45,7 @@ const heroProof = [
   },
   {
     label: 'Framework friendly',
-    value: 'React, Preact, Solid, vanilla',
+    value: 'React, Vue, Solid, Preact, Angular',
   },
 ]
 
@@ -82,7 +82,7 @@ const featureCards = [
   },
   {
     title: 'Frameworks get adapters, not rewrites.',
-    body: 'Use the shell from React, Preact, Solid, or vanilla integration points while panels keep their own internal state model.',
+    body: 'Use the shell from React, Vue, Solid, Preact, Angular, or vanilla integration points while panels keep their own internal state model.',
     icon: <Layers size={18} />,
   },
 ]
@@ -94,7 +94,7 @@ const panelLifecycle = [
   },
   {
     label: 'Register',
-    body: 'Provide TanStack panels or custom panels with a title, icon, and renderer.',
+    body: 'Provide TanStack panels or custom panels through the plugins array.',
   },
   {
     label: 'Inspect',
@@ -106,7 +106,14 @@ const panelLifecycle = [
   },
 ]
 
-const frameworkAdapters = ['React', 'Preact', 'Solid', 'Vanilla']
+const frameworkAdapters = [
+  'React',
+  'Vue',
+  'Solid',
+  'Preact',
+  'Angular',
+  'Vanilla',
+]
 
 export default function DevtoolsLanding({
   landingCodeExampleRsc,
@@ -449,15 +456,17 @@ function CustomPanelExample() {
     <div className="min-w-0 rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-zinc-100 dark:bg-black">
         <p className="font-mono leading-6">
-          registerDevtoolsPanel({'{'}
+          &lt;TanStackDevtools
           <br />
-          &nbsp;&nbsp;id: &quot;jobs&quot;,
+          &nbsp;&nbsp;plugins={'{'}[{'{'}
           <br />
-          &nbsp;&nbsp;title: &quot;Background Jobs&quot;,
+          &nbsp;&nbsp;&nbsp;&nbsp;name: &quot;Background Jobs&quot;,
           <br />
-          &nbsp;&nbsp;render: JobsPanel,
+          &nbsp;&nbsp;&nbsp;&nbsp;render: &lt;JobsPanel /&gt;,
           <br />
-          {'}'})
+          &nbsp;&nbsp;{'}'}]{'}'}
+          <br />
+          /&gt;
         </p>
       </div>
 

--- a/src/components/landing/FormLanding.tsx
+++ b/src/components/landing/FormLanding.tsx
@@ -62,7 +62,7 @@ type FormDemoPlan = 'team' | 'enterprise'
 const formFields: Array<FormDemoField> = [
   {
     name: 'profile.email',
-    detail: 'zod + async availability',
+    detail: 'schema + async availability',
   },
   {
     name: 'company.plan',
@@ -129,7 +129,7 @@ const fieldStates = [
   },
   {
     label: 'pending',
-    value: 'field.state.meta.isValidating',
+    value: 'form.state.isFieldsValidating',
   },
   {
     label: 'submit',
@@ -537,9 +537,9 @@ function SubscriptionPanel() {
     <div className="min-w-0 rounded-lg border border-yellow-200 bg-white p-4 dark:border-yellow-900 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-yellow-100 dark:bg-black">
         <p className="font-mono leading-6">
-          form.Subscribe({'{'} selector: state =&gt; state.canSubmit {'}'})
+          useStore(form.store, state =&gt; state.values.profile.email)
           <br />
-          field.Subscribe({'{'} selector: field =&gt; field.meta.errors {'}'})
+          form.Subscribe({'{'} selector: state =&gt; state.canSubmit {'}'})
         </p>
       </div>
 

--- a/src/components/landing/HotkeysLanding.tsx
+++ b/src/components/landing/HotkeysLanding.tsx
@@ -387,8 +387,8 @@ function ShortcutPanel() {
 
       <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-sm text-rose-100 dark:bg-black">
         <p className="font-mono leading-6">
-          useHotkeys(&quot;{activeShortcut}&quot;, runCommand, {'{'} scope {'}'}
-          )
+          useHotkey(&quot;{activeShortcut}&quot;, runCommand, {'{'} enabled:{' '}
+          isPanelOpen {'}'})
         </p>
       </div>
     </div>

--- a/src/components/landing/IntentLanding.tsx
+++ b/src/components/landing/IntentLanding.tsx
@@ -57,10 +57,10 @@ const heroProof = [
 ]
 
 const packageFiles = [
-  ['package.json', 'exports skill metadata'],
-  ['skills/router.md', 'procedural agent knowledge'],
+  ['package.json', 'keywords and files entries'],
+  ['skills/router/SKILL.md', 'procedural agent knowledge'],
   ['docs/routing.md', 'source reference'],
-  ['CI stale check', 'fails when sources drift'],
+  ['stale report', 'flags source drift'],
 ]
 
 const featureCards = [
@@ -316,7 +316,7 @@ function IntentPackagePanel() {
           <br />
           npx @tanstack/intent validate {activeFile[0]}
           <br />
-          npx @tanstack/intent stale --source "{activeFile[1]}"
+          npx @tanstack/intent stale --json
         </p>
       </div>
 

--- a/src/components/landing/PacerLanding.tsx
+++ b/src/components/landing/PacerLanding.tsx
@@ -514,11 +514,11 @@ function AsyncPanel() {
     <div className="min-w-0 rounded-lg border border-lime-200 bg-white p-4 dark:border-lime-900 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-lime-100 dark:bg-black">
         <p className="font-mono leading-6">
-          queue.add(uploadFile)
+          const queue = new AsyncQueuer(uploadFile, {'{'} concurrency: 3 {'}'})
           <br />
-          queue.setOptions({'{'} concurrency: 3, order: &quot;fifo&quot; {'}'})
+          queue.addItem(file)
           <br />
-          queue.subscribe(state =&gt; state.status)
+          queue.store.subscribe(state =&gt; syncStatus(state.status))
         </p>
       </div>
 

--- a/src/components/landing/QueryLanding.tsx
+++ b/src/components/landing/QueryLanding.tsx
@@ -160,7 +160,7 @@ const mutationSteps = [
   },
   {
     label: 'targeted refresh',
-    code: "invalidateQueries(['todos'])",
+    code: "invalidateQueries({ queryKey: ['todos'] })",
   },
   {
     label: 'rollback path',

--- a/src/components/landing/RangerLanding.tsx
+++ b/src/components/landing/RangerLanding.tsx
@@ -351,8 +351,14 @@ function RangerLabPanel() {
 
       <div className="mt-6 rounded-lg bg-zinc-950 p-4 text-sm text-zinc-100 dark:bg-black">
         <p className="font-mono leading-6">
-          useRanger({'{'} min: 0, max: 1000, step: 10, values: [
-          {values.join(', ')}] {'}'})
+          useRanger({'{'} getRangerElement: () =&gt; rangerRef.current,
+          <br />
+          &nbsp;&nbsp;min: 0, max: 1000,
+          <br />
+          &nbsp;&nbsp;stepSize: 10, values: [{values.join(', ')}],
+          <br />
+          &nbsp;&nbsp;onChange: instance =&gt; setValues(instance.sortedValues){' '}
+          {'}'})
         </p>
       </div>
     </div>

--- a/src/components/landing/RouterLanding.tsx
+++ b/src/components/landing/RouterLanding.tsx
@@ -501,7 +501,8 @@ function SearchStatePanel() {
 
       <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-sm text-emerald-100 dark:bg-black">
         <p className="font-mono leading-6">
-          <span className="text-emerald-300">search</span>: z.object({'{'}
+          <span className="text-emerald-300">validateSearch</span>: z.object(
+          {'{'}
           <br />
           &nbsp;&nbsp;q: z.string().optional(),
           <br />

--- a/src/components/landing/StoreLanding.tsx
+++ b/src/components/landing/StoreLanding.tsx
@@ -93,7 +93,7 @@ const lifecycleSteps = [
 const subscriptionExamples = [
   {
     label: 'component',
-    value: 'useStore(appStore, state => state.filters)',
+    value: 'useSelector(appStore, state => state.filters)',
   },
   {
     label: 'derived',
@@ -101,7 +101,7 @@ const subscriptionExamples = [
   },
   {
     label: 'effect',
-    value: 'store.subscribe(selector, listener)',
+    value: 'store.subscribe(listener)',
   },
   {
     label: 'adapter',
@@ -533,9 +533,9 @@ function SubscriptionPanel() {
     <div className="min-w-0 rounded-lg border border-twine-200 bg-white p-4 dark:border-twine-900 dark:bg-zinc-950">
       <div className="rounded-lg bg-zinc-950 p-4 text-sm text-twine-100 dark:bg-black">
         <p className="font-mono leading-6">
-          const filters = useStore(store, state =&gt; state.filters)
+          const filters = useSelector(store, state =&gt; state.filters)
           <br />
-          const canSave = useStore(store, state =&gt; state.draft.isDirty)
+          const canSave = useSelector(store, state =&gt; state.draft.isDirty)
         </p>
       </div>
 

--- a/src/components/landing/WorkflowLanding.tsx
+++ b/src/components/landing/WorkflowLanding.tsx
@@ -29,8 +29,8 @@ import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptB
 const library = getLibrary('workflow')
 const workflowAgentPrompt = [
   'Build a TanStack Workflow process for a TypeScript app.',
-  'Model a durable multi-step workflow with typed inputs and outputs, retries, backoff, approvals, fan-out, resumable state, and observable execution history.',
-  'Keep business process state inspectable instead of hiding it inside one-off background jobs.',
+  'Model a multi-step workflow with typed inputs and outputs, retries, backoff, approvals, fan-out, and inspectable execution history.',
+  'Keep business process state explicit, and verify concrete API calls against the current Workflow docs before implementation.',
 ].join(' ')
 
 const heroProof = [
@@ -39,8 +39,8 @@ const heroProof = [
     value: 'inputs, outputs, context, transitions',
   },
   {
-    label: 'Durable state',
-    value: 'resume through restarts and deploys',
+    label: 'Run state',
+    value: 'history, attempts, next actions',
   },
   {
     label: 'Recovery',
@@ -78,8 +78,8 @@ const featureCards = [
     icon: <GitBranch size={18} />,
   },
   {
-    title: 'Durability is part of the model.',
-    body: 'Long-running work should survive deploys, restarts, slow systems, and human delays without losing the state the business cares about.',
+    title: 'State is part of the model.',
+    body: 'Long-running work needs visible run state around slow systems, retries, human delays, and the next action the process is waiting on.',
     icon: <ShieldCheck size={18} />,
   },
   {
@@ -105,7 +105,7 @@ const lifecycleSteps = [
   },
   {
     label: 'Wait',
-    body: 'Durable state can pause for external systems, timers, or approvals.',
+    body: 'The run can pause around external systems, timers, or approvals.',
   },
   {
     label: 'Resume',
@@ -163,8 +163,8 @@ export default function WorkflowLanding({
             </p>
 
             <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-700 dark:text-zinc-300 sm:text-lg">
-              Workflow models approvals, retries, fan-out, slow external
-              systems, and resumable state as durable TypeScript workflows
+              Workflow is for modeling approvals, retries, fan-out, slow
+              external systems, and visible run state as TypeScript workflows
               instead of one-off background jobs scattered across the app.
             </p>
 
@@ -236,9 +236,9 @@ export default function WorkflowLanding({
               Start, step, wait, resume.
             </h2>
             <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Durable workflows let process state move through time deliberately
-              instead of hoping a single request, queue worker, or deploy window
-              keeps everything together.
+              Typed workflows let process state move through time deliberately
+              instead of hoping a single request or queue worker keeps
+              everything together.
             </p>
           </div>
         </div>
@@ -465,12 +465,11 @@ function ObservabilityPanel() {
 
       <div className="mt-4 rounded-lg bg-zinc-950 p-4 text-sm text-blue-100 dark:bg-black">
         <p className="font-mono leading-6">
-          workflow.step(&quot;reserve inventory&quot;)
+          step: &quot;reserve inventory&quot;
           <br />
-          &nbsp;&nbsp;.retry({'{'} attempts: 5, backoff: &quot;exponential&quot;{' '}
-          {'}'})
+          attempts: 2 / 5
           <br />
-          &nbsp;&nbsp;.waitForApproval(&quot;manager&quot;)
+          next: &quot;manager approval&quot;
         </p>
       </div>
     </div>

--- a/src/components/landing/codeExamples.server.tsx
+++ b/src/components/landing/codeExamples.server.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
 import type { LibraryId } from '~/libraries'
-import { formProject } from '~/libraries/form'
 import { queryProject } from '~/libraries/query'
 import { routerProject } from '~/libraries/router'
-import { tableProject } from '~/libraries/table'
-import { virtualProject } from '~/libraries/virtual'
 import {
   LandingCodeExampleCard,
   type LandingCodeExample,
@@ -88,19 +85,19 @@ const { data, isPending, error } = useQuery({
       code: `<script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
 
-  const todos = createQuery({
+  const todos = createQuery(() => ({
     queryKey: ['todos'],
     queryFn: () => fetch('/api/todos').then(r => r.json()),
-  })
+  }))
 </script>
 
-{#if $todos.isPending}
+{#if todos.isLoading}
   Loading...
-{:else if $todos.error}
+{:else if todos.isError}
   Oops!
-{:else}
+{:else if todos.isSuccess}
   <ul>
-    {#each $todos.data as t}
+    {#each todos.data as t}
       <li>{t.title}</li>
     {/each}
   </ul>
@@ -148,7 +145,7 @@ export class TodosList extends LitElement {
   })
 
   render() {
-    const { data, isPending, error } = this.todos.current
+    const { data, isPending, error } = this.todos()
 
     if (isPending) return html\`<span>Loading...</span>\`
     if (error) return html\`<span>Oops!</span>\`
@@ -201,218 +198,118 @@ export default function App() {
 }
 
 const formCodeExample: LandingCodeExample = {
-  frameworks: formProject.frameworks,
+  frameworks: ['react'],
+  title: 'React field and submit state',
   codeByFramework: {
     react: {
       lang: 'tsx',
       code: `import { useForm } from '@tanstack/react-form'
 
-const form = useForm({
-  defaultValues: { name: '' },
-  onSubmit: async ({ value }) => console.log(value),
-})
-// Bind inputs to form.state and form.handleSubmit`,
+export default function PeoplePage() {
+  const form = useForm({
+    defaultValues: { age: 0 },
+    onSubmit: ({ value }) => {
+      alert(JSON.stringify(value, null, 2))
     },
-    vue: {
-      lang: 'vue',
-      code: `<script setup lang="ts">
-import { useForm } from '@tanstack/vue-form'
-
-const form = useForm({
-  defaultValues: { name: '' },
-  onSubmit: async ({ value }) => console.log(value),
-})
-</script>
-
-<template>
-  <form @submit.prevent="form.handleSubmit">
-    <input v-model="form.state.values.name" />
-    <button type="submit">Submit</button>
-  </form>
-</template>`,
-    },
-    angular: {
-      lang: 'ts',
-      code: `import { Component } from '@angular/core'
-import { createAngularForm } from '@tanstack/angular-form'
-
-@Component({
-  standalone: true,
-  selector: 'app-form',
-  template: '<form (submit)="form.handleSubmit($event)"><input [value]="form.state().values.name" (input)="form.setFieldValue(\\"name\\", $any($event.target).value)" /><button type="submit">Submit</button></form>',
-})
-export class AppComponent {
-  form = createAngularForm(() => ({
-    defaultValues: { name: '' },
-    onSubmit: async ({ value }) => console.log(value),
-  }))
-}`,
-    },
-    solid: {
-      lang: 'tsx',
-      code: `import { createForm } from '@tanstack/solid-form'
-
-export default function SimpleForm() {
-  const form = createForm({
-    defaultValues: { name: '' },
-    onSubmit: async ({ value }) => console.log(value),
   })
 
   return (
-    <form onSubmit={form.handleSubmit}>
-      <input value={form.state.values.name} onInput={(e) => form.setFieldValue('name', e.currentTarget.value)} />
-      <button type="submit">Submit</button>
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        form.handleSubmit()
+      }}
+    >
+      <form.Field
+        name="age"
+        validators={{
+          onChange: ({ value }) =>
+            value > 13 ? undefined : 'Must be 13 or older',
+        }}
+        children={(field) => (
+          <>
+            <input
+              name={field.name}
+              value={field.state.value}
+              type="number"
+              onBlur={field.handleBlur}
+              onChange={(event) =>
+                field.handleChange(event.target.valueAsNumber)
+              }
+            />
+            {!field.state.meta.isValid && (
+              <em>{field.state.meta.errors.join(', ')}</em>
+            )}
+          </>
+        )}
+      />
+      <form.Subscribe
+        selector={(state) => [state.canSubmit, state.isSubmitting]}
+        children={([canSubmit, isSubmitting]) => (
+          <button type="submit" disabled={!canSubmit}>
+            {isSubmitting ? '...' : 'Submit'}
+          </button>
+        )}
+      />
     </form>
   )
-}`,
-    },
-    svelte: {
-      lang: 'svelte',
-      code: `<script lang="ts">
-  import { createForm } from '@tanstack/svelte-form'
-
-  const form = createForm({
-    defaultValues: { name: '' },
-    onSubmit: async ({ value }) => console.log(value),
-  })
-</script>
-
-<form on:submit|preventDefault={form.handleSubmit}>
-  <input bind:value={form.state.values.name} />
-  <button type="submit">Submit</button>
-</form>`,
-    },
-    lit: {
-      lang: 'ts',
-      code: `import { LitElement, customElement, html } from 'lit'
-import { createLitForm } from '@tanstack/lit-form'
-
-@customElement('simple-form')
-export class SimpleForm extends LitElement {
-  form = createLitForm({
-    defaultValues: { name: '' },
-    onSubmit: async ({ value }) => console.log(value),
-  })
-
-  override render() {
-    return html\`<form @submit=\${(e: Event) => { e.preventDefault(); this.form.handleSubmit(e); }}>
-      <input .value=\${this.form.state.values.name} @input=\${(e: any) => this.form.setFieldValue('name', e.target.value)} />
-      <button type="submit">Submit</button>
-    </form>\`
-  }
 }`,
     },
   },
 }
 
 const virtualCodeExample: LandingCodeExample = {
-  frameworks: virtualProject.frameworks,
+  frameworks: ['react'],
+  title: 'React virtual rows',
   codeByFramework: {
     react: {
       lang: 'tsx',
-      code: `import { useVirtualizer } from '@tanstack/react-virtual'
+      code: `import * as React from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 
-const rowVirtualizer = useVirtualizer({
-  count: 1000,
-  getScrollElement: () => parentRef.current,
-  estimateSize: () => 36,
-})
-// Map virtual rows to your UI`,
-    },
-    solid: {
-      lang: 'tsx',
-      code: `import { createVirtualizer } from '@tanstack/solid-virtual'
-
-const parentRef: HTMLElement | undefined = undefined
-
-const rowVirtualizer = createVirtualizer({
-  count: 1000,
-  getScrollElement: () => parentRef!,
-  estimateSize: () => 36,
-})
-// Map rowVirtualizer.getVirtualItems() to your UI`,
-    },
-    vue: {
-      lang: 'vue',
-      code: `<script setup lang="ts">
-import { ref } from 'vue'
-import { useVirtualizer } from '@tanstack/vue-virtual'
-
-const parentRef = ref<HTMLElement | null>(null)
-
-const rowVirtualizer = useVirtualizer({
-  count: 1000,
-  getScrollElement: () => parentRef.value!,
-  estimateSize: () => 36,
-})
-</script>
-
-<template>
-  <div ref="parentRef" style="overflow: auto; height: 300px">
-    <!-- Render rowVirtualizer.getVirtualItems() -->
-  </div>
-</template>`,
-    },
-    svelte: {
-      lang: 'svelte',
-      code: `<script lang="ts">
-  import { createVirtualizer } from '@tanstack/svelte-virtual'
-
-  let parentRef: HTMLDivElement
-  const rowVirtualizer = createVirtualizer({
-    count: 1000,
-    getScrollElement: () => parentRef,
-    estimateSize: () => 36,
-  })
-</script>
-
-<div bind:this={parentRef} style="overflow:auto; height:300px">
-  <!-- Render $rowVirtualizer.getVirtualItems() -->
-</div>`,
-    },
-    angular: {
-      lang: 'ts',
-      code: `import { Component, ElementRef, viewChild } from '@angular/core'
-import { createAngularVirtualizer } from '@tanstack/angular-virtual'
-
-@Component({
-  standalone: true,
-  selector: 'virtual-list',
-  template: '<div #parent style="overflow:auto; height:300px"></div>',
-})
-export class VirtualListComponent {
-  parent = viewChild.required<ElementRef<HTMLDivElement>>('parent')
-  virtualizer = createAngularVirtualizer(() => ({
-    count: 1000,
-    getScrollElement: () => this.parent().nativeElement,
-    estimateSize: () => 36,
-  }))
-}`,
-    },
-    lit: {
-      lang: 'ts',
-      code: `import { LitElement, customElement, html } from 'lit'
-import { createLitVirtualizer } from '@tanstack/lit-virtual'
-
-@customElement('virtual-list')
-export class VirtualList extends LitElement {
-  private parent?: HTMLDivElement
-  virtualizer = createLitVirtualizer({
-    count: 1000,
-    getScrollElement: () => this.parent!,
+export default function VirtualRows() {
+  const parentRef = React.useRef<HTMLDivElement>(null)
+  const rowVirtualizer = useVirtualizer({
+    count: 10000,
+    getScrollElement: () => parentRef.current,
     estimateSize: () => 36,
   })
 
-  render() {
-    return html\`<div style="overflow:auto; height:300px"></div>\`
-  }
+  return (
+    <div ref={parentRef} style={{ height: 320, overflow: 'auto' }}>
+      <div
+        style={{
+          height: rowVirtualizer.getTotalSize(),
+          position: 'relative',
+        }}
+      >
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => (
+          <div
+            key={virtualRow.key}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: virtualRow.size,
+              transform: 'translateY(' + virtualRow.start + 'px)',
+            }}
+          >
+            Row {virtualRow.index}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }`,
     },
   },
 }
 
 const tableCodeExample: LandingCodeExample = {
-  frameworks: tableProject.frameworks,
+  frameworks: ['react'],
+  title: 'React table instance',
   codeByFramework: {
     react: {
       lang: 'tsx',
@@ -422,16 +319,23 @@ const data = [{ id: 1, name: 'Ada' }]
 const columns = [{ accessorKey: 'name', header: 'Name' }]
 
 export default function SimpleTable() {
-  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() })
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
 
   return (
     <table>
       <thead>
-        {table.getHeaderGroups().map((hg) => (
-          <tr key={hg.id}>
-            {hg.headers.map((header) => (
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
               <th key={header.id}>
-                {flexRender(header.column.columnDef.header, header.getContext())}
+                {flexRender(
+                  header.column.columnDef.header,
+                  header.getContext(),
+                )}
               </th>
             ))}
           </tr>
@@ -452,262 +356,6 @@ export default function SimpleTable() {
   )
 }`,
     },
-    angular: {
-      lang: 'ts',
-      code: `import { Component, signal } from '@angular/core'
-import { createAngularTable, getCoreRowModel, FlexRenderDirective, type ColumnDef } from '@tanstack/angular-table'
-
-type Person = { id: number; name: string }
-
-@Component({
-  standalone: true,
-  selector: 'app-table',
-  imports: [FlexRenderDirective],
-  template: \
-\`
-<table>
-  <thead>
-    @for (hg of table.getHeaderGroups(); track hg.id) {
-      <tr>
-        @for (header of hg.headers; track header.id) {
-          <th>
-            <ng-container *flexRender="header.column.columnDef.header; props: header.getContext()"></ng-container>
-          </th>
-        }
-      </tr>
-    }
-  </thead>
-  <tbody>
-    @for (row of table.getRowModel().rows; track row.id) {
-      <tr>
-        @for (cell of row.getVisibleCells(); track cell.id) {
-          <td>
-            <ng-container *flexRender="cell.column.columnDef.cell; props: cell.getContext()"></ng-container>
-          </td>
-        }
-      </tr>
-    }
-  </tbody>
-</table>
-  \`,
-})
-export class AppComponent {
-  data = signal<Person[]>([{ id: 1, name: 'Ada' }])
-
-  columns: ColumnDef<Person>[] = [
-    { accessorKey: 'name', header: 'Name' },
-  ]
-
-  table = createAngularTable(() => ({
-    data: this.data(),
-    columns: this.columns,
-    getCoreRowModel: getCoreRowModel(),
-  }))
-}`,
-    },
-    solid: {
-      lang: 'tsx',
-      code: `import { createSolidTable, getCoreRowModel, flexRender } from '@tanstack/solid-table'
-
-const data = [{ id: 1, name: 'Ada' }]
-const columns = [{ accessorKey: 'name', header: 'Name' }]
-
-export default function SimpleTable() {
-  const table = createSolidTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-
-  return (
-    <table>
-      <thead>
-        {table.getHeaderGroups().map((hg) => (
-          <tr>
-            {hg.headers.map((header) => (
-              <th>{flexRender(header.column.columnDef.header, header.getContext())}</th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {table.getRowModel().rows.map((row) => (
-          <tr>
-            {row.getVisibleCells().map((cell) => (
-              <td>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-}`,
-    },
-    vue: {
-      lang: 'vue',
-      code: `<script setup lang="ts">
-import { useVueTable, getCoreRowModel, flexRender } from '@tanstack/vue-table'
-
-const data = [{ id: 1, name: 'Ada' }]
-const columns = [{ accessorKey: 'name', header: 'Name' }]
-const table = useVueTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-</script>
-
-<template>
-  <table>
-    <thead>
-      <tr v-for="hg in table.getHeaderGroups()" :key="hg.id">
-        <th v-for="header in hg.headers" :key="header.id">
-          {{ flexRender(header.column.columnDef.header, header.getContext()) }}
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="row in table.getRowModel().rows" :key="row.id">
-        <td v-for="cell in row.getVisibleCells()" :key="cell.id">
-          {{ flexRender(cell.column.columnDef.cell, cell.getContext()) }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</template>`,
-    },
-    svelte: {
-      lang: 'svelte',
-      code: `<script lang="ts">
-  import { createSvelteTable, getCoreRowModel, flexRender } from '@tanstack/svelte-table'
-
-  const data = [{ id: 1, name: 'Ada' }]
-  const columns = [{ accessorKey: 'name', header: 'Name' }]
-  const table = createSvelteTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-</script>
-
-<table>
-  <thead>
-    {#each table.getHeaderGroups() as hg}
-      <tr>
-        {#each hg.headers as header}
-          <th>{flexRender(header.column.columnDef.header, header.getContext())}</th>
-        {/each}
-      </tr>
-    {/each}
-  </thead>
-  <tbody>
-    {#each table.getRowModel().rows as row}
-      <tr>
-        {#each row.getVisibleCells() as cell}
-          <td>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-        {/each}
-      </tr>
-    {/each}
-  </tbody>
-</table>`,
-    },
-    lit: {
-      lang: 'ts',
-      code: `import { LitElement, customElement, html } from 'lit'
-import { createLitTable, getCoreRowModel, flexRender } from '@tanstack/lit-table'
-
-const data = [{ id: 1, name: 'Ada' }]
-const columns = [{ accessorKey: 'name', header: 'Name' }]
-
-@customElement('simple-table')
-export class SimpleTable extends LitElement {
-  table = createLitTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-
-  render() {
-    return html\`<table>
-      <thead>
-        \${this.table.getHeaderGroups().map((hg) => html\`<tr>
-          \${hg.headers.map((header) => html\`<th>\${flexRender(header.column.columnDef.header, header.getContext())}</th>\`)}
-        </tr>\`)}
-      </thead>
-      <tbody>
-        \${this.table.getRowModel().rows.map((row) => html\`<tr>
-          \${row.getVisibleCells().map((cell) => html\`<td>\${flexRender(cell.column.columnDef.cell, cell.getContext())}</td>\`)}
-        </tr>\`)}
-      </tbody>
-    </table>\`
-  }
-}`,
-    },
-    qwik: {
-      lang: 'tsx',
-      code: `import { component$ } from '@builder.io/qwik'
-import { createQwikTable, getCoreRowModel, flexRender } from '@tanstack/qwik-table'
-
-const data = [{ id: 1, name: 'Ada' }]
-const columns = [{ accessorKey: 'name', header: 'Name' }]
-
-export default component$(() => {
-  const table = createQwikTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-  return (
-    <table>
-      <thead>
-        {table.getHeaderGroups().map((hg) => (
-          <tr>
-            {hg.headers.map((header) => (
-              <th>{flexRender(header.column.columnDef.header, header.getContext())}</th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {table.getRowModel().rows.map((row) => (
-          <tr>
-            {row.getVisibleCells().map((cell) => (
-              <td>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-})`,
-    },
-    vanilla: {
-      lang: 'ts',
-      code: `import { createTable, getCoreRowModel, flexRender } from '@tanstack/table-core'
-
-const data = [{ id: 1, name: 'Ada' }]
-const columns = [{ accessorKey: 'name', header: 'Name' }]
-
-const table = createTable({ data, columns, getCoreRowModel: getCoreRowModel() })
-
-const thead = document.querySelector('thead')!
-table.getHeaderGroups().forEach((hg) => {
-  const tr = document.createElement('tr')
-  hg.headers.forEach((header) => {
-    const th = document.createElement('th')
-    th.textContent = String(flexRender(header.column.columnDef.header, header.getContext()))
-    tr.appendChild(th)
-  })
-  thead.appendChild(tr)
-})
-
-const tbody = document.querySelector('tbody')!
-table.getRowModel().rows.forEach((row) => {
-  const tr = document.createElement('tr')
-  row.getVisibleCells().forEach((cell) => {
-    const td = document.createElement('td')
-    td.textContent = String(flexRender(cell.column.columnDef.cell, cell.getContext()))
-    tr.appendChild(td)
-  })
-  tbody.appendChild(tr)
-})`,
-    },
-  },
-  renderFallback: (framework) => {
-    return (
-      <div className="p-6 text-center text-lg w-full bg-gray-900 text-white">
-        Looking for the <strong>@tanstack/{framework}-table</strong> example? We
-        could use your help to build the{' '}
-        <strong>@tanstack/{framework}-table</strong> adapter! Join the{' '}
-        <a
-          href="https://tlinz.com/discord"
-          className="text-teal-400 font-bold underline"
-        >
-          TanStack Discord Server
-        </a>{' '}
-        and let's get to work!
-      </div>
-    )
   },
 }
 

--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -747,7 +747,7 @@ export const devtools: LibrarySlim = {
   bgRadial:
     'from-black via-gray-600/50 to-transparent dark:from-gray-100 dark:via-gray-400/50',
   repo: 'tanstack/devtools',
-  frameworks: ['react', 'preact', 'solid', 'vanilla'],
+  frameworks: ['react', 'preact', 'solid', 'vue', 'angular', 'vanilla'],
   corePackageName: '@tanstack/devtools',
   npmPackageNames: ['@tanstack/devtools', '@tanstack/react-devtools'],
   latestVersion: 'v0',
@@ -787,9 +787,9 @@ export const mcp: LibrarySlim = {
   availableVersions: ['v1'],
   visible: false,
   handleRedirects: (href: string) => {
-    // All /mcp routes redirect to CLI MCP docs
+    // All /mcp routes redirect to the CLI MCP migration guide
     if (/\/mcp(\/|$)/.test(href)) {
-      throw redirect({ href: '/cli/latest/docs/mcp/overview' })
+      throw redirect({ href: '/cli/latest/docs/mcp-migration' })
     }
   },
 }
@@ -799,9 +799,9 @@ export const cli: LibrarySlim = {
   name: 'TanStack CLI',
   cardStyles: 'text-indigo-500 dark:text-indigo-400 hover:border-current',
   to: '/cli',
-  tagline: 'CLI, MCP server, and AI toolkit for TanStack',
+  tagline: 'CLI and project scaffolding toolkit for TanStack',
   description:
-    'A CLI, MCP server, and AI toolkit for TanStack. Create and customize TanStack Start apps, search docs, integrate with AI agents, and more.',
+    'A CLI toolkit for TanStack. Create and customize TanStack Start apps, search docs, inspect add-ons, and generate project changes with current TanStack context.',
   badge: 'alpha',
   bgStyle: 'bg-indigo-500',
   borderStyle: 'border-indigo-500/50',

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -103,7 +103,7 @@ export const getTanstackDocsConfig = createServerFn({ method: 'GET' })
       }
 
       if (!config) {
-        throw new Error(`Repo's ${docsRoot}/config.json was not found!`)
+        return getEmptyConfig()
       }
 
       try {


### PR DESCRIPTION
## Summary

- Replaces unsupported or misleading landing-page API snippets with docs-backed examples across TanStack library pages.
- Simplifies shared landing code examples to safer React examples where multi-framework snippets were inaccurate.
- Updates CLI/MCP, Devtools, AI, Config, Form, Store, Pacer, Query, Ranger, Router, DB, Intent, Hotkeys, and Workflow copy or examples for current docs alignment.
- Allows landing pages to render when a library docs config is missing by falling back to an empty docs config.

## Validation

- `pnpm test`
- Browser smoke-tested all current library landing routes locally; each rendered without the app error boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated landing page code examples and content across 14 products with current API patterns and best practices.
  * Expanded Devtools framework coverage to include Vue and Angular.
  * Updated MCP migration guide references.

* **Bug Fixes**
  * Improved configuration error handling for missing config files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->