### PR TITLE
Code split library landing routes

### DIFF
--- a/src/components/landing/AiLanding.tsx
+++ b/src/components/landing/AiLanding.tsx
@@ -24,7 +24,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'

--- a/src/components/landing/CliLanding.tsx
+++ b/src/components/landing/CliLanding.tsx
@@ -22,7 +22,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('cli')

--- a/src/components/landing/ConfigLanding.tsx
+++ b/src/components/landing/ConfigLanding.tsx
@@ -23,7 +23,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('config')

--- a/src/components/landing/DbLanding.tsx
+++ b/src/components/landing/DbLanding.tsx
@@ -24,7 +24,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'

--- a/src/components/landing/DevtoolsLanding.tsx
+++ b/src/components/landing/DevtoolsLanding.tsx
@@ -24,7 +24,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('devtools')

--- a/src/components/landing/FormLanding.tsx
+++ b/src/components/landing/FormLanding.tsx
@@ -26,7 +26,7 @@ import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
 import { formProject } from '~/libraries/form'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'

--- a/src/components/landing/HotkeysLanding.tsx
+++ b/src/components/landing/HotkeysLanding.tsx
@@ -21,7 +21,7 @@ import { LazySponsorSection } from '~/components/LazySponsorSection'
 import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('hotkeys')

--- a/src/components/landing/IntentLanding.tsx
+++ b/src/components/landing/IntentLanding.tsx
@@ -30,7 +30,7 @@ import {
   intentSkillHistoryQueryOptions,
   intentStatsQueryOptions,
 } from '~/queries/intent'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 import type { SkillHistoryEntry } from '~/utils/intent.functions'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'

--- a/src/components/landing/PacerLanding.tsx
+++ b/src/components/landing/PacerLanding.tsx
@@ -24,7 +24,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('pacer')

--- a/src/components/landing/QueryLanding.tsx
+++ b/src/components/landing/QueryLanding.tsx
@@ -29,7 +29,7 @@ import LandingPageGad from '~/components/LandingPageGad'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
 import { getLibrary } from '~/libraries'
 import { queryProject } from '~/libraries/query'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'

--- a/src/components/landing/RangerLanding.tsx
+++ b/src/components/landing/RangerLanding.tsx
@@ -23,7 +23,7 @@ import { LibraryWordmark } from '~/components/LibraryWordmark'
 import { StackBlitzSection } from '~/components/StackBlitzSection'
 import { getBranch, getLibrary } from '~/libraries'
 import { rangerProject } from '~/libraries/ranger'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('ranger')

--- a/src/components/landing/StoreLanding.tsx
+++ b/src/components/landing/StoreLanding.tsx
@@ -23,7 +23,7 @@ import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('store')

--- a/src/components/landing/TableLanding.tsx
+++ b/src/components/landing/TableLanding.tsx
@@ -44,7 +44,7 @@ import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
 import { tableProject } from '~/libraries/table'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'

--- a/src/components/landing/VirtualLanding.tsx
+++ b/src/components/landing/VirtualLanding.tsx
@@ -34,7 +34,7 @@ import { LibraryWordmark } from '~/components/LibraryWordmark'
 import LandingPageGad from '~/components/LandingPageGad'
 import { getLibrary } from '~/libraries'
 import { virtualProject } from '~/libraries/virtual'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 
 import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'

--- a/src/components/landing/WorkflowLanding.tsx
+++ b/src/components/landing/WorkflowLanding.tsx
@@ -23,7 +23,7 @@ import { LazySponsorSection } from '~/components/LazySponsorSection'
 import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
 import { LibraryWordmark } from '~/components/LibraryWordmark'
 import { getLibrary } from '~/libraries'
-import type { LandingComponentProps } from '~/routes/$libraryId/$version'
+import type { LandingComponentProps } from '~/routes/-library-landing'
 
 import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('workflow')

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -79,9 +79,26 @@ import { Route as AccountIntegrationsRouteImport } from './routes/account/integr
 import { Route as AccountFeedbackRouteImport } from './routes/account/feedback'
 import { Route as DotwellKnownOauthAuthorizationServerRouteImport } from './routes/[.]well-known/oauth-authorization-server'
 import { Route as LibraryIdVersionRouteImport } from './routes/$libraryId/$version'
+import { Route as WorkflowVersionIndexRouteImport } from './routes/workflow.$version.index'
+import { Route as VirtualVersionIndexRouteImport } from './routes/virtual.$version.index'
+import { Route as TableVersionIndexRouteImport } from './routes/table.$version.index'
+import { Route as StoreVersionIndexRouteImport } from './routes/store.$version.index'
 import { Route as StatsNpmIndexRouteImport } from './routes/stats/npm/index'
+import { Route as StartVersionIndexRouteImport } from './routes/start.$version.index'
+import { Route as RouterVersionIndexRouteImport } from './routes/router.$version.index'
+import { Route as RangerVersionIndexRouteImport } from './routes/ranger.$version.index'
+import { Route as QueryVersionIndexRouteImport } from './routes/query.$version.index'
+import { Route as PacerVersionIndexRouteImport } from './routes/pacer.$version.index'
 import { Route as IntentRegistryIndexRouteImport } from './routes/intent/registry/index'
+import { Route as IntentVersionIndexRouteImport } from './routes/intent.$version.index'
+import { Route as HotkeysVersionIndexRouteImport } from './routes/hotkeys.$version.index'
+import { Route as FormVersionIndexRouteImport } from './routes/form.$version.index'
+import { Route as DevtoolsVersionIndexRouteImport } from './routes/devtools.$version.index'
+import { Route as DbVersionIndexRouteImport } from './routes/db.$version.index'
+import { Route as ConfigVersionIndexRouteImport } from './routes/config.$version.index'
+import { Route as CliVersionIndexRouteImport } from './routes/cli.$version.index'
 import { Route as ApiMcpIndexRouteImport } from './routes/api/mcp/index'
+import { Route as AiVersionIndexRouteImport } from './routes/ai.$version.index'
 import { Route as AdminShowcasesIndexRouteImport } from './routes/admin/showcases.index'
 import { Route as AdminRolesIndexRouteImport } from './routes/admin/roles.index'
 import { Route as AdminNotesIndexRouteImport } from './routes/admin/notes.index'
@@ -490,9 +507,54 @@ const LibraryIdVersionRoute = LibraryIdVersionRouteImport.update({
   path: '/$version',
   getParentRoute: () => LibraryIdRouteRoute,
 } as any)
