### PR TITLE
fix(routes/examples): remove fixed 'h-[95dvh]' breaking Safari render

### DIFF
--- a/src/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
+++ b/src/routes/$libraryId/$version.docs.framework.$framework.examples.$.tsx
@@ -351,7 +351,7 @@ function PageComponent() {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-auto h-[95dvh]">
+    <div className="flex-1 flex flex-col min-h-0 overflow-auto">
       <div className="p-4 lg:p-6">
         <DocTitle>
           <span>


### PR DESCRIPTION
## Summary

Removes the fixed `h-[95dvh]` height from the examples page scroll container, which prevented the embedded code example viewer from rendering in Safari.

## Problem

On example pages, the interactive code explorer rendered correctly in Chrome but collapsed in Safari. The scroll container used a fixed `h-[95dvh]` inside a `md:flex-row` flex layout. WebKit miscalculated this fixed `dvh` height, collapsing the container to ~79px while its content was ~1005px tall. The `overflow-auto` then clipped everything below the collapsed height.

## Fix

```diff
-    <div className="flex-1 flex flex-col min-h-0 overflow-auto h-[95dvh]">
+    <div className="flex-1 flex flex-col min-h-0 overflow-auto">
```

The container already receives its height from the parent flex layout via `flex-1 min-h-0`, so `h-[95dvh]` was redundant in Chrome (height unchanged) and harmful in Safari. Verified the fix renders correctly in both Safari and Chrome.

## Screenshot

### AS-IS

#### Safari

<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/63d51d8f-14fe-45af-a7cc-520ca51eb191" />

#### Chrome

<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/f31df548-6151-4011-bb52-3dc814812e08" />

### TO-BE

#### Safari

<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/91547010-a7b3-445a-bb5c-9d93579a6f4b" />

#### Chrome

<img width="1919" height="993" alt="image" src="https://github.com/user-attachments/assets/ae05c67c-3189-47f6-b2b4-589d1bd893ac" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout of the examples section to provide better vertical flexibility by removing a fixed height constraint while maintaining responsive scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->