+const WorkflowVersionIndexRoute = WorkflowVersionIndexRouteImport.update({
+  id: '/workflow/$version/',
+  path: '/workflow/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const VirtualVersionIndexRoute = VirtualVersionIndexRouteImport.update({
+  id: '/virtual/$version/',
+  path: '/virtual/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TableVersionIndexRoute = TableVersionIndexRouteImport.update({
+  id: '/table/$version/',
+  path: '/table/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StoreVersionIndexRoute = StoreVersionIndexRouteImport.update({
+  id: '/store/$version/',
+  path: '/store/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const StatsNpmIndexRoute = StatsNpmIndexRouteImport.update({
   id: '/stats/npm/',
   path: '/stats/npm/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StartVersionIndexRoute = StartVersionIndexRouteImport.update({
+  id: '/start/$version/',
+  path: '/start/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RouterVersionIndexRoute = RouterVersionIndexRouteImport.update({
+  id: '/router/$version/',
+  path: '/router/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RangerVersionIndexRoute = RangerVersionIndexRouteImport.update({
+  id: '/ranger/$version/',
+  path: '/ranger/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QueryVersionIndexRoute = QueryVersionIndexRouteImport.update({
+  id: '/query/$version/',
+  path: '/query/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PacerVersionIndexRoute = PacerVersionIndexRouteImport.update({
+  id: '/pacer/$version/',
+  path: '/pacer/$version/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IntentRegistryIndexRoute = IntentRegistryIndexRouteImport.update({
@@ -500,9 +562,49 @@ const IntentRegistryIndexRoute = IntentRegistryIndexRouteImport.update({
   path: '/intent/registry/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const IntentVersionIndexRoute = IntentVersionIndexRouteImport.update({
+  id: '/intent/$version/',
+  path: '/intent/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HotkeysVersionIndexRoute = HotkeysVersionIndexRouteImport.update({
+  id: '/hotkeys/$version/',
+  path: '/hotkeys/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FormVersionIndexRoute = FormVersionIndexRouteImport.update({
+  id: '/form/$version/',
+  path: '/form/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DevtoolsVersionIndexRoute = DevtoolsVersionIndexRouteImport.update({
+  id: '/devtools/$version/',
+  path: '/devtools/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DbVersionIndexRoute = DbVersionIndexRouteImport.update({
+  id: '/db/$version/',
+  path: '/db/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfigVersionIndexRoute = ConfigVersionIndexRouteImport.update({
+  id: '/config/$version/',
+  path: '/config/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CliVersionIndexRoute = CliVersionIndexRouteImport.update({
+  id: '/cli/$version/',
+  path: '/cli/$version/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMcpIndexRoute = ApiMcpIndexRouteImport.update({
   id: '/api/mcp/',
   path: '/api/mcp/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AiVersionIndexRoute = AiVersionIndexRouteImport.update({
+  id: '/ai/$version/',
+  path: '/ai/$version/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminShowcasesIndexRoute = AdminShowcasesIndexRouteImport.update({
@@ -917,9 +1019,26 @@ export interface FileRoutesByFullPath {
   '/admin/notes/': typeof AdminNotesIndexRoute
   '/admin/roles/': typeof AdminRolesIndexRoute
   '/admin/showcases/': typeof AdminShowcasesIndexRoute
+  '/ai/$version/': typeof AiVersionIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
+  '/cli/$version/': typeof CliVersionIndexRoute
+  '/config/$version/': typeof ConfigVersionIndexRoute
+  '/db/$version/': typeof DbVersionIndexRoute
+  '/devtools/$version/': typeof DevtoolsVersionIndexRoute
+  '/form/$version/': typeof FormVersionIndexRoute
+  '/hotkeys/$version/': typeof HotkeysVersionIndexRoute
+  '/intent/$version/': typeof IntentVersionIndexRoute
   '/intent/registry/': typeof IntentRegistryIndexRoute
+  '/pacer/$version/': typeof PacerVersionIndexRoute
+  '/query/$version/': typeof QueryVersionIndexRoute
+  '/ranger/$version/': typeof RangerVersionIndexRoute
+  '/router/$version/': typeof RouterVersionIndexRoute
+  '/start/$version/': typeof StartVersionIndexRoute
   '/stats/npm/': typeof StatsNpmIndexRoute
+  '/store/$version/': typeof StoreVersionIndexRoute
+  '/table/$version/': typeof TableVersionIndexRoute
+  '/virtual/$version/': typeof VirtualVersionIndexRoute
+  '/workflow/$version/': typeof WorkflowVersionIndexRoute
   '/$libraryId/$version/docs/$': typeof LibraryIdVersionDocsSplatRoute
   '/$libraryId/$version/docs/blog': typeof LibraryIdVersionDocsBlogRoute
   '/$libraryId/$version/docs/community-resources': typeof LibraryIdVersionDocsCommunityResourcesRoute
@@ -1038,9 +1157,26 @@ export interface FileRoutesByTo {
   '/admin/notes': typeof AdminNotesIndexRoute
   '/admin/roles': typeof AdminRolesIndexRoute
   '/admin/showcases': typeof AdminShowcasesIndexRoute
+  '/ai/$version': typeof AiVersionIndexRoute
   '/api/mcp': typeof ApiMcpIndexRoute
+  '/cli/$version': typeof CliVersionIndexRoute
+  '/config/$version': typeof ConfigVersionIndexRoute
+  '/db/$version': typeof DbVersionIndexRoute
+  '/devtools/$version': typeof DevtoolsVersionIndexRoute
+  '/form/$version': typeof FormVersionIndexRoute
+  '/hotkeys/$version': typeof HotkeysVersionIndexRoute
+  '/intent/$version': typeof IntentVersionIndexRoute
   '/intent/registry': typeof IntentRegistryIndexRoute
+  '/pacer/$version': typeof PacerVersionIndexRoute
+  '/query/$version': typeof QueryVersionIndexRoute
+  '/ranger/$version': typeof RangerVersionIndexRoute
+  '/router/$version': typeof RouterVersionIndexRoute
+  '/start/$version': typeof StartVersionIndexRoute
   '/stats/npm': typeof StatsNpmIndexRoute
+  '/store/$version': typeof StoreVersionIndexRoute
+  '/table/$version': typeof TableVersionIndexRoute
+  '/virtual/$version': typeof VirtualVersionIndexRoute
+  '/workflow/$version': typeof WorkflowVersionIndexRoute
   '/$libraryId/$version/docs/$': typeof LibraryIdVersionDocsSplatRoute
   '/$libraryId/$version/docs/blog': typeof LibraryIdVersionDocsBlogRoute
   '/$libraryId/$version/docs/community-resources': typeof LibraryIdVersionDocsCommunityResourcesRoute
@@ -1170,9 +1306,26 @@ export interface FileRoutesById {
   '/admin/notes/': typeof AdminNotesIndexRoute
   '/admin/roles/': typeof AdminRolesIndexRoute
   '/admin/showcases/': typeof AdminShowcasesIndexRoute
+  '/ai/$version/': typeof AiVersionIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
+  '/cli/$version/': typeof CliVersionIndexRoute
+  '/config/$version/': typeof ConfigVersionIndexRoute
+  '/db/$version/': typeof DbVersionIndexRoute
+  '/devtools/$version/': typeof DevtoolsVersionIndexRoute
+  '/form/$version/': typeof FormVersionIndexRoute
+  '/hotkeys/$version/': typeof HotkeysVersionIndexRoute
+  '/intent/$version/': typeof IntentVersionIndexRoute
   '/intent/registry/': typeof IntentRegistryIndexRoute
+  '/pacer/$version/': typeof PacerVersionIndexRoute
+  '/query/$version/': typeof QueryVersionIndexRoute
+  '/ranger/$version/': typeof RangerVersionIndexRoute
+  '/router/$version/': typeof RouterVersionIndexRoute
+  '/start/$version/': typeof StartVersionIndexRoute
   '/stats/npm/': typeof StatsNpmIndexRoute
+  '/store/$version/': typeof StoreVersionIndexRoute
+  '/table/$version/': typeof TableVersionIndexRoute
+  '/virtual/$version/': typeof VirtualVersionIndexRoute
+  '/workflow/$version/': typeof WorkflowVersionIndexRoute
   '/$libraryId/$version/docs/$': typeof LibraryIdVersionDocsSplatRoute
   '/$libraryId/$version/docs/blog': typeof LibraryIdVersionDocsBlogRoute
   '/$libraryId/$version/docs/community-resources': typeof LibraryIdVersionDocsCommunityResourcesRoute
@@ -1303,9 +1456,26 @@ export interface FileRouteTypes {
     | '/admin/notes/'
     | '/admin/roles/'
     | '/admin/showcases/'
+    | '/ai/$version/'
     | '/api/mcp/'
+    | '/cli/$version/'
+    | '/config/$version/'
+    | '/db/$version/'
+    | '/devtools/$version/'
+    | '/form/$version/'
+    | '/hotkeys/$version/'
+    | '/intent/$version/'
     | '/intent/registry/'
+    | '/pacer/$version/'
+    | '/query/$version/'
+    | '/ranger/$version/'
+    | '/router/$version/'
+    | '/start/$version/'
     | '/stats/npm/'
+    | '/store/$version/'
+    | '/table/$version/'
+    | '/virtual/$version/'
+    | '/workflow/$version/'
     | '/$libraryId/$version/docs/$'
     | '/$libraryId/$version/docs/blog'
     | '/$libraryId/$version/docs/community-resources'
@@ -1424,9 +1594,26 @@ export interface FileRouteTypes {
     | '/admin/notes'
     | '/admin/roles'
     | '/admin/showcases'
+    | '/ai/$version'
     | '/api/mcp'
+    | '/cli/$version'
+    | '/config/$version'
+    | '/db/$version'
+    | '/devtools/$version'
+    | '/form/$version'
+    | '/hotkeys/$version'
+    | '/intent/$version'
     | '/intent/registry'
+    | '/pacer/$version'
+    | '/query/$version'
+    | '/ranger/$version'
+    | '/router/$version'
+    | '/start/$version'
     | '/stats/npm'
+    | '/store/$version'
+    | '/table/$version'
+    | '/virtual/$version'
+    | '/workflow/$version'
     | '/$libraryId/$version/docs/$'
     | '/$libraryId/$version/docs/blog'
     | '/$libraryId/$version/docs/community-resources'
@@ -1555,9 +1742,26 @@ export interface FileRouteTypes {
     | '/admin/notes/'
     | '/admin/roles/'
     | '/admin/showcases/'
+    | '/ai/$version/'
     | '/api/mcp/'
+    | '/cli/$version/'
+    | '/config/$version/'
+    | '/db/$version/'
+    | '/devtools/$version/'
+    | '/form/$version/'
+    | '/hotkeys/$version/'
+    | '/intent/$version/'
     | '/intent/registry/'
+    | '/pacer/$version/'
+    | '/query/$version/'
+    | '/ranger/$version/'
+    | '/router/$version/'
+    | '/start/$version/'
     | '/stats/npm/'
+    | '/store/$version/'
+    | '/table/$version/'
+    | '/virtual/$version/'
+    | '/workflow/$version/'
     | '/$libraryId/$version/docs/$'
     | '/$libraryId/$version/docs/blog'
     | '/$libraryId/$version/docs/community-resources'
@@ -1648,9 +1852,26 @@ export interface RootRouteChildren {
   IntentRegistryPackageNameRoute: typeof IntentRegistryPackageNameRouteWithChildren
   ShowcaseEditIdRoute: typeof ShowcaseEditIdRoute
   StatsNpmPackagesRoute: typeof StatsNpmPackagesRoute
+  AiVersionIndexRoute: typeof AiVersionIndexRoute
   ApiMcpIndexRoute: typeof ApiMcpIndexRoute
+  CliVersionIndexRoute: typeof CliVersionIndexRoute
+  ConfigVersionIndexRoute: typeof ConfigVersionIndexRoute
+  DbVersionIndexRoute: typeof DbVersionIndexRoute
+  DevtoolsVersionIndexRoute: typeof DevtoolsVersionIndexRoute
+  FormVersionIndexRoute: typeof FormVersionIndexRoute
+  HotkeysVersionIndexRoute: typeof HotkeysVersionIndexRoute
+  IntentVersionIndexRoute: typeof IntentVersionIndexRoute
   IntentRegistryIndexRoute: typeof IntentRegistryIndexRoute
+  PacerVersionIndexRoute: typeof PacerVersionIndexRoute
+  QueryVersionIndexRoute: typeof QueryVersionIndexRoute
+  RangerVersionIndexRoute: typeof RangerVersionIndexRoute
+  RouterVersionIndexRoute: typeof RouterVersionIndexRoute
+  StartVersionIndexRoute: typeof StartVersionIndexRoute
   StatsNpmIndexRoute: typeof StatsNpmIndexRoute
+  StoreVersionIndexRoute: typeof StoreVersionIndexRoute
+  TableVersionIndexRoute: typeof TableVersionIndexRoute
+  VirtualVersionIndexRoute: typeof VirtualVersionIndexRoute
+  WorkflowVersionIndexRoute: typeof WorkflowVersionIndexRoute
   ApiAuthCallbackProviderRoute: typeof ApiAuthCallbackProviderRoute
   ApiAuthCliCreateTicketRoute: typeof ApiAuthCliCreateTicketRoute
   ApiBuilderDeployCheckNameRoute: typeof ApiBuilderDeployCheckNameRoute
@@ -2150,11 +2371,74 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LibraryIdVersionRouteImport
       parentRoute: typeof LibraryIdRouteRoute
     }
+    '/workflow/$version/': {
+      id: '/workflow/$version/'
+      path: '/workflow/$version'
+      fullPath: '/workflow/$version/'
+      preLoaderRoute: typeof WorkflowVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/virtual/$version/': {
+      id: '/virtual/$version/'
+      path: '/virtual/$version'
+      fullPath: '/virtual/$version/'
+      preLoaderRoute: typeof VirtualVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/table/$version/': {
+      id: '/table/$version/'
+      path: '/table/$version'
+      fullPath: '/table/$version/'
+      preLoaderRoute: typeof TableVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/store/$version/': {
+      id: '/store/$version/'
+      path: '/store/$version'
+      fullPath: '/store/$version/'
+      preLoaderRoute: typeof StoreVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/stats/npm/': {
       id: '/stats/npm/'
       path: '/stats/npm'
       fullPath: '/stats/npm/'
       preLoaderRoute: typeof StatsNpmIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/start/$version/': {
+      id: '/start/$version/'
+      path: '/start/$version'
+      fullPath: '/start/$version/'
+      preLoaderRoute: typeof StartVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/router/$version/': {
+      id: '/router/$version/'
+      path: '/router/$version'
+      fullPath: '/router/$version/'
+      preLoaderRoute: typeof RouterVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ranger/$version/': {
+      id: '/ranger/$version/'
+      path: '/ranger/$version'
+      fullPath: '/ranger/$version/'
+      preLoaderRoute: typeof RangerVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/query/$version/': {
+      id: '/query/$version/'
+      path: '/query/$version'
+      fullPath: '/query/$version/'
+      preLoaderRoute: typeof QueryVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pacer/$version/': {
+      id: '/pacer/$version/'
+      path: '/pacer/$version'
+      fullPath: '/pacer/$version/'
+      preLoaderRoute: typeof PacerVersionIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/intent/registry/': {
@@ -2164,11 +2448,67 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IntentRegistryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/intent/$version/': {
+      id: '/intent/$version/'
+      path: '/intent/$version'
+      fullPath: '/intent/$version/'
+      preLoaderRoute: typeof IntentVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hotkeys/$version/': {
+      id: '/hotkeys/$version/'
+      path: '/hotkeys/$version'
+      fullPath: '/hotkeys/$version/'
+      preLoaderRoute: typeof HotkeysVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/form/$version/': {
+      id: '/form/$version/'
+      path: '/form/$version'
+      fullPath: '/form/$version/'
+      preLoaderRoute: typeof FormVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/devtools/$version/': {
+      id: '/devtools/$version/'
+      path: '/devtools/$version'
+      fullPath: '/devtools/$version/'
+      preLoaderRoute: typeof DevtoolsVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/db/$version/': {
+      id: '/db/$version/'
+      path: '/db/$version'
+      fullPath: '/db/$version/'
+      preLoaderRoute: typeof DbVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/config/$version/': {
+      id: '/config/$version/'
+      path: '/config/$version'
+      fullPath: '/config/$version/'
+      preLoaderRoute: typeof ConfigVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cli/$version/': {
+      id: '/cli/$version/'
+      path: '/cli/$version'
+      fullPath: '/cli/$version/'
+      preLoaderRoute: typeof CliVersionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/mcp/': {
       id: '/api/mcp/'
       path: '/api/mcp'
       fullPath: '/api/mcp/'
       preLoaderRoute: typeof ApiMcpIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ai/$version/': {
+      id: '/ai/$version/'
+      path: '/ai/$version'
+      fullPath: '/ai/$version/'
+      preLoaderRoute: typeof AiVersionIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/showcases/': {
@@ -2856,9 +3196,26 @@ const rootRouteChildren: RootRouteChildren = {
   IntentRegistryPackageNameRoute: IntentRegistryPackageNameRouteWithChildren,
   ShowcaseEditIdRoute: ShowcaseEditIdRoute,
   StatsNpmPackagesRoute: StatsNpmPackagesRoute,
+  AiVersionIndexRoute: AiVersionIndexRoute,
   ApiMcpIndexRoute: ApiMcpIndexRoute,
+  CliVersionIndexRoute: CliVersionIndexRoute,
+  ConfigVersionIndexRoute: ConfigVersionIndexRoute,
+  DbVersionIndexRoute: DbVersionIndexRoute,
+  DevtoolsVersionIndexRoute: DevtoolsVersionIndexRoute,
+  FormVersionIndexRoute: FormVersionIndexRoute,
+  HotkeysVersionIndexRoute: HotkeysVersionIndexRoute,
+  IntentVersionIndexRoute: IntentVersionIndexRoute,
   IntentRegistryIndexRoute: IntentRegistryIndexRoute,
+  PacerVersionIndexRoute: PacerVersionIndexRoute,
+  QueryVersionIndexRoute: QueryVersionIndexRoute,
+  RangerVersionIndexRoute: RangerVersionIndexRoute,
+  RouterVersionIndexRoute: RouterVersionIndexRoute,
+  StartVersionIndexRoute: StartVersionIndexRoute,
   StatsNpmIndexRoute: StatsNpmIndexRoute,
+  StoreVersionIndexRoute: StoreVersionIndexRoute,
+  TableVersionIndexRoute: TableVersionIndexRoute,
+  VirtualVersionIndexRoute: VirtualVersionIndexRoute,
+  WorkflowVersionIndexRoute: WorkflowVersionIndexRoute,
   ApiAuthCallbackProviderRoute: ApiAuthCallbackProviderRoute,
   ApiAuthCliCreateTicketRoute: ApiAuthCliCreateTicketRoute,
   ApiBuilderDeployCheckNameRoute: ApiBuilderDeployCheckNameRoute,
@@ -2868,13 +3225,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/src/routes/$libraryId/$version.index.tsx
+++ b/src/routes/$libraryId/$version.index.tsx
@@ -1,186 +1,62 @@
-import type { ComponentType } from 'react'
-import {
-  Link,
-  createFileRoute,
-  notFound,
-  redirect,
-} from '@tanstack/react-router'
-import AiLanding from '~/components/landing/AiLanding'
-import CliLanding from '~/components/landing/CliLanding'
-import ConfigLanding from '~/components/landing/ConfigLanding'
-import DbLanding from '~/components/landing/DbLanding'
-import DevtoolsLanding from '~/components/landing/DevtoolsLanding'
-import FormLanding from '~/components/landing/FormLanding'
-import HotkeysLanding from '~/components/landing/HotkeysLanding'
-import IntentLanding from '~/components/landing/IntentLanding'
-import PacerLanding from '~/components/landing/PacerLanding'
-import QueryLanding from '~/components/landing/QueryLanding'
-import RangerLanding from '~/components/landing/RangerLanding'
-import RouterLanding from '~/components/landing/RouterLanding'
-import StartLanding from '~/components/landing/StartLanding'
-import StoreLanding from '~/components/landing/StoreLanding'
-import TableLanding from '~/components/landing/TableLanding'
-import VirtualLanding from '~/components/landing/VirtualLanding'
-import WorkflowLanding from '~/components/landing/WorkflowLanding'
-import { DocsLayout } from '~/components/DocsLayout'
-import { RedirectVersionBanner } from '~/components/RedirectVersionBanner'
-import { Scarf } from '~/components/Scarf'
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router'
 import { findLibrary } from '~/libraries'
-import type { LibraryId } from '~/libraries'
-import { loadLibraryConfig, validateLibraryVersion } from '../-library-landing'
-import type { LandingComponentProps } from '../-library-landing'
-import { fetchLandingCodeExample } from '~/utils/landing-code-example.functions'
-import { seo } from '~/utils/seo'
-import { ogImageUrl } from '~/utils/og'
-import { stackBlitzEmbedHeaders } from '~/utils/stackblitz-embed'
-
-type LibraryLandingConfig = {
-  LandingComponent: ComponentType<LandingComponentProps>
-  hasStackBlitzEmbed?: boolean
-}
-
-const libraryLandingConfigs: Partial<Record<LibraryId, LibraryLandingConfig>> =
-  {
-    ai: { LandingComponent: AiLanding },
-    cli: { LandingComponent: CliLanding },
-    config: { LandingComponent: ConfigLanding },
-    db: { LandingComponent: DbLanding },
-    devtools: { LandingComponent: DevtoolsLanding },
-    form: { LandingComponent: FormLanding, hasStackBlitzEmbed: true },
-    hotkeys: { LandingComponent: HotkeysLanding },
-    intent: { LandingComponent: IntentLanding },
-    pacer: { LandingComponent: PacerLanding },
-    query: { LandingComponent: QueryLanding, hasStackBlitzEmbed: true },
-    ranger: { LandingComponent: RangerLanding, hasStackBlitzEmbed: true },
-    router: { LandingComponent: RouterLanding, hasStackBlitzEmbed: true },
-    start: { LandingComponent: StartLanding },
-    store: { LandingComponent: StoreLanding },
-    table: { LandingComponent: TableLanding, hasStackBlitzEmbed: true },
-    virtual: { LandingComponent: VirtualLanding, hasStackBlitzEmbed: true },
-    workflow: { LandingComponent: WorkflowLanding },
-  }
-
-function getLibraryLandingConfig(libraryId: string) {
-  const library = findLibrary(libraryId)
-
-  if (!library) {
-    throw notFound()
-  }
-
-  const landingConfig = libraryLandingConfigs[library.id]
-
-  if (!landingConfig) {
-    throw notFound()
-  }
-
-  return { landingConfig, library }
-}
+import { validateLibraryVersion } from '../-library-landing'
 
 export const Route = createFileRoute('/$libraryId/$version/')({
-  staleTime: 1000 * 60 * 5,
-  beforeLoad: (ctx) => {
-    const { library } = getLibraryLandingConfig(ctx.params.libraryId)
+  beforeLoad: ({ params, location }) => {
+    const library = findLibrary(params.libraryId)
 
-    library.handleRedirects?.(ctx.location.href)
+    if (!library) {
+      throw notFound()
+    }
 
-    validateLibraryVersion(library.id, ctx.params.version, () => {
+    library.handleRedirects?.(location.href)
+
+    validateLibraryVersion(library.id, params.version, () => {
       throw redirect({ href: `/${library.id}/latest` })
     })
-  },
-  loader: async ({ params }) => {
-    const { library } = getLibraryLandingConfig(params.libraryId)
 
-    const [config, landingCodeExample] = await Promise.all([
-      loadLibraryConfig(library.id, params.version),
-      fetchLandingCodeExample({
-        data: {
-          libraryId: library.id,
-        },
-      }),
-    ])
-
-    return {
-      config,
-      landingCodeExampleRsc: landingCodeExample?.contentRsc ?? null,
-    }
+    redirectToStaticLanding(library.id, params.version)
   },
-  head: ({ params }) => {
-    const { library } = getLibraryLandingConfig(params.libraryId)
-
-    return {
-      meta: seo({
-        title: library.name,
-        description: library.description,
-        image: ogImageUrl(library.id),
-        noindex: library.visible === false,
-      }),
-    }
-  },
-  headers: ({ params }) => {
-    const { landingConfig } = getLibraryLandingConfig(params.libraryId)
-
-    return landingConfig.hasStackBlitzEmbed ? stackBlitzEmbedHeaders : {}
-  },
-  staticData: {
-    Title: LibraryNavbarTitle,
-  },
-  component: LibraryVersionIndex,
 })
 
-function LibraryVersionIndex() {
-  const { libraryId, version } = Route.useParams()
-  const { config, landingCodeExampleRsc } = Route.useLoaderData()
-  const { landingConfig, library } = getLibraryLandingConfig(libraryId)
-  const { LandingComponent } = landingConfig
-
-  if (!config) {
-    throw notFound()
+function redirectToStaticLanding(libraryId: string, version: string) {
+  switch (libraryId) {
+    case 'ai':
+      throw redirect({ to: '/ai/$version', params: { version } })
+    case 'cli':
+      throw redirect({ to: '/cli/$version', params: { version } })
+    case 'config':
+      throw redirect({ to: '/config/$version', params: { version } })
+    case 'db':
+      throw redirect({ to: '/db/$version', params: { version } })
+    case 'devtools':
+      throw redirect({ to: '/devtools/$version', params: { version } })
+    case 'form':
+      throw redirect({ to: '/form/$version', params: { version } })
+    case 'hotkeys':
+      throw redirect({ to: '/hotkeys/$version', params: { version } })
+    case 'intent':
+      throw redirect({ to: '/intent/$version', params: { version } })
+    case 'pacer':
+      throw redirect({ to: '/pacer/$version', params: { version } })
+    case 'query':
+      throw redirect({ to: '/query/$version', params: { version } })
+    case 'ranger':
+      throw redirect({ to: '/ranger/$version', params: { version } })
+    case 'router':
+      throw redirect({ to: '/router/$version', params: { version } })
+    case 'start':
+      throw redirect({ to: '/start/$version', params: { version } })
+    case 'store':
+      throw redirect({ to: '/store/$version', params: { version } })
+    case 'table':
+      throw redirect({ to: '/table/$version', params: { version } })
+    case 'virtual':
+      throw redirect({ to: '/virtual/$version', params: { version } })
+    case 'workflow':
+      throw redirect({ to: '/workflow/$version', params: { version } })
+    default:
+      throw notFound()
   }
-
-  return (
-    <>
-      <DocsLayout
-        libraryId={library.id}
-        name={library.name.replace('TanStack ', '')}
-        version={version === 'latest' ? library.latestVersion : version}
-        colorFrom={library.accentColorFrom ?? library.colorFrom}
-        colorTo={library.accentColorTo ?? library.colorTo}
-        textColor={library.accentTextColor ?? library.textColor ?? ''}
-        config={config}
-        frameworks={library.frameworks}
-        versions={library.availableVersions}
-        repo={library.repo}
-        isLandingPage
-      >
-        <LandingComponent landingCodeExampleRsc={landingCodeExampleRsc} />
-      </DocsLayout>
-      <RedirectVersionBanner
-        version={version}
-        latestVersion={library.latestVersion}
-      />
-      {library.scarfId ? <Scarf id={library.scarfId} /> : null}
-    </>
-  )
-}
-
-function LibraryNavbarTitle() {
-  const { libraryId, version } = Route.useParams()
-  const { library } = getLibraryLandingConfig(libraryId)
-  const libraryName = library.name.replace('TanStack ', '')
-  const resolvedVersion = version === 'latest' ? library.latestVersion : version
-  const gradientText = `inline-block text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
-
-  return (
-    <Link
-      to="/$libraryId"
-      params={{ libraryId: library.id }}
-      className="relative whitespace-nowrap"
-    >
-      <span className={gradientText}>{libraryName}</span>{' '}
-      <span className="text-sm absolute right-0 top-0 font-normal normal-case">
-        {resolvedVersion}
-      </span>
-      <span className="text-sm opacity-0 normal-case">{resolvedVersion}</span>
-    </Link>
-  )
 }

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from 'react'
+import { Link, redirect } from '@tanstack/react-router'
+import { DocsLayout } from '~/components/DocsLayout'
+import { RedirectVersionBanner } from '~/components/RedirectVersionBanner'
+import { Scarf } from '~/components/Scarf'
+import { getLibrary } from '~/libraries'
+import type { LibraryId } from '~/libraries'
+import { fetchLandingCodeExample } from '~/utils/landing-code-example.functions'
+import type { ConfigSchema } from '~/utils/config'
+import { ogImageUrl } from '~/utils/og'
+import { seo } from '~/utils/seo'
+import { stackBlitzEmbedHeaders } from '~/utils/stackblitz-embed'
+import { loadLibraryConfig, validateLibraryVersion } from './-library-landing'
+import type { LandingLibraryId } from './-library-landing'
+
+const stackBlitzLandingLibraryIds = new Set<LibraryId>([
+  'form',
+  'query',
+  'ranger',
+  'router',
+  'table',
+  'virtual',
+])
+
+export const libraryLandingStaleTime = 1000 * 60 * 5
+
+export function beforeLoadLibraryLanding(
+  libraryId: LandingLibraryId,
+  version: string | undefined,
+  href: string,
+) {
+  const library = validateLibraryVersion(libraryId, version, () => {
+    throw redirect({ href: `/${libraryId}/latest` })
+  })
+
+  library.handleRedirects?.(href)
+}
+
+export async function loadLibraryLandingRouteData(
+  libraryId: LandingLibraryId,
+  version: string,
+) {
+  const [config, landingCodeExample] = await Promise.all([
+    loadLibraryConfig(libraryId, version),
+    fetchLandingCodeExample({
+      data: {
+        libraryId,
+      },
+    }),
+  ])
+
+  return {
+    config,
+    landingCodeExampleRsc: landingCodeExample?.contentRsc ?? null,
+  }
+}
+
+export function getLibraryLandingHead(libraryId: LandingLibraryId) {
+  const library = getLibrary(libraryId)
+
+  return {
+    meta: seo({
+      title: library.name,
+      description: library.description,
+      image: ogImageUrl(library.id),
+      noindex: library.visible === false,
+    }),
+  }
+}
+
+export function getLibraryLandingHeaders(libraryId: LandingLibraryId) {
+  return stackBlitzLandingLibraryIds.has(libraryId)
+    ? stackBlitzEmbedHeaders
+    : {}
+}
+
+export function LibraryLandingLayout({
+  children,
+  config,
+  libraryId,
+  version,
+}: {
+  children: ReactNode
+  config: ConfigSchema
+  libraryId: LandingLibraryId
+  version: string
+}) {
+  const library = getLibrary(libraryId)
+
+  return (
+    <>
+      <DocsLayout
+        libraryId={library.id}
+        name={library.name.replace('TanStack ', '')}
+        version={version === 'latest' ? library.latestVersion : version}
+        colorFrom={library.accentColorFrom ?? library.colorFrom}
+        colorTo={library.accentColorTo ?? library.colorTo}
+        textColor={library.accentTextColor ?? library.textColor ?? ''}
+        config={config}
+        frameworks={library.frameworks}
+        versions={library.availableVersions}
+        repo={library.repo}
+        isLandingPage
+      >
+        {children}
+      </DocsLayout>
+      <RedirectVersionBanner
+        version={version}
+        latestVersion={library.latestVersion}
+      />
+      {library.scarfId ? <Scarf id={library.scarfId} /> : null}
+    </>
+  )
+}
+
+export function LibraryNavbarTitle({
+  libraryId,
+  version,
+}: {
+  libraryId: LandingLibraryId
+  version: string
+}) {
+  const library = getLibrary(libraryId)
+  const libraryName = library.name.replace('TanStack ', '')
+  const resolvedVersion = version === 'latest' ? library.latestVersion : version
+  const gradientText = `inline-block text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
+
+  return (
+    <Link
+      to="/$libraryId"
+      params={{ libraryId: library.id }}
+      className="relative whitespace-nowrap"
+    >
+      <span className={gradientText}>{libraryName}</span>{' '}
+      <span className="text-sm absolute right-0 top-0 font-normal normal-case">
+        {resolvedVersion}
+      </span>
+      <span className="text-sm opacity-0 normal-case">{resolvedVersion}</span>
+    </Link>
+  )
+}

--- a/src/routes/-library-landing.tsx
+++ b/src/routes/-library-landing.tsx
@@ -8,6 +8,25 @@ export type LandingComponentProps = {
   landingCodeExampleRsc?: ReactNode
 }
 
+export type LandingLibraryId =
+  | 'ai'
+  | 'cli'
+  | 'config'
+  | 'db'
+  | 'devtools'
+  | 'form'
+  | 'hotkeys'
+  | 'intent'
+  | 'pacer'
+  | 'query'
+  | 'ranger'
+  | 'router'
+  | 'start'
+  | 'store'
+  | 'table'
+  | 'virtual'
+  | 'workflow'
+
 function getLibraryOrThrow(libraryId: string) {
   const library = findLibrary(libraryId)
 

--- a/src/routes/ai.$version.index.tsx
+++ b/src/routes/ai.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import AiLanding from '~/components/landing/AiLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/ai/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('ai', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('ai', params.version),
+  head: () => getLibraryLandingHead('ai'),
+  headers: () => getLibraryLandingHeaders('ai'),
+  staticData: {
+    Title: AiNavbarTitle,
+  },
+  component: AiLandingRoute,
+})
+
+function AiNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="ai" version={version} />
+}
+
+function AiLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="ai" version={version} config={config}>
+      <AiLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/cli.$version.index.tsx
+++ b/src/routes/cli.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import CliLanding from '~/components/landing/CliLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/cli/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('cli', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('cli', params.version),
+  head: () => getLibraryLandingHead('cli'),
+  headers: () => getLibraryLandingHeaders('cli'),
+  staticData: {
+    Title: CliNavbarTitle,
+  },
+  component: CliLandingRoute,
+})
+
+function CliNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="cli" version={version} />
+}
+
+function CliLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="cli" version={version} config={config}>
+      <CliLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/config.$version.index.tsx
+++ b/src/routes/config.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import ConfigLanding from '~/components/landing/ConfigLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/config/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('config', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('config', params.version),
+  head: () => getLibraryLandingHead('config'),
+  headers: () => getLibraryLandingHeaders('config'),
+  staticData: {
+    Title: ConfigNavbarTitle,
+  },
+  component: ConfigLandingRoute,
+})
+
+function ConfigNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="config" version={version} />
+}
+
+function ConfigLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="config" version={version} config={config}>
+      <ConfigLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/db.$version.index.tsx
+++ b/src/routes/db.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import DbLanding from '~/components/landing/DbLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/db/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('db', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('db', params.version),
+  head: () => getLibraryLandingHead('db'),
+  headers: () => getLibraryLandingHeaders('db'),
+  staticData: {
+    Title: DbNavbarTitle,
+  },
+  component: DbLandingRoute,
+})
+
+function DbNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="db" version={version} />
+}
+
+function DbLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="db" version={version} config={config}>
+      <DbLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/devtools.$version.index.tsx
+++ b/src/routes/devtools.$version.index.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+import DevtoolsLanding from '~/components/landing/DevtoolsLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/devtools/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('devtools', params.version, location.href)
+  },
+  loader: ({ params }) =>
+    loadLibraryLandingRouteData('devtools', params.version),
+  head: () => getLibraryLandingHead('devtools'),
+  headers: () => getLibraryLandingHeaders('devtools'),
+  staticData: {
+    Title: DevtoolsNavbarTitle,
+  },
+  component: DevtoolsLandingRoute,
+})
+
+function DevtoolsNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="devtools" version={version} />
+}
+
+function DevtoolsLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout
+      libraryId="devtools"
+      version={version}
+      config={config}
+    >
+      <DevtoolsLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/form.$version.index.tsx
+++ b/src/routes/form.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import FormLanding from '~/components/landing/FormLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/form/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('form', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('form', params.version),
+  head: () => getLibraryLandingHead('form'),
+  headers: () => getLibraryLandingHeaders('form'),
+  staticData: {
+    Title: FormNavbarTitle,
+  },
+  component: FormLandingRoute,
+})
+
+function FormNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="form" version={version} />
+}
+
+function FormLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="form" version={version} config={config}>
+      <FormLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/hotkeys.$version.index.tsx
+++ b/src/routes/hotkeys.$version.index.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router'
+import HotkeysLanding from '~/components/landing/HotkeysLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/hotkeys/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('hotkeys', params.version, location.href)
+  },
+  loader: ({ params }) =>
+    loadLibraryLandingRouteData('hotkeys', params.version),
+  head: () => getLibraryLandingHead('hotkeys'),
+  headers: () => getLibraryLandingHeaders('hotkeys'),
+  staticData: {
+    Title: HotkeysNavbarTitle,
+  },
+  component: HotkeysLandingRoute,
+})
+
+function HotkeysNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="hotkeys" version={version} />
+}
+
+function HotkeysLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="hotkeys" version={version} config={config}>
+      <HotkeysLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/intent.$version.index.tsx
+++ b/src/routes/intent.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import IntentLanding from '~/components/landing/IntentLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/intent/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('intent', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('intent', params.version),
+  head: () => getLibraryLandingHead('intent'),
+  headers: () => getLibraryLandingHeaders('intent'),
+  staticData: {
+    Title: IntentNavbarTitle,
+  },
+  component: IntentLandingRoute,
+})
+
+function IntentNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="intent" version={version} />
+}
+
+function IntentLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="intent" version={version} config={config}>
+      <IntentLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/pacer.$version.index.tsx
+++ b/src/routes/pacer.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import PacerLanding from '~/components/landing/PacerLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/pacer/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('pacer', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('pacer', params.version),
+  head: () => getLibraryLandingHead('pacer'),
+  headers: () => getLibraryLandingHeaders('pacer'),
+  staticData: {
+    Title: PacerNavbarTitle,
+  },
+  component: PacerLandingRoute,
+})
+
+function PacerNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="pacer" version={version} />
+}
+
+function PacerLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="pacer" version={version} config={config}>
+      <PacerLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/query.$version.index.tsx
+++ b/src/routes/query.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import QueryLanding from '~/components/landing/QueryLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/query/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('query', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('query', params.version),
+  head: () => getLibraryLandingHead('query'),
+  headers: () => getLibraryLandingHeaders('query'),
+  staticData: {
+    Title: QueryNavbarTitle,
+  },
+  component: QueryLandingRoute,
+})
+
+function QueryNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="query" version={version} />
+}
+
+function QueryLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="query" version={version} config={config}>
+      <QueryLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/ranger.$version.index.tsx
+++ b/src/routes/ranger.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import RangerLanding from '~/components/landing/RangerLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/ranger/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('ranger', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('ranger', params.version),
+  head: () => getLibraryLandingHead('ranger'),
+  headers: () => getLibraryLandingHeaders('ranger'),
+  staticData: {
+    Title: RangerNavbarTitle,
+  },
+  component: RangerLandingRoute,
+})
+
+function RangerNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="ranger" version={version} />
+}
+
+function RangerLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="ranger" version={version} config={config}>
+      <RangerLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/router.$version.index.tsx
+++ b/src/routes/router.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import RouterLanding from '~/components/landing/RouterLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/router/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('router', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('router', params.version),
+  head: () => getLibraryLandingHead('router'),
+  headers: () => getLibraryLandingHeaders('router'),
+  staticData: {
+    Title: RouterNavbarTitle,
+  },
+  component: RouterLandingRoute,
+})
+
+function RouterNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="router" version={version} />
+}
+
+function RouterLandingRoute() {
+  const { version } = Route.useParams()
+  const { config } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="router" version={version} config={config}>
+      <RouterLanding />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/start.$version.index.tsx
+++ b/src/routes/start.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import StartLanding from '~/components/landing/StartLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/start/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('start', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('start', params.version),
+  head: () => getLibraryLandingHead('start'),
+  headers: () => getLibraryLandingHeaders('start'),
+  staticData: {
+    Title: StartNavbarTitle,
+  },
+  component: StartLandingRoute,
+})
+
+function StartNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="start" version={version} />
+}
+
+function StartLandingRoute() {
+  const { version } = Route.useParams()
+  const { config } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="start" version={version} config={config}>
+      <StartLanding />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/store.$version.index.tsx
+++ b/src/routes/store.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import StoreLanding from '~/components/landing/StoreLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/store/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('store', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('store', params.version),
+  head: () => getLibraryLandingHead('store'),
+  headers: () => getLibraryLandingHeaders('store'),
+  staticData: {
+    Title: StoreNavbarTitle,
+  },
+  component: StoreLandingRoute,
+})
+
+function StoreNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="store" version={version} />
+}
+
+function StoreLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="store" version={version} config={config}>
+      <StoreLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/table.$version.index.tsx
+++ b/src/routes/table.$version.index.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import TableLanding from '~/components/landing/TableLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/table/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('table', params.version, location.href)
+  },
+  loader: ({ params }) => loadLibraryLandingRouteData('table', params.version),
+  head: () => getLibraryLandingHead('table'),
+  headers: () => getLibraryLandingHeaders('table'),
+  staticData: {
+    Title: TableNavbarTitle,
+  },
+  component: TableLandingRoute,
+})
+
+function TableNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="table" version={version} />
+}
+
+function TableLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="table" version={version} config={config}>
+      <TableLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/virtual.$version.index.tsx
+++ b/src/routes/virtual.$version.index.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router'
+import VirtualLanding from '~/components/landing/VirtualLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/virtual/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('virtual', params.version, location.href)
+  },
+  loader: ({ params }) =>
+    loadLibraryLandingRouteData('virtual', params.version),
+  head: () => getLibraryLandingHead('virtual'),
+  headers: () => getLibraryLandingHeaders('virtual'),
+  staticData: {
+    Title: VirtualNavbarTitle,
+  },
+  component: VirtualLandingRoute,
+})
+
+function VirtualNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="virtual" version={version} />
+}
+
+function VirtualLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout libraryId="virtual" version={version} config={config}>
+      <VirtualLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}

--- a/src/routes/workflow.$version.index.tsx
+++ b/src/routes/workflow.$version.index.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+import WorkflowLanding from '~/components/landing/WorkflowLanding'
+import {
+  LibraryLandingLayout,
+  LibraryNavbarTitle,
+  beforeLoadLibraryLanding,
+  getLibraryLandingHead,
+  getLibraryLandingHeaders,
+  libraryLandingStaleTime,
+  loadLibraryLandingRouteData,
+} from './-library-landing-route'
+
+export const Route = createFileRoute('/workflow/$version/')({
+  staleTime: libraryLandingStaleTime,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('workflow', params.version, location.href)
+  },
+  loader: ({ params }) =>
+    loadLibraryLandingRouteData('workflow', params.version),
+  head: () => getLibraryLandingHead('workflow'),
+  headers: () => getLibraryLandingHeaders('workflow'),
+  staticData: {
+    Title: WorkflowNavbarTitle,
+  },
+  component: WorkflowLandingRoute,
+})
+
+function WorkflowNavbarTitle() {
+  const { version } = Route.useParams()
+
+  return <LibraryNavbarTitle libraryId="workflow" version={version} />
+}
+
+function WorkflowLandingRoute() {
+  const { version } = Route.useParams()
+  const { config, landingCodeExampleRsc } = Route.useLoaderData()
+
+  return (
+    <LibraryLandingLayout
+      libraryId="workflow"
+      version={version}
+      config={config}
+    >
+      <WorkflowLanding landingCodeExampleRsc={landingCodeExampleRsc} />
+    </LibraryLandingLayout>
+  )
+}


### PR DESCRIPTION
## What changed

- Added concrete landing routes for each library, so each landing page imports only its own landing component.
- Moved shared landing route behavior into a route-only helper and kept the existing library version helper lightweight for docs routes.
- Left the dynamic landing fallback as a redirect into the new static route IDs.
- Regenerated the TanStack Router route tree and moved landing prop types off the dynamic route module.

## Why

The previous dynamic landing route imported every landing component up front. With real per-library routes, TanStack Router's built-in route code splitting can split those landing chunks normally.

## Validation

- pnpm test
- Commit hook ran pnpm run format && pnpm run test

Lint still reports the existing warnings in admin/shop files, but exits successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized landing page routing infrastructure by consolidating shared logic and creating library-specific versioned route handlers for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->