### PR TITLE
Update site navigation

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -16,9 +16,8 @@ type CollapsibleProps = {
   className?: string
 }
 
-type CollapsibleTriggerProps = {
+type CollapsibleTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode
-  className?: string
 }
 
 type CollapsibleContentProps = {
@@ -76,16 +75,26 @@ export function Collapsible({
 export function CollapsibleTrigger({
   children,
   className,
+  onClick,
+  onMouseDown,
+  type = 'button',
+  ...props
 }: CollapsibleTriggerProps) {
-  const { toggle } = useCollapsible()
+  const { open, toggle } = useCollapsible()
 
   return (
     <button
-      type="button"
-      onMouseDown={(e) => e.stopPropagation()}
+      {...props}
+      type={type}
+      aria-expanded={open}
+      onMouseDown={(e) => {
+        e.stopPropagation()
+        onMouseDown?.(e)
+      }}
       onClick={(e) => {
         e.stopPropagation()
         toggle()
+        onClick?.(e)
       }}
       className={twMerge('cursor-pointer select-none', className)}
       data-collapsible-trigger

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,27 +15,33 @@ import { NavbarCartButton } from './NavbarCartButton'
 import { Link, useLocation, useMatches } from '@tanstack/react-router'
 import { NetlifyImage } from './NetlifyImage'
 import {
-  Code,
-  Users,
-  Music,
-  HelpCircle,
   BookOpen,
-  TrendingUp,
-  Shirt,
-  ShieldCheck,
-  Paintbrush,
-  Hammer,
-  User,
-  Menu,
-  X,
+  Code,
+  ExternalLink,
   Grid2X2,
+  Hammer,
+  Heart,
+  HelpCircle,
+  Mail,
+  Menu,
+  Newspaper,
+  Paintbrush,
+  ShieldCheck,
+  Shirt,
   Sparkles,
+  TrendingUp,
+  User,
+  Users,
+  X,
 } from 'lucide-react'
 import { ThemeToggle } from './ThemeToggle'
 import { AiDockButton, SearchButton } from './SearchButton'
-import { libraries, SIDEBAR_LIBRARY_IDS, type LibrarySlim } from '~/libraries'
-import { useClickOutside } from '~/hooks/useClickOutside'
 import { useSearchContext } from '~/contexts/SearchContext'
+import {
+  librariesByGroup,
+  librariesGroupNamesMap,
+  type LibrarySlim,
+} from '~/libraries'
 import { GithubIcon } from '~/components/icons/GithubIcon'
 import {
   Dropdown,
@@ -48,98 +54,385 @@ import { InstagramIcon } from '~/components/icons/InstagramIcon'
 import { BSkyIcon } from '~/components/icons/BSkyIcon'
 import { BrandXIcon } from '~/components/icons/BrandXIcon'
 import { YouTubeIcon } from '~/components/icons/YouTubeIcon'
-
-import { Card } from '~/components/Card'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { groupToSlug } from '~/components/stack/stack-categories'
 
 type LogoProps = {
-  showMenu: boolean
-  setShowMenu: React.Dispatch<React.SetStateAction<boolean>>
-  menuButtonRef: React.RefObject<HTMLButtonElement | null>
-  title?: React.ComponentType<any> | null
+  title?: React.ComponentType | null
 }
 
-const LogoSection = ({
-  showMenu,
-  setShowMenu,
-  menuButtonRef,
-  title,
-}: LogoProps) => {
-  const pointerInsideButtonRef = React.useRef(false)
-  const toggleMenu = () => {
-    setShowMenu((prev) => !prev)
-  }
+const LogoSection = ({ title }: LogoProps) => {
   return (
-    <>
-      <button
-        aria-label="Open Menu"
-        className={twMerge(
-          'flex items-center justify-center',
-          'transition-all duration-300 h-8 px-2 py-1 lg:px-0',
-          // At lg: only visible when Title exists (flyout mode)
-          // Below lg: always visible
-          title
-            ? 'lg:w-9 lg:opacity-100 lg:translate-x-0'
-            : 'lg:w-0 lg:opacity-0 lg:-translate-x-full',
-        )}
-        ref={menuButtonRef}
-        onClick={toggleMenu}
-        onPointerEnter={(e) => {
-          // Enable hover to open flyout at md+ (but not touch)
-          if (window.innerWidth < 768 || e.pointerType === 'touch') return
-          if (pointerInsideButtonRef.current) return
-          pointerInsideButtonRef.current = true
-          setShowMenu(true)
-        }}
-        onPointerLeave={() => {
-          pointerInsideButtonRef.current = false
-        }}
-      >
-        {showMenu ? <X /> : <Menu />}
-      </button>
-      <Link
-        to="/"
-        className={twMerge(`inline-flex items-center gap-1.5 cursor-pointer`)}
-      >
-        <div className="w-[30px] inline-grid items-center grid-cols-1 grid-rows-1 [&>*]:transition-opacity [&>*]:duration-1000">
-          <NetlifyImage
-            src="/images/logos/logo-color-100.png"
-            alt=""
-            width={30}
-            className="row-start-1 col-start-1 w-full group-hover:opacity-0"
-          />
-          <img
-            src={'/images/logos/logo-black.svg'}
-            alt=""
-            className="row-start-1 col-start-1 w-full dark:opacity-0 opacity-0 group-hover:opacity-100"
-          />
-          <img
-            src={'/images/logos/logo-white.svg'}
-            alt=""
-            className="row-start-1 col-start-1 w-full light:opacity-0 dark:block opacity-0 group-hover:opacity-100"
-          />
-        </div>
-        <div>TanStack</div>
-      </Link>
-    </>
+    <Link
+      to="/"
+      className={twMerge(
+        `inline-flex items-center gap-1.5 cursor-pointer`,
+        title ? 'shrink-0' : '',
+      )}
+    >
+      <div className="w-[30px] inline-grid items-center grid-cols-1 grid-rows-1 [&>*]:transition-opacity [&>*]:duration-1000">
+        <NetlifyImage
+          src="/images/logos/logo-color-100.png"
+          alt=""
+          width={30}
+          className="row-start-1 col-start-1 w-full group-hover:opacity-0"
+        />
+        <img
+          src={'/images/logos/logo-black.svg'}
+          alt=""
+          className="row-start-1 col-start-1 w-full dark:opacity-0 opacity-0 group-hover:opacity-100"
+        />
+        <img
+          src={'/images/logos/logo-white.svg'}
+          alt=""
+          className="row-start-1 col-start-1 w-full light:opacity-0 dark:block opacity-0 group-hover:opacity-100"
+        />
+      </div>
+      <div>TanStack</div>
+    </Link>
   )
 }
 
-const MobileCard = ({
-  children,
-  isActive,
-}: {
-  children: React.ReactNode
-  isActive?: boolean
-}) => (
-  <Card
-    className={twMerge(
-      'md:contents border-gray-200/50 dark:border-gray-700/50 shadow-sm',
-      isActive && 'ring-2 ring-gray-400/30 dark:ring-gray-500/30',
-    )}
-  >
-    {children}
-  </Card>
-)
+type IconComponent = React.ComponentType<{ className?: string }>
+
+type NavMenuKey =
+  | 'libraries'
+  | 'learn'
+  | 'community'
+  | 'tools'
+  | 'merch'
+  | 'support'
+
+type MegaMenuDirection = 'left' | 'right' | 'down'
+type MegaMenuPanePhase = 'enter' | 'exit' | 'current'
+
+type MegaMenuPane = {
+  id: number
+  key: NavMenuKey
+  phase: MegaMenuPanePhase
+  direction: MegaMenuDirection
+}
+
+type MegaMenuLayout = {
+  left: number
+  width: number
+}
+
+type NavMenuItem = {
+  label: string
+  to: string
+  hash?: string
+  description?: string
+  badge?: string
+  icon?: IconComponent
+}
+
+type NavMenuSection = {
+  label: string
+  items: readonly NavMenuItem[]
+}
+
+type NavMenuGroup = {
+  key: NavMenuKey
+  label: string
+  to?: string
+  sections: readonly NavMenuSection[]
+  rail?: {
+    eyebrow: string
+    title: string
+    description: string
+    item: NavMenuItem
+  }
+}
+
+type NavigationLibrary = LibrarySlim & {
+  to: string
+}
+
+type LibraryGroupId = keyof typeof librariesByGroup
+
+const DESKTOP_NAV_CLASS = 'hidden min-[1024px]:flex'
+const MOBILE_NAV_CLASS = 'min-[1024px]:hidden'
+const CLOSE_DELAY_MS = 140
+const MEGA_MENU_TRANSITION_MS = 400
+const MEGA_MENU_PANEL_CLOSE_MS = 180
+const MEGA_MENU_MAX_WIDTH = 1120
+const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
+const MEGA_MENU_VIEWPORT_PADDING = 16
+const MEGA_MENU_ORDER: Record<NavMenuKey, number> = {
+  libraries: 0,
+  learn: 1,
+  community: 2,
+  tools: 3,
+  merch: 4,
+  support: 5,
+}
+const LIBRARY_MENU_GROUP_IDS: readonly LibraryGroupId[] = [
+  'framework',
+  'state',
+  'headlessUI',
+  'performance',
+  'tooling',
+]
+
+const NAV_GROUPS = [
+  {
+    key: 'libraries',
+    label: 'Libraries',
+    to: '/libraries',
+    sections: [],
+    rail: {
+      eyebrow: 'Browse',
+      title: 'All TanStack libraries',
+      description:
+        'Filter the ecosystem by framework and find the right package faster.',
+      item: {
+        label: 'All Libraries',
+        to: '/libraries',
+        icon: Grid2X2,
+      },
+    },
+  },
+  {
+    key: 'learn',
+    label: 'Learn',
+    sections: [
+      {
+        label: 'Resources',
+        items: [
+          {
+            label: 'Blog',
+            to: '/blog',
+            description: 'Release notes, architecture notes, and essays.',
+            icon: Newspaper,
+          },
+          {
+            label: 'YouTube',
+            to: 'https://youtube.com/@tan_stack',
+            description: 'The official TanStack channel.',
+            icon: YouTubeIcon,
+          },
+        ],
+      },
+    ],
+    rail: {
+      eyebrow: 'Workshops',
+      title: 'Learn from maintainers',
+      description:
+        'Remote and in-person TanStack workshops for teams that need depth.',
+      item: {
+        label: 'Professional Workshops',
+        to: '/workshops',
+        icon: Users,
+      },
+    },
+  },
+  {
+    key: 'community',
+    label: 'Community',
+    sections: [
+      {
+        label: 'Channels',
+        items: [
+          {
+            label: 'Discord',
+            to: 'https://tlinz.com/discord',
+            description: 'Community support and real-time discussion.',
+            icon: DiscordIcon,
+          },
+          {
+            label: 'GitHub',
+            to: 'https://github.com/TanStack',
+            description: 'Source, issues, discussions, and releases.',
+            icon: GithubIcon,
+          },
+        ],
+      },
+      {
+        label: 'People & Work',
+        items: [
+          {
+            label: 'Maintainers',
+            to: '/maintainers',
+            description: 'Meet the people maintaining the stack.',
+            icon: Code,
+          },
+          {
+            label: 'Contributors',
+            to: '/maintainers',
+            description: 'Core, library, and community contributors.',
+            icon: Users,
+          },
+          {
+            label: 'Showcase',
+            to: '/showcase',
+            description: 'Products and teams building with TanStack.',
+            icon: Sparkles,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'tools',
+    label: 'Tools',
+    sections: [
+      {
+        label: 'Tools',
+        items: [
+          {
+            label: 'Builder',
+            to: '/builder',
+            description: 'Generate TanStack app starters.',
+            badge: 'Alpha',
+            icon: Hammer,
+          },
+          {
+            label: 'Stats',
+            to: '/stats/npm',
+            description: 'NPM and ecosystem usage data.',
+            icon: TrendingUp,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'merch',
+    label: 'Merch',
+    sections: [
+      {
+        label: 'Shop',
+        items: [
+          {
+            label: 'New Apparel',
+            to: '/merch',
+            description: 'TanStack shirts, hoodies, and new drops.',
+            icon: Shirt,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'support',
+    label: 'Support',
+    sections: [
+      {
+        label: 'Support',
+        items: [
+          {
+            label: 'Support Overview',
+            to: '/support',
+            description: 'Find the right support path.',
+            icon: HelpCircle,
+          },
+          {
+            label: 'Partners',
+            to: '/partners',
+            description: 'Companies supporting TanStack.',
+            icon: Heart,
+          },
+          {
+            label: 'OSS Sponsors',
+            to: '/',
+            hash: 'sponsors',
+            description: 'Sponsors keeping TanStack open source.',
+            icon: ShieldCheck,
+          },
+          {
+            label: 'Enterprise Support',
+            to: '/paid-support',
+            description: 'Private consulting and expert support.',
+            icon: Users,
+          },
+          {
+            label: 'Contact',
+            to: 'mailto:support@tanstack.com',
+            description: 'Get in touch with the TanStack team.',
+            icon: Mail,
+          },
+        ],
+      },
+      {
+        label: 'About',
+        items: [
+          {
+            label: 'Ethos',
+            to: '/ethos',
+            description: 'How we think about open source and products.',
+            icon: ShieldCheck,
+          },
+          {
+            label: 'Tenets',
+            to: '/tenets',
+            description: 'The values that shape TanStack libraries.',
+            icon: BookOpen,
+          },
+          {
+            label: 'Brand Guide',
+            to: '/brand-guide',
+            description: 'Logos, colors, and brand usage.',
+            icon: Paintbrush,
+          },
+        ],
+      },
+    ],
+    rail: {
+      eyebrow: 'Partners',
+      title: 'Work with TanStack',
+      description: 'Sponsorships, placements, and partner pages.',
+      item: {
+        label: 'Partnership Inquiry',
+        to: 'mailto:partners@tanstack.com?subject=TanStack Partnership Inquiry',
+        icon: Mail,
+      },
+    },
+  },
+] as const satisfies readonly NavMenuGroup[]
+
+function isNavigationLibrary(
+  library: LibrarySlim,
+): library is NavigationLibrary {
+  return (
+    typeof library.to === 'string' &&
+    library.to.startsWith('/') &&
+    library.visible !== false
+  )
+}
+
+function getLibraryDisplayName(library: LibrarySlim) {
+  return library.name.replace(/^TanStack\s+/, '')
+}
+
+function isExternalLink(to: string) {
+  return to.startsWith('http') || to.startsWith('mailto:')
+}
+
+function getLibraryDocsTo(library: NavigationLibrary) {
+  return `${library.to}/latest/docs`
+}
+
+function getMenuGroup(key: NavMenuKey) {
+  return NAV_GROUPS.find((group) => group.key === key)
+}
+
+function getLibraryMenuGroups() {
+  return LIBRARY_MENU_GROUP_IDS.map((groupId) => {
+    const groupLibraries = librariesByGroup[groupId]
+    const libraries = groupLibraries.filter(isNavigationLibrary)
+
+    return {
+      id: groupId,
+      label: librariesGroupNamesMap[groupId],
+      libraries,
+    }
+  }).filter((group) => group.libraries.length > 0)
+}
 
 function AiDockMount() {
   const { isAiDockOpen } = useSearchContext()
@@ -164,6 +457,7 @@ function AiDockMount() {
 
 export function Navbar({ children }: { children: React.ReactNode }) {
   const matches = useMatches()
+  const location = useLocation()
 
   const { Title } = React.useMemo(() => {
     const match = [...matches].reverse().find((m) => m.staticData.Title)
@@ -174,6 +468,10 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   }, [matches])
 
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const primaryNavRef = React.useRef<HTMLElement>(null)
+  const megaMenuRef = React.useRef<HTMLDivElement>(null)
+  const closeTimerRef = React.useRef<number | undefined>(undefined)
+  const activeMenuKeyRef = React.useRef<NavMenuKey | null>(null)
 
   React.useEffect(() => {
     const updateContainerHeight = () => {
@@ -186,7 +484,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
       }
     }
 
-    updateContainerHeight() // Initial call to set the height
+    updateContainerHeight()
 
     window.addEventListener('resize', updateContainerHeight)
     return () => {
@@ -194,10 +492,126 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  const [showMenu, setShowMenu] = React.useState(false)
+  const [activeMenuKey, setActiveMenuKey] = React.useState<NavMenuKey | null>(
+    null,
+  )
+  const [megaMenuDirection, setMegaMenuDirection] =
+    React.useState<MegaMenuDirection>('down')
+  const [megaMenuLayout, setMegaMenuLayout] = React.useState<MegaMenuLayout>({
+    left: MEGA_MENU_VIEWPORT_PADDING,
+    width: MEGA_MENU_MAX_WIDTH,
+  })
+  const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
   const [canLoadAuthControls, setCanLoadAuthControls] = React.useState(false)
-  const largeMenuRef = React.useRef<HTMLDivElement>(null)
-  const menuButtonRef = React.useRef<HTMLButtonElement>(null)
+
+  React.useEffect(() => {
+    document.documentElement.classList.add('ts-nav-hydrated')
+
+    return () => {
+      document.documentElement.classList.remove('ts-nav-hydrated')
+    }
+  }, [])
+
+  const closeMegaMenu = React.useCallback(() => {
+    activeMenuKeyRef.current = null
+    setActiveMenuKey(null)
+  }, [])
+
+  const cancelMegaMenuClose = React.useCallback(() => {
+    if (closeTimerRef.current !== undefined) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = undefined
+    }
+  }, [])
+
+  const scheduleMegaMenuClose = React.useCallback(() => {
+    cancelMegaMenuClose()
+    closeTimerRef.current = window.setTimeout(() => {
+      closeMegaMenu()
+    }, CLOSE_DELAY_MS)
+  }, [cancelMegaMenuClose, closeMegaMenu])
+
+  const updateMegaMenuLayout = React.useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const trigger =
+      primaryNavRef.current?.querySelector<HTMLElement>('.ts-mega-trigger')
+    const viewportWidth = window.innerWidth
+    const availableWidth = Math.max(
+      0,
+      viewportWidth - MEGA_MENU_VIEWPORT_PADDING * 2,
+    )
+    const triggerLeft = Math.round(
+      trigger?.getBoundingClientRect().left ?? MEGA_MENU_VIEWPORT_PADDING,
+    )
+    const alignedWidth = Math.min(
+      MEGA_MENU_MAX_WIDTH,
+      Math.max(0, viewportWidth - triggerLeft - MEGA_MENU_VIEWPORT_PADDING),
+    )
+    const nextLayout =
+      alignedWidth >= MEGA_MENU_MIN_ALIGNED_WIDTH
+        ? {
+            left: triggerLeft,
+            width: alignedWidth,
+          }
+        : {
+            left: MEGA_MENU_VIEWPORT_PADDING,
+            width: availableWidth,
+          }
+
+    setMegaMenuLayout((previousLayout) => {
+      if (
+        previousLayout.left === nextLayout.left &&
+        previousLayout.width === nextLayout.width
+      ) {
+        return previousLayout
+      }
+
+      return nextLayout
+    })
+  }, [])
+
+  const openMegaMenu = React.useCallback(
+    (key: NavMenuKey) => {
+      cancelMegaMenuClose()
+      updateMegaMenuLayout()
+      const previousKey = activeMenuKeyRef.current
+
+      if (previousKey && previousKey !== key) {
+        setMegaMenuDirection(
+          MEGA_MENU_ORDER[key] > MEGA_MENU_ORDER[previousKey]
+            ? 'right'
+            : 'left',
+        )
+      } else if (!previousKey) {
+        setMegaMenuDirection('down')
+      }
+
+      activeMenuKeyRef.current = key
+      setActiveMenuKey(key)
+    },
+    [cancelMegaMenuClose, updateMegaMenuLayout],
+  )
+
+  React.useEffect(() => {
+    if (!activeMenuKey) {
+      return
+    }
+
+    updateMegaMenuLayout()
+    window.addEventListener('resize', updateMegaMenuLayout)
+
+    return () => {
+      window.removeEventListener('resize', updateMegaMenuLayout)
+    }
+  }, [activeMenuKey, updateMegaMenuLayout])
+
+  React.useEffect(() => {
+    closeMegaMenu()
+    setMobileMenuOpen(false)
+  }, [closeMegaMenu, location.pathname, location.hash])
 
   React.useEffect(() => {
     if (typeof window === 'undefined') {
@@ -226,12 +640,53 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  // Close mobile menu when clicking outside
-  const smallMenuRef = useClickOutside<HTMLDivElement>({
-    enabled: showMenu,
-    onClickOutside: () => setShowMenu(false),
-    additionalRefs: [largeMenuRef, menuButtonRef],
-  })
+  React.useEffect(() => {
+    if (!activeMenuKey && !mobileMenuOpen) {
+      return
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMegaMenu()
+        setMobileMenuOpen(false)
+      }
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!activeMenuKey) {
+        return
+      }
+
+      const target = event.target
+
+      if (!(target instanceof Node)) {
+        return
+      }
+
+      if (
+        containerRef.current?.contains(target) ||
+        megaMenuRef.current?.contains(target)
+      ) {
+        return
+      }
+
+      closeMegaMenu()
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('pointerdown', onPointerDown)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [activeMenuKey, closeMegaMenu, mobileMenuOpen])
+
+  React.useEffect(() => {
+    return () => {
+      cancelMegaMenuClose()
+    }
+  }, [cancelMegaMenuClose])
 
   const loginButtonFallback = (
     <Link
@@ -253,32 +708,18 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     <div
       className={twMerge(
         'w-full p-2 fixed top-0 z-[100] bg-white/90 dark:bg-black/90 backdrop-blur-lg',
-        'flex items-center justify-between gap-4',
+        'flex items-center justify-between gap-3',
         'border-b border-gray-500/20',
       )}
       ref={containerRef}
     >
-      <div className="flex items-center min-w-0">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <div className="flex items-center gap-2 font-black text-xl uppercase min-w-0">
-          <React.Suspense
-            fallback={
-              <LogoSection
-                menuButtonRef={menuButtonRef}
-                setShowMenu={setShowMenu}
-                showMenu={showMenu}
-                title={Title}
-              />
-            }
-          >
+          <React.Suspense fallback={<LogoSection title={Title} />}>
             <LazyBrandContextMenu
               className={twMerge(`flex items-center group flex-shrink-0`)}
             >
-              <LogoSection
-                menuButtonRef={menuButtonRef}
-                setShowMenu={setShowMenu}
-                showMenu={showMenu}
-                title={Title}
-              />
+              <LogoSection title={Title} />
             </LazyBrandContextMenu>
           </React.Suspense>
           {Title ? (
@@ -287,8 +728,32 @@ export function Navbar({ children }: { children: React.ReactNode }) {
             </div>
           ) : null}
         </div>
+
+        <nav
+          ref={primaryNavRef}
+          aria-label="Primary navigation"
+          className={twMerge(
+            DESKTOP_NAV_CLASS,
+            'relative shrink-0 items-center gap-1',
+          )}
+          onPointerEnter={cancelMegaMenuClose}
+          onPointerLeave={(event) => {
+            if (event.pointerType === 'touch') return
+            scheduleMegaMenuClose()
+          }}
+        >
+          {NAV_GROUPS.map((group) => (
+            <DesktopNavTrigger
+              key={group.key}
+              group={group}
+              isOpen={activeMenuKey === group.key}
+              onOpen={() => openMegaMenu(group.key)}
+            />
+          ))}
+        </nav>
       </div>
-      <div className="flex items-center gap-1.5 sm:gap-2">
+
+      <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
         <div className="hidden min-[750px]:block">{socialLinks}</div>
         <ThemeToggle />
         <div className="hidden sm:block">
@@ -305,476 +770,673 @@ export function Navbar({ children }: { children: React.ReactNode }) {
             loginButtonFallback
           )}
         </div>
+        <button
+          type="button"
+          aria-label={mobileMenuOpen ? 'Close Menu' : 'Open Menu'}
+          aria-expanded={mobileMenuOpen}
+          aria-controls="primary-mobile-menu"
+          className={twMerge(
+            'inline-flex h-9 w-9 items-center justify-center rounded-md',
+            'border border-gray-500/20 text-gray-700 transition-colors hover:bg-gray-500/10',
+            'dark:text-gray-200',
+            MOBILE_NAV_CLASS,
+          )}
+          onClick={() => setMobileMenuOpen((prev) => !prev)}
+        >
+          {mobileMenuOpen ? (
+            <X className="h-5 w-5" />
+          ) : (
+            <Menu className="h-5 w-5" />
+          )}
+        </button>
       </div>
     </div>
   )
 
-  const activeLibrary = useLocation({
-    select: (location) => {
-      return libraries.find((library) => {
-        return library.to && location.pathname.startsWith(library.to)
-      })
-    },
-  })
-
-  const linkClasses = `flex items-center justify-between gap-2 group px-3 py-3 md:px-2 md:py-1 rounded-lg hover:bg-gray-500/10 font-bold text-base md:text-sm`
-
-  const items = (
-    <div className="contents md:block">
-      <div className="contents md:block">
-        {(() => {
-          return libraries
-            .filter(
-              (
-                d,
-              ): d is LibrarySlim & {
-                to: string
-                textStyle: string
-                badge?: string
-                colorFrom: string
-              } =>
-                d.to !== undefined &&
-                d.visible !== false &&
-                (SIDEBAR_LIBRARY_IDS as readonly string[]).includes(d.id),
-            )
-            .sort((a, b) => {
-              const indexA = SIDEBAR_LIBRARY_IDS.indexOf(
-                a.id as (typeof SIDEBAR_LIBRARY_IDS)[number],
-              )
-              const indexB = SIDEBAR_LIBRARY_IDS.indexOf(
-                b.id as (typeof SIDEBAR_LIBRARY_IDS)[number],
-              )
-              return indexA - indexB
-            })
-        })().map((library, i) => {
-          const [_, name] = library.name.split(' ')
-          const isActive = library.to === activeLibrary?.to
-
-          return (
-            <div key={i} className="contents md:block">
-              {library.to?.startsWith('http') ? (
-                <>
-                  {/* Mobile: Card wrapper */}
-                  <MobileCard>
-                    <a
-                      href={library.to}
-                      className={twMerge(linkClasses, 'md:hidden')}
-                    >
-                      <span
-                        className={twMerge(
-                          'w-4 h-4 md:w-3 md:h-3 rounded-sm border border-white/50',
-                          library.bgStyle,
-                        )}
-                      />
-                      {name}
-                    </a>
-                  </MobileCard>
-                  {/* Desktop: no card */}
-                  <a
-                    href={library.to}
-                    className={twMerge(linkClasses, 'hidden md:flex')}
-                  >
-                    <span
-                      className={twMerge(
-                        'w-3 h-3 rounded-sm border border-white/50',
-                        library.bgStyle,
-                      )}
-                    />
-                    {name}
-                  </a>
-                </>
-              ) : (
-                <>
-                  {/* Mobile: Direct link with Card */}
-                  <MobileCard isActive={isActive}>
-                    <Link
-                      to="/$libraryId/$version"
-                      params={{ libraryId: library.id, version: 'latest' }}
-                      className={twMerge(
-                        linkClasses,
-                        'md:hidden',
-                        isActive ? 'bg-gray-500/5' : '',
-                      )}
-                    >
-                      <span
-                        className={twMerge(
-                          'w-4 h-4 md:w-3 md:h-3 rounded-sm',
-                          library.bgStyle,
-                        )}
-                      />
-                      <span
-                        style={{
-                          viewTransitionName: `library-name-${library.id}`,
-                        }}
-                        className={twMerge(
-                          'flex-1 text-left',
-                          isActive ? 'font-bold' : '',
-                        )}
-                      >
-                        {name}
-                      </span>
-                      {library.badge ? (
-                        <span
-                          className={twMerge(
-                            `px-2 py-px uppercase font-black rounded-md text-[.65rem]`,
-                            'border-2 bg-transparent',
-                            library.textStyle,
-                            library.borderStyle,
-                          )}
-                        >
-                          {library.badge}
-                        </span>
-                      ) : null}
-                    </Link>
-                  </MobileCard>
-                  {/* Desktop: Simple link */}
-                  <Link
-                    to="/$libraryId/$version"
-                    params={{ libraryId: library.id, version: 'latest' }}
-                    className={twMerge(
-                      linkClasses,
-                      'hidden md:flex',
-                      isActive ? 'bg-gray-500/10 dark:bg-gray-500/30' : '',
-                    )}
-                  >
-                    <span
-                      className={twMerge('w-3 h-3 rounded-sm', library.bgStyle)}
-                    />
-                    <span
-                      style={{
-                        viewTransitionName: `library-name-${library.id}`,
-                      }}
-                      className={twMerge(
-                        'flex-1 text-left',
-                        isActive ? 'font-bold' : '',
-                      )}
-                    >
-                      {name}
-                    </span>
-                    {library.badge ? (
-                      <span
-                        className={twMerge(
-                          `px-2 py-px uppercase font-black rounded-md text-[.6rem]`,
-                          'border bg-transparent',
-                          'border-current text-current',
-                          'opacity-0 group-hover:opacity-100 transition-opacity',
-                          library.textColor,
-                        )}
-                      >
-                        {library.badge}
-                      </span>
-                    ) : null}
-                  </Link>
-                </>
-              )}
-            </div>
-          )
-        })}
-        {/* Mobile: More Libraries card */}
-        <MobileCard>
-          <Link
-            to="/libraries"
-            className={twMerge(linkClasses, 'font-normal md:hidden')}
-            activeProps={{
-              className: twMerge(
-                'font-bold! bg-gray-500/10 dark:bg-gray-500/30',
-              ),
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <Grid2X2 className="w-5 h-5 md:w-4 md:h-4" />
-              <div>More Libraries</div>
-            </div>
-          </Link>
-        </MobileCard>
-        {/* Desktop: More Libraries link */}
-        <Link
-          to="/libraries"
-          className={twMerge(linkClasses, 'font-normal hidden md:flex')}
-          activeProps={{
-            className: twMerge('font-bold! bg-gray-500/10 dark:bg-gray-500/30'),
-          }}
-        >
-          <div className="flex items-center gap-2">
-            <Grid2X2 className="w-4 h-4" />
-            <div>More Libraries</div>
-          </div>
-        </Link>
-        <div className="py-2 hidden md:block col-span-2">
-          <div className="bg-gray-500/10 h-px" />
-        </div>
-      </div>
-      {/* Mobile separator */}
-      <div className="col-span-2 sm:col-span-3 py-3 md:hidden">
-        <div className="bg-gray-500/10 h-px" />
-      </div>
-      <div className="contents md:block">
-        {/* Mobile: Builder card */}
-        <MobileCard>
-          <Link
-            to="/builder"
-            className={twMerge(linkClasses, 'font-normal md:hidden')}
-            activeProps={{
-              className: twMerge(
-                'font-bold! bg-gray-500/10 dark:bg-gray-500/30',
-              ),
-            }}
-          >
-            <div className="flex items-center gap-2 w-full">
-              <Hammer className="w-5 h-5" />
-              <div className="flex items-center justify-between flex-1 gap-2">
-                <span>Builder</span>
-                <span className="px-1.5 py-0.5 text-[.6rem] font-black border border-amber-500 text-amber-500 rounded-md uppercase md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                  Alpha
-                </span>
-              </div>
-            </div>
-          </Link>
-        </MobileCard>
-        {/* Desktop: Builder link */}
-        <Link
-          to="/builder"
-          className={twMerge(linkClasses, 'font-normal hidden md:flex')}
-          activeProps={{
-            className: twMerge('font-bold! bg-gray-500/10 dark:bg-gray-500/30'),
-          }}
-        >
-          <div className="flex items-center gap-2 w-full">
-            <Hammer className="w-4 h-4" />
-            <div className="flex items-center justify-between flex-1 gap-2">
-              <span>Builder</span>
-              <span className="px-1.5 py-0.5 text-[.6rem] font-black border border-amber-500 text-amber-500 rounded-md uppercase md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                Alpha
-              </span>
-            </div>
-          </div>
-        </Link>
-        {[
-          {
-            label: 'Blog',
-            icon: Music,
-            to: '/blog',
-          },
-          {
-            label: 'Maintainers',
-            icon: Code,
-            to: '/maintainers',
-          },
-          {
-            label: 'Partners',
-            icon: Users,
-            to: '/partners',
-          },
-          {
-            label: 'Showcase',
-            icon: Sparkles,
-            to: '/showcase',
-          },
-          {
-            label: (
-              <>
-                <span>Learn</span>
-                <span className="px-1.5 py-0.5 text-[.6rem] font-black border border-green-500 text-green-500 rounded-md uppercase md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                  NEW
-                </span>
-              </>
-            ),
-            icon: BookOpen,
-            to: '/learn',
-          },
-          {
-            label: 'Stats',
-            icon: TrendingUp,
-            to: '/stats/npm',
-          },
-          {
-            label: 'YouTube',
-            icon: YouTubeIcon,
-            to: 'https://youtube.com/@tan_stack',
-            target: '_blank',
-          },
-          {
-            label: 'Discord',
-            icon: DiscordIcon,
-            to: 'https://tlinz.com/discord',
-            target: '_blank',
-          },
-          {
-            label: 'Merch',
-            icon: Shirt,
-            to: '/merch',
-          },
-          {
-            label: 'Support',
-            icon: HelpCircle,
-            to: '/support',
-          },
-          {
-            label: 'GitHub',
-            icon: GithubIcon,
-            to: 'https://github.com/TanStack',
-          },
-          {
-            label: 'Ethos',
-            icon: ShieldCheck,
-            to: '/ethos',
-          },
-          {
-            label: 'Tenets',
-            icon: BookOpen,
-            to: '/tenets',
-          },
-          {
-            label: 'Brand Guide',
-            icon: Paintbrush,
-            to: '/brand-guide',
-          },
-        ].map((item, i) => {
-          const Icon = item.icon
-          return (
-            <React.Fragment key={i}>
-              {/* Mobile: Card */}
-              <MobileCard>
-                <Link
-                  to={item.to}
-                  className={twMerge(linkClasses, 'font-normal md:hidden')}
-                  activeProps={{
-                    className: twMerge(
-                      'font-bold! bg-gray-500/10 dark:bg-gray-500/30',
-                    ),
-                  }}
-                  target={item.to.startsWith('http') ? '_blank' : undefined}
-                >
-                  <div className="flex items-center gap-2 w-full">
-                    <Icon className="w-5 h-5" />
-                    <div className="flex items-center justify-between flex-1 gap-2">
-                      {item.label}
-                    </div>
-                  </div>
-                </Link>
-              </MobileCard>
-              {/* Desktop: Link */}
-              <Link
-                to={item.to}
-                className={twMerge(linkClasses, 'font-normal hidden md:flex')}
-                activeProps={{
-                  className: twMerge(
-                    'font-bold! bg-gray-500/10 dark:bg-gray-500/30',
-                  ),
-                }}
-                target={item.to.startsWith('http') ? '_blank' : undefined}
-              >
-                <div className="flex items-center gap-2 w-full">
-                  <Icon className="w-4 h-4" />
-                  <div className="flex items-center justify-between flex-1 gap-2">
-                    {item.label}
-                  </div>
-                </div>
-              </Link>
-            </React.Fragment>
-          )
-        })}
-      </div>
-    </div>
-  )
-
-  const smallMenu = showMenu ? (
+  const desktopMegaMenu = (
     <div
-      ref={smallMenuRef}
-      className="md:hidden bg-white/50 dark:bg-black/60 backdrop-blur-[20px] z-50
-    fixed top-[var(--navbar-height)] left-0 right-0 max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto
-    "
+      ref={megaMenuRef}
+      className={twMerge(
+        DESKTOP_NAV_CLASS,
+        'fixed left-0 right-0 top-[var(--navbar-height)] z-[90] justify-start',
+        'pointer-events-none',
+      )}
     >
       <div
-        className="flex flex-col whitespace-nowrap overflow-y-auto
-          border-t border-gray-500/20 text-lg bg-white/80 dark:bg-black/90"
+        data-open={activeMenuKey ? 'true' : 'false'}
+        style={{
+          marginLeft: megaMenuLayout.left,
+          width: megaMenuLayout.width,
+        }}
+        className={twMerge(
+          'ts-mega-panel ts-glass-menu mt-2 rounded-xl',
+          'border border-white/45 bg-white/80 p-4 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+          'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
+        )}
+        onPointerEnter={(event) => {
+          if (event.pointerType === 'touch') return
+          cancelMegaMenuClose()
+        }}
+        onPointerLeave={(event) => {
+          if (event.pointerType === 'touch') return
+          scheduleMegaMenuClose()
+        }}
       >
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-        <div
-          onClick={(event) => {
-            const target = event.target as HTMLElement
-            if (target.closest('[data-collapsible-trigger]')) {
-              return
-            }
-            if (target.closest('a') || target.closest('button')) {
-              setShowMenu(false)
-            }
-          }}
-        >
-          <div className="px-3 pt-3 sm:hidden">
-            <SearchButton className="w-full py-3 text-base [&_svg]:w-5 [&_svg]:h-5" />
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-base p-3 border-b border-gray-500/20">
-            {items}
-          </div>
-          <div className="p-4 sm:hidden">{socialLinks}</div>
+        <MegaMenuContentTransition
+          activeKey={activeMenuKey}
+          direction={megaMenuDirection}
+          onNavigate={closeMegaMenu}
+        />
+      </div>
+    </div>
+  )
+
+  const mobileMenu = mobileMenuOpen ? (
+    <div
+      id="primary-mobile-menu"
+      data-mobile-menu
+      className={twMerge(
+        MOBILE_NAV_CLASS,
+        'fixed left-0 right-0 top-[var(--navbar-height)] z-[90] isolate',
+        'max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto',
+        'border-b border-white/45 bg-white/85 text-base shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+        'dark:border-white/10 dark:bg-black/75 dark:shadow-black/50',
+      )}
+    >
+      <div className="border-t border-white/30 dark:border-white/10">
+        <div className="p-2 sm:hidden">
+          <SearchButton className="w-full py-3 text-base [&_svg]:w-5 [&_svg]:h-5" />
+        </div>
+        <nav className="grid gap-1.5 px-2 pb-2" aria-label="Mobile navigation">
+          {NAV_GROUPS.map((group) => (
+            <MobileMenuGroup
+              key={group.key}
+              group={group}
+              onNavigate={() => setMobileMenuOpen(false)}
+            />
+          ))}
+        </nav>
+        <div className="border-t border-gray-500/10 p-3 sm:hidden">
+          {socialLinks}
         </div>
       </div>
     </div>
   ) : null
 
-  const inlineMenu = !Title
-
-  const leaveTimer = React.useRef<NodeJS.Timeout | undefined>(undefined)
-
-  const largeMenu = (
-    <>
-      <div
-        ref={largeMenuRef}
-        className={twMerge(
-          `hidden md:flex flex-col
-      h-[calc(100dvh-var(--navbar-height))] z-20
-      bg-white/50 dark:bg-black/30 border-r border-gray-500/20`,
-          'transition-all duration-300',
-          'z-50',
-          // md breakpoint: always flyout
-          'md:fixed md:top-[var(--navbar-height)] md:bg-white md:dark:bg-black/90 md:backdrop-blur-lg md:shadow-xl',
-          !showMenu && 'md:-translate-x-full',
-          showMenu && 'md:translate-x-0',
-          // lg breakpoint: inline when no Title, flyout when Title
-          inlineMenu &&
-            'lg:sticky lg:top-[var(--navbar-height)] lg:translate-x-0 lg:bg-white/50 lg:dark:bg-black/30 lg:backdrop-blur-none lg:shadow-none',
-          !inlineMenu &&
-            'lg:fixed lg:top-[var(--navbar-height)] lg:bg-white lg:dark:bg-black/90 lg:backdrop-blur-lg lg:shadow-xl',
-          !inlineMenu && !showMenu && 'lg:-translate-x-full',
-          !inlineMenu && showMenu && 'lg:translate-x-0',
-        )}
-        onPointerEnter={(e) => {
-          if (e.pointerType === 'touch') return
-          clearTimeout(leaveTimer.current)
-        }}
-        onPointerLeave={(e) => {
-          if (e.pointerType === 'touch') return
-          leaveTimer.current = setTimeout(() => {
-            setShowMenu(false)
-          }, 300)
-        }}
-      >
-        <div className="flex-1 flex flex-col gap-4 whitespace-nowrap overflow-y-auto text-base pb-[50px] min-w-[220px]">
-          <div className="flex flex-col gap-1 text-sm p-2">{items}</div>
-        </div>
-      </div>
-    </>
-  )
-
   return (
     <>
       {navbar}
+      {desktopMegaMenu}
+      {mobileMenu}
       <div
+        aria-hidden="true"
+        data-site-menu-tint
+        className={twMerge(
+          DESKTOP_NAV_CLASS,
+          'pointer-events-none fixed inset-x-0 bottom-0 top-[var(--navbar-height)] z-[80]',
+          'bg-white/45 transition-opacity duration-200 motion-reduce:transition-none dark:bg-black/45',
+          activeMenuKey ? 'opacity-100' : 'opacity-0',
+        )}
+      />
+      <div
+        data-site-content
         className={twMerge(
           `min-h-[calc(100dvh-var(--navbar-height))] flex flex-col
-          min-w-0 md:flex-row w-full transition-all duration-300
+          min-w-0 w-full transition-[filter] duration-200 motion-reduce:transition-none
           pt-[var(--navbar-height)]`,
+          activeMenuKey ? 'blur-[4px]' : 'filter-none',
         )}
       >
-        {smallMenu}
-        {largeMenu}
         <div className="flex-1 min-w-0 flex flex-col w-full min-h-0">
           {children}
         </div>
       </div>
       <AiDockMount />
     </>
+  )
+}
+
+function DesktopNavTrigger({
+  group,
+  isOpen,
+  onOpen,
+}: {
+  group: NavMenuGroup
+  isOpen: boolean
+  onOpen: () => void
+}) {
+  const triggerClassName = twMerge(
+    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-2.5 py-2 text-sm font-bold',
+    'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
+    'dark:text-gray-300 dark:hover:text-white',
+    isOpen && 'bg-gray-500/10 text-gray-950 dark:text-white',
+  )
+  const triggerEvents = {
+    onPointerEnter: (event: React.PointerEvent<HTMLElement>) => {
+      if (event.pointerType === 'touch') return
+      onOpen()
+    },
+    onFocus: onOpen,
+  }
+
+  return (
+    <div className="ts-mega-trigger-wrap">
+      {group.to ? (
+        <Link
+          to={group.to}
+          aria-expanded={isOpen}
+          aria-haspopup="menu"
+          data-open={isOpen ? 'true' : 'false'}
+          className={triggerClassName}
+          preload="intent"
+          {...triggerEvents}
+        >
+          <span>{group.label}</span>
+        </Link>
+      ) : (
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          aria-haspopup="menu"
+          data-open={isOpen ? 'true' : 'false'}
+          className={triggerClassName}
+          onClick={onOpen}
+          {...triggerEvents}
+        >
+          <span>{group.label}</span>
+        </button>
+      )}
+      <DesktopNavFallback group={group} />
+    </div>
+  )
+}
+
+function DesktopNavFallback({ group }: { group: NavMenuGroup }) {
+  return (
+    <div className="ts-mega-fallback">
+      <div
+        className={twMerge(
+          'ts-glass-menu rounded-xl',
+          'border border-white/45 bg-white/80 p-4 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+          'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
+        )}
+      >
+        <MegaMenuContent
+          group={group}
+          onNavigate={() => undefined}
+          variant="desktop"
+        />
+      </div>
+    </div>
+  )
+}
+
+function MobileMenuGroup({
+  group,
+  onNavigate,
+}: {
+  group: NavMenuGroup
+  onNavigate: () => void
+}) {
+  return (
+    <Collapsible className="overflow-hidden rounded-lg border border-gray-500/10 bg-white/35 dark:border-white/10 dark:bg-white/[0.03]">
+      {({ open }) => (
+        <>
+          <CollapsibleTrigger
+            className={twMerge(
+              'flex w-full items-center px-3 py-3 text-left font-black text-gray-800',
+              'hover:text-gray-950 dark:text-gray-200 dark:hover:text-white',
+              open && 'text-gray-950 dark:text-white',
+            )}
+          >
+            {group.label}
+          </CollapsibleTrigger>
+          <CollapsibleContent className="border-t border-gray-500/10 motion-reduce:transition-none dark:border-white/10">
+            <div className="px-2 pb-3 pt-1">
+              <MegaMenuContent
+                group={group}
+                onNavigate={onNavigate}
+                variant="mobile"
+              />
+            </div>
+          </CollapsibleContent>
+        </>
+      )}
+    </Collapsible>
+  )
+}
+
+function MegaMenuContentTransition({
+  activeKey,
+  direction,
+  onNavigate,
+}: {
+  activeKey: NavMenuKey | null
+  direction: MegaMenuDirection
+  onNavigate: () => void
+}) {
+  const previousActiveRef = React.useRef<NavMenuKey | null>(null)
+  const paneIdRef = React.useRef(0)
+  const [panes, setPanes] = React.useState<readonly MegaMenuPane[]>([])
+
+  React.useLayoutEffect(() => {
+    if (activeKey === null) {
+      previousActiveRef.current = null
+      const timeoutId = window.setTimeout(() => {
+        setPanes([])
+      }, MEGA_MENU_PANEL_CLOSE_MS)
+
+      return () => {
+        window.clearTimeout(timeoutId)
+      }
+    }
+
+    const previousActive = previousActiveRef.current
+    if (previousActive === activeKey) {
+      return
+    }
+
+    const transitionDirection = previousActive ? direction : 'down'
+    const enteringPane: MegaMenuPane = {
+      id: paneIdRef.current + 1,
+      key: activeKey,
+      phase: 'enter',
+      direction: transitionDirection,
+    }
+    paneIdRef.current += 1
+
+    const nextPanes: MegaMenuPane[] = previousActive
+      ? [
+          {
+            id: paneIdRef.current + 1,
+            key: previousActive,
+            phase: 'exit',
+            direction: transitionDirection,
+          },
+          enteringPane,
+        ]
+      : [enteringPane]
+
+    if (previousActive) {
+      paneIdRef.current += 1
+    }
+
+    previousActiveRef.current = activeKey
+    setPanes(nextPanes)
+
+    const timeoutId = window.setTimeout(() => {
+      setPanes([{ ...enteringPane, phase: 'current' }])
+    }, MEGA_MENU_TRANSITION_MS)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [activeKey, direction])
+
+  if (panes.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="ts-mega-content">
+      {panes.map((pane) => {
+        const group = getMenuGroup(pane.key)
+
+        if (!group) {
+          return null
+        }
+
+        return (
+          <div
+            key={pane.id}
+            className="ts-mega-pane"
+            data-direction={pane.direction}
+            data-state={pane.phase}
+            aria-hidden={pane.phase === 'exit'}
+          >
+            <MegaMenuContent
+              group={group}
+              onNavigate={onNavigate}
+              variant="desktop"
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function MegaMenuContent({
+  group,
+  onNavigate,
+  variant,
+}: {
+  group: NavMenuGroup
+  onNavigate: () => void
+  variant: 'desktop' | 'mobile'
+}) {
+  if (group.key === 'libraries') {
+    return <LibrariesMenuContent onNavigate={onNavigate} variant={variant} />
+  }
+
+  return (
+    <div
+      className={twMerge(
+        variant === 'desktop'
+          ? 'grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]'
+          : 'grid gap-3',
+      )}
+    >
+      <div>
+        <div
+          className={twMerge(
+            'grid gap-3',
+            variant === 'desktop' &&
+              group.sections.length > 1 &&
+              'md:grid-cols-2',
+          )}
+        >
+          {group.sections.map((section) => (
+            <div key={section.label}>
+              <div className="mb-2 px-2 text-xs font-black uppercase text-gray-500 dark:text-gray-400">
+                {section.label}
+              </div>
+              <div
+                className={twMerge(
+                  'grid gap-1',
+                  variant === 'desktop' &&
+                    group.key === 'learn' &&
+                    'md:grid-cols-2',
+                )}
+              >
+                {section.items.map((item) => (
+                  <MenuItemLink
+                    key={`${item.label}-${item.to}-${item.hash ?? ''}`}
+                    item={item}
+                    onNavigate={onNavigate}
+                    variant={variant}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {group.rail ? (
+        <MenuRail rail={group.rail} onNavigate={onNavigate} variant={variant} />
+      ) : null}
+    </div>
+  )
+}
+
+function LibrariesMenuContent({
+  onNavigate,
+  variant,
+}: {
+  onNavigate: () => void
+  variant: 'desktop' | 'mobile'
+}) {
+  const libraryMenuGroups = getLibraryMenuGroups()
+
+  return (
+    <div
+      className={twMerge(
+        variant === 'desktop'
+          ? 'grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]'
+          : 'grid gap-3',
+      )}
+    >
+      <div>
+        <div
+          className={twMerge(
+            variant === 'desktop'
+              ? 'max-h-[min(72dvh,680px)] columns-2 overflow-y-auto pr-2 [column-gap:1rem]'
+              : 'grid gap-3',
+          )}
+        >
+          {libraryMenuGroups.map((group) => (
+            <LibraryMenuGroup
+              key={group.id}
+              group={group}
+              onNavigate={onNavigate}
+              variant={variant}
+            />
+          ))}
+        </div>
+      </div>
+      <MenuRail
+        rail={{
+          eyebrow: 'Browse',
+          title: 'All TanStack libraries',
+          description:
+            'Filter by framework and compare the full set of public packages.',
+          item: {
+            label: 'All Libraries',
+            to: '/libraries',
+            icon: Grid2X2,
+          },
+        }}
+        onNavigate={onNavigate}
+        variant={variant}
+      />
+    </div>
+  )
+}
+
+function LibraryMenuGroup({
+  group,
+  onNavigate,
+  variant,
+}: {
+  group: ReturnType<typeof getLibraryMenuGroups>[number]
+  onNavigate: () => void
+  variant: 'desktop' | 'mobile'
+}) {
+  const categorySlug = groupToSlug[group.id]
+
+  return (
+    <section
+      className={twMerge(
+        'break-inside-avoid',
+        variant === 'desktop' ? 'mb-5 [break-inside:avoid]' : 'pb-3',
+      )}
+    >
+      <div className="mb-1.5 px-1">
+        <Link
+          to="/stack/$category"
+          params={{ category: categorySlug }}
+          onClick={onNavigate}
+          className="inline-flex rounded px-1 py-0.5 text-xs font-black uppercase text-gray-500 hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none dark:text-gray-400 dark:hover:text-white dark:focus:text-white"
+          preload="intent"
+        >
+          {group.label}
+        </Link>
+      </div>
+      <div className="grid gap-0.5">
+        {group.libraries.map((library) => (
+          <LibraryMenuItem
+            key={library.id}
+            library={library}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function LibraryMenuItem({
+  library,
+  onNavigate,
+}: {
+  library: NavigationLibrary
+  onNavigate: () => void
+}) {
+  const name = getLibraryDisplayName(library)
+  const docsTo = getLibraryDocsTo(library)
+
+  return (
+    <div data-library-menu-item className="flex items-center gap-1.5">
+      <Link
+        to={library.to}
+        onClick={onNavigate}
+        className="group/library flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-2 text-sm font-black text-gray-900 hover:bg-gray-500/10 focus:bg-gray-500/10 focus:outline-none dark:text-gray-100"
+        preload="intent"
+      >
+        <span
+          className={twMerge(
+            'h-4 w-3.5 shrink-0 rounded border border-white/50',
+            library.bgStyle,
+          )}
+        />
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="min-w-0 truncate">{name}</span>
+          {library.badge ? (
+            <span
+              data-library-badge
+              className={twMerge(
+                'hidden shrink-0 rounded-md border border-current px-1.5 py-0.5 text-[0.58rem] font-black uppercase leading-none',
+                'group-hover/library:inline-flex group-focus-within/library:inline-flex',
+                library.textStyle,
+              )}
+            >
+              {library.badge}
+            </span>
+          ) : null}
+        </span>
+      </Link>
+      <div className="flex shrink-0 items-center gap-1">
+        <Link
+          to={docsTo}
+          onClick={onNavigate}
+          className="rounded-lg px-2 py-2 text-xs font-bold text-gray-600 hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none dark:text-gray-400 dark:hover:text-white dark:focus:text-white"
+          preload="intent"
+        >
+          Docs
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function MenuRail({
+  rail,
+  onNavigate,
+  variant,
+}: {
+  rail: NonNullable<NavMenuGroup['rail']>
+  onNavigate: () => void
+  variant: 'desktop' | 'mobile'
+}) {
+  if (variant === 'mobile') {
+    return (
+      <div className="pt-1">
+        <MenuItemLink
+          item={rail.item}
+          onNavigate={onNavigate}
+          variant="mobile"
+          compact
+        />
+      </div>
+    )
+  }
+
+  return (
+    <aside className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-950">
+      <div className="text-xs font-black uppercase text-gray-500 dark:text-gray-400">
+        {rail.eyebrow}
+      </div>
+      <div className="mt-2 text-base font-black text-gray-950 dark:text-white">
+        {rail.title}
+      </div>
+      <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+        {rail.description}
+      </p>
+      <div className="mt-4">
+        <MenuItemLink
+          item={rail.item}
+          onNavigate={onNavigate}
+          variant="desktop"
+          compact
+        />
+      </div>
+    </aside>
+  )
+}
+
+function MenuItemLink({
+  item,
+  onNavigate,
+  variant,
+  compact,
+}: {
+  item: NavMenuItem
+  onNavigate: () => void
+  variant: 'desktop' | 'mobile'
+  compact?: boolean
+}) {
+  const Icon = item.icon
+  const isExternal = isExternalLink(item.to)
+  const className = twMerge(
+    'group flex items-start gap-3 rounded-lg px-2 py-2.5 text-left',
+    'hover:bg-gray-500/10 focus:bg-gray-500/10 focus:outline-none',
+    compact && 'bg-white dark:bg-black/40',
+    variant === 'mobile' && 'px-2 py-3',
+  )
+  const content = (
+    <>
+      {Icon ? (
+        <span className="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-300">
+          <Icon className="h-4 w-4" />
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="font-bold text-gray-950 dark:text-white">
+            {item.label}
+          </span>
+          {item.badge ? (
+            <span className="rounded-md border border-green-500/50 px-1.5 py-0.5 text-[0.6rem] font-black uppercase leading-none text-green-600 dark:text-green-400">
+              {item.badge}
+            </span>
+          ) : null}
+          {isExternal && !item.to.startsWith('mailto:') ? (
+            <ExternalLink className="h-3 w-3 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300" />
+          ) : null}
+        </span>
+        {item.description ? (
+          <span className="mt-0.5 block text-sm leading-5 text-gray-600 dark:text-gray-400">
+            {item.description}
+          </span>
+        ) : null}
+      </span>
+    </>
+  )
+
+  if (isExternal) {
+    return (
+      <a
+        href={item.to}
+        target={item.to.startsWith('mailto:') ? undefined : '_blank'}
+        rel={item.to.startsWith('mailto:') ? undefined : 'noopener noreferrer'}
+        className={className}
+        onClick={onNavigate}
+      >
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <Link
+      to={item.to}
+      hash={item.hash}
+      className={className}
+      onClick={onNavigate}
+      preload="intent"
+    >
+      {content}
+    </Link>
   )
 }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1379,7 +1379,7 @@ function LibraryMenuItem({
       >
         <span
           className={twMerge(
-            'h-4 w-3.5 shrink-0 rounded border border-white/50',
+            'h-4 w-3.5 shrink-0 rounded-[5px] border border-white/50',
             library.bgStyle,
           )}
         />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -870,11 +870,7 @@ function LibrariesMenuContent({
 
   return (
     <div
-      className={twMerge(
-        variant === 'desktop'
-          ? 'grid gap-4'
-          : 'grid gap-3',
-      )}
+      className={twMerge(variant === 'desktop' ? 'grid gap-4' : 'grid gap-3')}
     >
       <div>
         <div

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -155,7 +155,17 @@ const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
 const MEGA_MENU_VIEWPORT_PADDING = 16
 const MEGA_MENU_HOVER_BRIDGE_HEIGHT = 32
 
-function runMegaMenuBgTransition(update: () => void) {
+type MegaMenuBgFlipOptions = {
+  animationRef: React.MutableRefObject<Animation | null>
+  getElement: () => HTMLElement | null
+  update: () => void
+}
+
+function runMegaMenuBgFlip({
+  animationRef,
+  getElement,
+  update,
+}: MegaMenuBgFlipOptions) {
   if (
     typeof document === 'undefined' ||
     typeof window === 'undefined' ||
@@ -165,40 +175,79 @@ function runMegaMenuBgTransition(update: () => void) {
     return
   }
 
-  const startViewTransition: unknown = Reflect.get(
-    document,
-    'startViewTransition',
-  )
+  const previousElement = getElement()
+  const previousRect = previousElement?.getBoundingClientRect()
 
-  if (typeof startViewTransition !== 'function') {
-    update()
+  animationRef.current?.cancel()
+  animationRef.current = null
+
+  flushSync(update)
+
+  if (!previousRect) {
     return
   }
 
-  const removeTransitionClass = () => {
-    document.documentElement.classList.remove('ts-mega-bg-transitioning')
+  const nextElement = getElement()
+
+  if (!nextElement) {
+    return
   }
 
-  document.documentElement.classList.add('ts-mega-bg-transitioning')
+  if (typeof nextElement.animate !== 'function') {
+    return
+  }
 
-  try {
-    const transitionResult: unknown = startViewTransition.call(document, () => {
-      flushSync(update)
-    })
-    const finished =
-      transitionResult && typeof transitionResult === 'object'
-        ? Reflect.get(transitionResult, 'finished')
-        : null
+  const nextRect = nextElement.getBoundingClientRect()
 
-    if (finished instanceof Promise) {
-      finished.finally(removeTransitionClass)
-    } else {
-      window.setTimeout(removeTransitionClass, MEGA_MENU_BG_TRANSITION_MS)
+  if (
+    previousRect.width <= 0 ||
+    previousRect.height <= 0 ||
+    nextRect.width <= 0 ||
+    nextRect.height <= 0
+  ) {
+    return
+  }
+
+  const deltaX = previousRect.left - nextRect.left
+  const deltaY = previousRect.top - nextRect.top
+  const scaleX = previousRect.width / nextRect.width
+  const scaleY = previousRect.height / nextRect.height
+
+  if (
+    Math.abs(deltaX) < 0.5 &&
+    Math.abs(deltaY) < 0.5 &&
+    Math.abs(scaleX - 1) < 0.005 &&
+    Math.abs(scaleY - 1) < 0.005
+  ) {
+    return
+  }
+
+  nextElement.style.transformOrigin = 'top left'
+
+  const animation = nextElement.animate(
+    [
+      {
+        transform: `translate3d(${deltaX}px, ${deltaY}px, 0) scale(${scaleX}, ${scaleY})`,
+      },
+      { transform: 'translate3d(0, 0, 0) scale(1, 1)' },
+    ],
+    {
+      duration: MEGA_MENU_BG_TRANSITION_MS,
+      easing: 'cubic-bezier(0.42, 0, 0.18, 1)',
+      fill: 'both',
+    },
+  )
+
+  animationRef.current = animation
+
+  const clearAnimation = () => {
+    if (animationRef.current === animation) {
+      animationRef.current = null
+      nextElement.style.transformOrigin = ''
     }
-  } catch {
-    removeTransitionClass()
-    update()
   }
+
+  animation.finished.then(clearAnimation, clearAnimation)
 }
 const LIBRARY_MENU_GROUP_IDS: readonly LibraryGroupId[] = [
   'framework',
@@ -450,6 +499,16 @@ function getMenuGroup(key: NavMenuKey) {
   return NAV_GROUPS.find((group) => group.key === key)
 }
 
+function getNavMenuKey(value: string | undefined) {
+  for (const group of NAV_GROUPS) {
+    if (group.key === value) {
+      return group.key
+    }
+  }
+
+  return null
+}
+
 function getLibraryMenuGroups() {
   return LIBRARY_MENU_GROUP_IDS.map((groupId) => {
     const groupLibraries = librariesByGroup[groupId]
@@ -500,6 +559,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   const primaryNavRef = React.useRef<HTMLElement>(null)
   const megaMenuRef = React.useRef<HTMLDivElement>(null)
   const closeTimerRef = React.useRef<number | undefined>(undefined)
+  const megaMenuBgAnimationRef = React.useRef<Animation | null>(null)
   const activeMenuKeyRef = React.useRef<NavMenuKey | null>(null)
 
   React.useEffect(() => {
@@ -531,15 +591,9 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
   const [canLoadAuthControls, setCanLoadAuthControls] = React.useState(false)
 
-  React.useEffect(() => {
-    document.documentElement.classList.add('ts-nav-hydrated')
-
-    return () => {
-      document.documentElement.classList.remove('ts-nav-hydrated')
-    }
-  }, [])
-
   const closeMegaMenu = React.useCallback(() => {
+    megaMenuBgAnimationRef.current?.cancel()
+    megaMenuBgAnimationRef.current = null
     activeMenuKeyRef.current = null
     setActiveMenuKey(null)
   }, [])
@@ -600,25 +654,50 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     })
   }, [])
 
+  const getMegaMenuBgElement = React.useCallback(
+    () => megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-bg') ?? null,
+    [],
+  )
+
   const openMegaMenu = React.useCallback(
     (key: NavMenuKey) => {
       cancelMegaMenuClose()
-      updateMegaMenuLayout()
       const previousKey = activeMenuKeyRef.current
 
       const commitOpenState = () => {
+        updateMegaMenuLayout()
         activeMenuKeyRef.current = key
         setActiveMenuKey(key)
       }
 
       if (previousKey && previousKey !== key) {
-        runMegaMenuBgTransition(commitOpenState)
+        runMegaMenuBgFlip({
+          animationRef: megaMenuBgAnimationRef,
+          getElement: getMegaMenuBgElement,
+          update: commitOpenState,
+        })
       } else {
         commitOpenState()
       }
     },
-    [cancelMegaMenuClose, updateMegaMenuLayout],
+    [cancelMegaMenuClose, getMegaMenuBgElement, updateMegaMenuLayout],
   )
+
+  React.useLayoutEffect(() => {
+    const activeWrap = primaryNavRef.current?.querySelector<HTMLElement>(
+      '.ts-mega-trigger-wrap:hover, .ts-mega-trigger-wrap:focus-within',
+    )
+    const hydratedKey = getNavMenuKey(activeWrap?.dataset.menuKey)
+
+    if (hydratedKey) {
+      cancelMegaMenuClose()
+      updateMegaMenuLayout()
+      activeMenuKeyRef.current = hydratedKey
+      setActiveMenuKey(hydratedKey)
+    }
+
+    return undefined
+  }, [cancelMegaMenuClose, updateMegaMenuLayout])
 
   React.useEffect(() => {
     if (!activeMenuKey) {
@@ -757,6 +836,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
     return () => {
       cancelMegaMenuClose()
+      megaMenuBgAnimationRef.current?.cancel()
     }
   }, [cancelMegaMenuClose])
 
@@ -1013,10 +1093,11 @@ function DesktopNavTrigger({
   }
 
   return (
-    <div className="ts-mega-trigger-wrap">
+    <div className="ts-mega-trigger-wrap" data-menu-key={group.key}>
       {group.to ? (
         <Link
           to={group.to}
+          data-menu-key={group.key}
           data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
           preload="intent"
@@ -1027,6 +1108,7 @@ function DesktopNavTrigger({
       ) : (
         <button
           type="button"
+          data-menu-key={group.key}
           data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
           onClick={onOpen}
@@ -1035,27 +1117,6 @@ function DesktopNavTrigger({
           <span>{group.label}</span>
         </button>
       )}
-      <DesktopNavFallback group={group} />
-    </div>
-  )
-}
-
-function DesktopNavFallback({ group }: { group: NavMenuGroup }) {
-  return (
-    <div className="ts-mega-fallback">
-      <div
-        className={twMerge(
-          'ts-glass-menu rounded-xl',
-          'border border-white/45 bg-white/80 p-4 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
-          'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
-        )}
-      >
-        <MegaMenuContent
-          group={group}
-          onNavigate={() => undefined}
-          variant="desktop"
-        />
-      </div>
     </div>
   )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { flushSync } from 'react-dom'
 import { twMerge } from 'tailwind-merge'
 const LazyBrandContextMenu = React.lazy(() =>
   import('./BrandContextMenu').then((m) => ({ default: m.BrandContextMenu })),
@@ -108,11 +107,6 @@ type NavMenuKey =
   | 'merch'
   | 'support'
 
-type MegaMenuLayout = {
-  left: number
-  width: number
-}
-
 type NavMenuItem = {
   label: string
   to: string
@@ -148,107 +142,6 @@ type LibraryGroupId = keyof typeof librariesByGroup
 
 const DESKTOP_NAV_CLASS = 'hidden min-[960px]:flex'
 const MOBILE_NAV_CLASS = 'min-[960px]:hidden'
-const CLOSE_DELAY_MS = 140
-const MEGA_MENU_BG_TRANSITION_MS = 360
-const MEGA_MENU_MAX_WIDTH = 1120
-const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
-const MEGA_MENU_VIEWPORT_PADDING = 16
-const MEGA_MENU_HOVER_BRIDGE_HEIGHT = 32
-
-type MegaMenuBgFlipOptions = {
-  animationRef: React.MutableRefObject<Animation | null>
-  getElement: () => HTMLElement | null
-  update: () => void
-}
-
-function runMegaMenuBgFlip({
-  animationRef,
-  getElement,
-  update,
-}: MegaMenuBgFlipOptions) {
-  if (
-    typeof document === 'undefined' ||
-    typeof window === 'undefined' ||
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  ) {
-    update()
-    return
-  }
-
-  const previousElement = getElement()
-  const previousRect = previousElement?.getBoundingClientRect()
-
-  animationRef.current?.cancel()
-  animationRef.current = null
-
-  flushSync(update)
-
-  if (!previousRect) {
-    return
-  }
-
-  const nextElement = getElement()
-
-  if (!nextElement) {
-    return
-  }
-
-  if (typeof nextElement.animate !== 'function') {
-    return
-  }
-
-  const nextRect = nextElement.getBoundingClientRect()
-
-  if (
-    previousRect.width <= 0 ||
-    previousRect.height <= 0 ||
-    nextRect.width <= 0 ||
-    nextRect.height <= 0
-  ) {
-    return
-  }
-
-  const deltaX = previousRect.left - nextRect.left
-  const deltaY = previousRect.top - nextRect.top
-  const scaleX = previousRect.width / nextRect.width
-  const scaleY = previousRect.height / nextRect.height
-
-  if (
-    Math.abs(deltaX) < 0.5 &&
-    Math.abs(deltaY) < 0.5 &&
-    Math.abs(scaleX - 1) < 0.005 &&
-    Math.abs(scaleY - 1) < 0.005
-  ) {
-    return
-  }
-
-  nextElement.style.transformOrigin = 'top left'
-
-  const animation = nextElement.animate(
-    [
-      {
-        transform: `translate3d(${deltaX}px, ${deltaY}px, 0) scale(${scaleX}, ${scaleY})`,
-      },
-      { transform: 'translate3d(0, 0, 0) scale(1, 1)' },
-    ],
-    {
-      duration: MEGA_MENU_BG_TRANSITION_MS,
-      easing: 'cubic-bezier(0.42, 0, 0.18, 1)',
-      fill: 'both',
-    },
-  )
-
-  animationRef.current = animation
-
-  const clearAnimation = () => {
-    if (animationRef.current === animation) {
-      animationRef.current = null
-      nextElement.style.transformOrigin = ''
-    }
-  }
-
-  animation.finished.then(clearAnimation, clearAnimation)
-}
 const LIBRARY_MENU_GROUP_IDS: readonly LibraryGroupId[] = [
   'framework',
   'state',
@@ -495,20 +388,6 @@ function getLibraryDocsTo(library: NavigationLibrary) {
   return `${library.to}/latest/docs`
 }
 
-function getMenuGroup(key: NavMenuKey) {
-  return NAV_GROUPS.find((group) => group.key === key)
-}
-
-function getNavMenuKey(value: string | undefined) {
-  for (const group of NAV_GROUPS) {
-    if (group.key === value) {
-      return group.key
-    }
-  }
-
-  return null
-}
-
 function getLibraryMenuGroups() {
   return LIBRARY_MENU_GROUP_IDS.map((groupId) => {
     const groupLibraries = librariesByGroup[groupId]
@@ -556,11 +435,6 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   }, [matches])
 
   const containerRef = React.useRef<HTMLDivElement>(null)
-  const primaryNavRef = React.useRef<HTMLElement>(null)
-  const megaMenuRef = React.useRef<HTMLDivElement>(null)
-  const closeTimerRef = React.useRef<number | undefined>(undefined)
-  const megaMenuBgAnimationRef = React.useRef<Animation | null>(null)
-  const activeMenuKeyRef = React.useRef<NavMenuKey | null>(null)
 
   React.useEffect(() => {
     const updateContainerHeight = () => {
@@ -581,189 +455,12 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  const [activeMenuKey, setActiveMenuKey] = React.useState<NavMenuKey | null>(
-    null,
-  )
-  const [megaMenuLayout, setMegaMenuLayout] = React.useState<MegaMenuLayout>({
-    left: MEGA_MENU_VIEWPORT_PADDING,
-    width: MEGA_MENU_MAX_WIDTH,
-  })
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false)
   const [canLoadAuthControls, setCanLoadAuthControls] = React.useState(false)
 
-  const closeMegaMenu = React.useCallback(() => {
-    megaMenuBgAnimationRef.current?.cancel()
-    megaMenuBgAnimationRef.current = null
-    activeMenuKeyRef.current = null
-    setActiveMenuKey(null)
-  }, [])
-
-  const cancelMegaMenuClose = React.useCallback(() => {
-    if (closeTimerRef.current !== undefined) {
-      window.clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = undefined
-    }
-  }, [])
-
-  const scheduleMegaMenuClose = React.useCallback(() => {
-    cancelMegaMenuClose()
-    closeTimerRef.current = window.setTimeout(() => {
-      closeMegaMenu()
-    }, CLOSE_DELAY_MS)
-  }, [cancelMegaMenuClose, closeMegaMenu])
-
-  const updateMegaMenuLayout = React.useCallback(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    const trigger =
-      primaryNavRef.current?.querySelector<HTMLElement>('.ts-mega-trigger')
-    const viewportWidth = window.innerWidth
-    const availableWidth = Math.max(
-      0,
-      viewportWidth - MEGA_MENU_VIEWPORT_PADDING * 2,
-    )
-    const triggerLeft = Math.round(
-      trigger?.getBoundingClientRect().left ?? MEGA_MENU_VIEWPORT_PADDING,
-    )
-    const alignedWidth = Math.min(
-      MEGA_MENU_MAX_WIDTH,
-      Math.max(0, viewportWidth - triggerLeft - MEGA_MENU_VIEWPORT_PADDING),
-    )
-    const nextLayout =
-      alignedWidth >= MEGA_MENU_MIN_ALIGNED_WIDTH
-        ? {
-            left: triggerLeft,
-            width: alignedWidth,
-          }
-        : {
-            left: MEGA_MENU_VIEWPORT_PADDING,
-            width: availableWidth,
-          }
-
-    setMegaMenuLayout((previousLayout) => {
-      if (
-        previousLayout.left === nextLayout.left &&
-        previousLayout.width === nextLayout.width
-      ) {
-        return previousLayout
-      }
-
-      return nextLayout
-    })
-  }, [])
-
-  const getMegaMenuBgElement = React.useCallback(
-    () =>
-      megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-bg') ?? null,
-    [],
-  )
-
-  const openMegaMenu = React.useCallback(
-    (key: NavMenuKey) => {
-      cancelMegaMenuClose()
-      const previousKey = activeMenuKeyRef.current
-
-      const commitOpenState = () => {
-        updateMegaMenuLayout()
-        activeMenuKeyRef.current = key
-        setActiveMenuKey(key)
-      }
-
-      if (previousKey && previousKey !== key) {
-        runMegaMenuBgFlip({
-          animationRef: megaMenuBgAnimationRef,
-          getElement: getMegaMenuBgElement,
-          update: commitOpenState,
-        })
-      } else {
-        commitOpenState()
-      }
-    },
-    [cancelMegaMenuClose, getMegaMenuBgElement, updateMegaMenuLayout],
-  )
-
-  React.useLayoutEffect(() => {
-    const activeWrap = primaryNavRef.current?.querySelector<HTMLElement>(
-      '.ts-mega-trigger-wrap:hover, .ts-mega-trigger-wrap:focus-within',
-    )
-    const hydratedKey = getNavMenuKey(activeWrap?.dataset.menuKey)
-
-    if (hydratedKey) {
-      cancelMegaMenuClose()
-      updateMegaMenuLayout()
-      activeMenuKeyRef.current = hydratedKey
-      setActiveMenuKey(hydratedKey)
-    }
-
-    return undefined
-  }, [cancelMegaMenuClose, updateMegaMenuLayout])
-
   React.useEffect(() => {
-    if (!activeMenuKey) {
-      return
-    }
-
-    updateMegaMenuLayout()
-    window.addEventListener('resize', updateMegaMenuLayout)
-
-    return () => {
-      window.removeEventListener('resize', updateMegaMenuLayout)
-    }
-  }, [activeMenuKey, updateMegaMenuLayout])
-
-  React.useEffect(() => {
-    if (!activeMenuKey) {
-      return
-    }
-
-    const onPointerMove = (event: PointerEvent) => {
-      if (event.pointerType === 'touch') {
-        return
-      }
-
-      const target = event.target
-
-      if (
-        target instanceof Node &&
-        (containerRef.current?.contains(target) ||
-          megaMenuRef.current?.contains(target))
-      ) {
-        cancelMegaMenuClose()
-        return
-      }
-
-      const panel =
-        megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-panel')
-
-      if (!panel) {
-        return
-      }
-
-      const rect = panel.getBoundingClientRect()
-      const withinPanelX =
-        event.clientX >= rect.left && event.clientX <= rect.right
-      const withinPanelOrBridgeY =
-        event.clientY >= rect.top - MEGA_MENU_HOVER_BRIDGE_HEIGHT &&
-        event.clientY <= rect.bottom
-
-      if (withinPanelX && withinPanelOrBridgeY) {
-        cancelMegaMenuClose()
-      }
-    }
-
-    document.addEventListener('pointermove', onPointerMove)
-
-    return () => {
-      document.removeEventListener('pointermove', onPointerMove)
-    }
-  }, [activeMenuKey, cancelMegaMenuClose])
-
-  React.useEffect(() => {
-    closeMegaMenu()
     setMobileMenuOpen(false)
-  }, [closeMegaMenu, location.pathname, location.hash])
+  }, [location.pathname, location.hash])
 
   React.useEffect(() => {
     if (typeof window === 'undefined') {
@@ -793,53 +490,22 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   }, [])
 
   React.useEffect(() => {
-    if (!activeMenuKey && !mobileMenuOpen) {
+    if (!mobileMenuOpen) {
       return
     }
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        closeMegaMenu()
         setMobileMenuOpen(false)
       }
     }
 
-    const onPointerDown = (event: PointerEvent) => {
-      if (!activeMenuKey) {
-        return
-      }
-
-      const target = event.target
-
-      if (!(target instanceof Node)) {
-        return
-      }
-
-      if (
-        containerRef.current?.contains(target) ||
-        megaMenuRef.current?.contains(target)
-      ) {
-        return
-      }
-
-      closeMegaMenu()
-    }
-
     document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('pointerdown', onPointerDown)
 
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('pointerdown', onPointerDown)
     }
-  }, [activeMenuKey, closeMegaMenu, mobileMenuOpen])
-
-  React.useEffect(() => {
-    return () => {
-      cancelMegaMenuClose()
-      megaMenuBgAnimationRef.current?.cancel()
-    }
-  }, [cancelMegaMenuClose])
+  }, [mobileMenuOpen])
 
   const getLoginButtonFallback = (className?: string) => (
     <Link
@@ -867,7 +533,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     )
 
   const socialLinks = <SocialStack />
-  const siteBackdropActive = Boolean(activeMenuKey || mobileMenuOpen)
+  const siteBackdropActive = mobileMenuOpen
 
   const navbar = (
     <div
@@ -895,25 +561,14 @@ export function Navbar({ children }: { children: React.ReactNode }) {
         </div>
 
         <nav
-          ref={primaryNavRef}
           aria-label="Primary navigation"
           className={twMerge(
             DESKTOP_NAV_CLASS,
             'relative shrink-0 items-center gap-1',
           )}
-          onPointerEnter={cancelMegaMenuClose}
-          onPointerLeave={(event) => {
-            if (event.pointerType === 'touch') return
-            scheduleMegaMenuClose()
-          }}
         >
           {NAV_GROUPS.map((group) => (
-            <DesktopNavTrigger
-              key={group.key}
-              group={group}
-              isOpen={activeMenuKey === group.key}
-              onOpen={() => openMegaMenu(group.key)}
-            />
+            <DesktopNavTrigger key={group.key} group={group} />
           ))}
         </nav>
       </div>
@@ -946,48 +601,6 @@ export function Navbar({ children }: { children: React.ReactNode }) {
             <Menu className="h-5 w-5" />
           )}
         </button>
-      </div>
-    </div>
-  )
-
-  const desktopMegaMenu = (
-    <div
-      ref={megaMenuRef}
-      className={twMerge(
-        DESKTOP_NAV_CLASS,
-        'fixed left-0 right-0 top-[var(--navbar-height)] z-[90] justify-start',
-        'pointer-events-none',
-      )}
-    >
-      <div
-        data-open={activeMenuKey ? 'true' : 'false'}
-        style={{
-          marginLeft: megaMenuLayout.left,
-          width: megaMenuLayout.width,
-        }}
-        className="ts-mega-panel mt-2 rounded-xl p-4"
-        onPointerEnter={(event) => {
-          if (event.pointerType === 'touch') return
-          cancelMegaMenuClose()
-        }}
-        onPointerLeave={(event) => {
-          if (event.pointerType === 'touch') return
-          scheduleMegaMenuClose()
-        }}
-      >
-        <div
-          key={activeMenuKey ?? 'closed'}
-          aria-hidden="true"
-          className={twMerge(
-            'ts-mega-bg rounded-xl',
-            'border border-white/45 bg-white/80 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
-            'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
-          )}
-        />
-        <MegaMenuContentTransition
-          activeKey={activeMenuKey}
-          onNavigate={closeMegaMenu}
-        />
       </div>
     </div>
   )
@@ -1041,7 +654,6 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   return (
     <>
       {navbar}
-      {desktopMegaMenu}
       {mobileMenu}
       <div
         aria-hidden="true"
@@ -1070,28 +682,12 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   )
 }
 
-function DesktopNavTrigger({
-  group,
-  isOpen,
-  onOpen,
-}: {
-  group: NavMenuGroup
-  isOpen: boolean
-  onOpen: () => void
-}) {
+function DesktopNavTrigger({ group }: { group: NavMenuGroup }) {
   const triggerClassName = twMerge(
     'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-2 py-2 text-sm font-bold',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
-    isOpen && 'bg-gray-500/10 text-gray-950 dark:text-white',
   )
-  const triggerEvents = {
-    onPointerEnter: (event: React.PointerEvent<HTMLElement>) => {
-      if (event.pointerType === 'touch') return
-      onOpen()
-    },
-    onFocus: onOpen,
-  }
 
   return (
     <div className="ts-mega-trigger-wrap" data-menu-key={group.key}>
@@ -1099,10 +695,8 @@ function DesktopNavTrigger({
         <Link
           to={group.to}
           data-menu-key={group.key}
-          data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
           preload="intent"
-          {...triggerEvents}
         >
           <span>{group.label}</span>
         </Link>
@@ -1110,14 +704,32 @@ function DesktopNavTrigger({
         <button
           type="button"
           data-menu-key={group.key}
-          data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
-          onClick={onOpen}
-          {...triggerEvents}
         >
           <span>{group.label}</span>
         </button>
       )}
+      <DesktopNavDropdown group={group} />
+    </div>
+  )
+}
+
+function DesktopNavDropdown({ group }: { group: NavMenuGroup }) {
+  return (
+    <div className="ts-mega-dropdown">
+      <div
+        className={twMerge(
+          'ts-mega-dropdown-panel ts-glass-menu rounded-xl',
+          'border border-white/45 bg-white/80 p-4 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+          'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
+        )}
+      >
+        <MegaMenuContent
+          group={group}
+          onNavigate={() => undefined}
+          variant="desktop"
+        />
+      </div>
     </div>
   )
 }
@@ -1169,30 +781,6 @@ function MobileMenuGroup({
         </>
       )}
     </Collapsible>
-  )
-}
-
-function MegaMenuContentTransition({
-  activeKey,
-  onNavigate,
-}: {
-  activeKey: NavMenuKey | null
-  onNavigate: () => void
-}) {
-  const group = activeKey ? getMenuGroup(activeKey) : null
-
-  if (!group) {
-    return null
-  }
-
-  return (
-    <div key={activeKey} className="ts-mega-content">
-      <MegaMenuContent
-        group={group}
-        onNavigate={onNavigate}
-        variant="desktop"
-      />
-    </div>
   )
 }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,8 +24,10 @@ import {
   HelpCircle,
   Mail,
   Menu,
+  Minus,
   Newspaper,
   Paintbrush,
+  Plus,
   ShieldCheck,
   Shirt,
   Sparkles,
@@ -159,7 +161,6 @@ const DESKTOP_NAV_CLASS = 'hidden min-[1024px]:flex'
 const MOBILE_NAV_CLASS = 'min-[1024px]:hidden'
 const CLOSE_DELAY_MS = 140
 const MEGA_MENU_TRANSITION_MS = 400
-const MEGA_MENU_PANEL_CLOSE_MS = 180
 const MEGA_MENU_MAX_WIDTH = 1120
 const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
 const MEGA_MENU_VIEWPORT_PADDING = 16
@@ -924,8 +925,6 @@ function DesktopNavTrigger({
       {group.to ? (
         <Link
           to={group.to}
-          aria-expanded={isOpen}
-          aria-haspopup="menu"
           data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
           preload="intent"
@@ -936,8 +935,6 @@ function DesktopNavTrigger({
       ) : (
         <button
           type="button"
-          aria-expanded={isOpen}
-          aria-haspopup="menu"
           data-open={isOpen ? 'true' : 'false'}
           className={triggerClassName}
           onClick={onOpen}
@@ -982,15 +979,46 @@ function MobileMenuGroup({
     <Collapsible className="overflow-hidden rounded-lg border border-gray-500/10 bg-white/35 dark:border-white/10 dark:bg-white/[0.03]">
       {({ open }) => (
         <>
-          <CollapsibleTrigger
-            className={twMerge(
-              'flex w-full items-center px-3 py-3 text-left font-black text-gray-800',
-              'hover:text-gray-950 dark:text-gray-200 dark:hover:text-white',
-              open && 'text-gray-950 dark:text-white',
-            )}
-          >
-            {group.label}
-          </CollapsibleTrigger>
+          {group.to ? (
+            <div className="flex items-center">
+              <Link
+                to={group.to}
+                onClick={onNavigate}
+                className={twMerge(
+                  'min-w-0 flex-1 px-3 py-3 text-left font-black text-gray-800',
+                  'hover:text-gray-950 focus:outline-none dark:text-gray-200 dark:hover:text-white',
+                  open && 'text-gray-950 dark:text-white',
+                )}
+                preload="intent"
+              >
+                {group.label}
+              </Link>
+              <CollapsibleTrigger
+                aria-label={`${open ? 'Collapse' : 'Expand'} ${group.label}`}
+                className={twMerge(
+                  'mr-1 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-gray-600',
+                  'hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none',
+                  'dark:text-gray-300 dark:hover:text-white dark:focus:text-white',
+                )}
+              >
+                {open ? (
+                  <Minus className="h-4 w-4" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+              </CollapsibleTrigger>
+            </div>
+          ) : (
+            <CollapsibleTrigger
+              className={twMerge(
+                'flex w-full items-center px-3 py-3 text-left font-black text-gray-800',
+                'hover:text-gray-950 dark:text-gray-200 dark:hover:text-white',
+                open && 'text-gray-950 dark:text-white',
+              )}
+            >
+              {group.label}
+            </CollapsibleTrigger>
+          )}
           <CollapsibleContent className="border-t border-gray-500/10 motion-reduce:transition-none dark:border-white/10">
             <div className="px-2 pb-3 pt-1">
               <MegaMenuContent
@@ -1022,13 +1050,8 @@ function MegaMenuContentTransition({
   React.useLayoutEffect(() => {
     if (activeKey === null) {
       previousActiveRef.current = null
-      const timeoutId = window.setTimeout(() => {
-        setPanes([])
-      }, MEGA_MENU_PANEL_CLOSE_MS)
-
-      return () => {
-        window.clearTimeout(timeoutId)
-      }
+      setPanes([])
+      return
     }
 
     const previousActive = previousActiveRef.current

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,10 +24,8 @@ import {
   HelpCircle,
   Mail,
   Menu,
-  Minus,
   Newspaper,
   Paintbrush,
-  Plus,
   ShieldCheck,
   Shirt,
   Sparkles,
@@ -157,13 +155,14 @@ type NavigationLibrary = LibrarySlim & {
 
 type LibraryGroupId = keyof typeof librariesByGroup
 
-const DESKTOP_NAV_CLASS = 'hidden min-[1024px]:flex'
-const MOBILE_NAV_CLASS = 'min-[1024px]:hidden'
+const DESKTOP_NAV_CLASS = 'hidden min-[960px]:flex'
+const MOBILE_NAV_CLASS = 'min-[960px]:hidden'
 const CLOSE_DELAY_MS = 140
 const MEGA_MENU_TRANSITION_MS = 400
 const MEGA_MENU_MAX_WIDTH = 1120
 const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
 const MEGA_MENU_VIEWPORT_PADDING = 16
+const MEGA_MENU_HOVER_BRIDGE_HEIGHT = 32
 const MEGA_MENU_ORDER: Record<NavMenuKey, number> = {
   libraries: 0,
   learn: 1,
@@ -610,6 +609,53 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   }, [activeMenuKey, updateMegaMenuLayout])
 
   React.useEffect(() => {
+    if (!activeMenuKey) {
+      return
+    }
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerType === 'touch') {
+        return
+      }
+
+      const target = event.target
+
+      if (
+        target instanceof Node &&
+        (containerRef.current?.contains(target) ||
+          megaMenuRef.current?.contains(target))
+      ) {
+        cancelMegaMenuClose()
+        return
+      }
+
+      const panel =
+        megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-panel')
+
+      if (!panel) {
+        return
+      }
+
+      const rect = panel.getBoundingClientRect()
+      const withinPanelX =
+        event.clientX >= rect.left && event.clientX <= rect.right
+      const withinPanelOrBridgeY =
+        event.clientY >= rect.top - MEGA_MENU_HOVER_BRIDGE_HEIGHT &&
+        event.clientY <= rect.bottom
+
+      if (withinPanelX && withinPanelOrBridgeY) {
+        cancelMegaMenuClose()
+      }
+    }
+
+    document.addEventListener('pointermove', onPointerMove)
+
+    return () => {
+      document.removeEventListener('pointermove', onPointerMove)
+    }
+  }, [activeMenuKey, cancelMegaMenuClose])
+
+  React.useEffect(() => {
     closeMegaMenu()
     setMobileMenuOpen(false)
   }, [closeMegaMenu, location.pathname, location.hash])
@@ -689,21 +735,33 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     }
   }, [cancelMegaMenuClose])
 
-  const loginButtonFallback = (
+  const getLoginButtonFallback = (className?: string) => (
     <Link
       to="/login"
       aria-label="Log In"
-      className="flex shrink-0 items-center gap-1 rounded-md px-2 py-1.5 whitespace-nowrap
-             bg-black dark:bg-white text-white dark:text-black
-             hover:bg-gray-800 dark:hover:bg-gray-200
-             transition-colors duration-200 text-xs font-medium"
+      className={twMerge(
+        'flex shrink-0 items-center gap-1 rounded-md px-2 py-1.5 whitespace-nowrap',
+        'bg-black dark:bg-white text-white dark:text-black',
+        'hover:bg-gray-800 dark:hover:bg-gray-200',
+        'transition-colors duration-200 text-xs font-medium',
+        className,
+      )}
     >
       <User className="w-3.5 h-3.5" />
       <span className="hidden min-[430px]:inline">Log In</span>
     </Link>
   )
+  const renderAuthControls = (className?: string) =>
+    canLoadAuthControls ? (
+      <React.Suspense fallback={getLoginButtonFallback(className)}>
+        <LazyNavbarAuthControls className={className} />
+      </React.Suspense>
+    ) : (
+      getLoginButtonFallback(className)
+    )
 
   const socialLinks = <SocialStack />
+  const siteBackdropActive = Boolean(activeMenuKey || mobileMenuOpen)
 
   const navbar = (
     <div
@@ -755,21 +813,13 @@ export function Navbar({ children }: { children: React.ReactNode }) {
       </div>
 
       <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
-        <div className="hidden min-[750px]:block">{socialLinks}</div>
+        <div className={DESKTOP_NAV_CLASS}>{socialLinks}</div>
         <ThemeToggle />
-        <div className="hidden sm:block">
-          <SearchButton iconOnly />
-        </div>
         <NavbarCartButton />
+        <SearchButton iconOnly />
         <AiDockButton />
-        <div className="flex items-center gap-2">
-          {canLoadAuthControls ? (
-            <React.Suspense fallback={loginButtonFallback}>
-              <LazyNavbarAuthControls />
-            </React.Suspense>
-          ) : (
-            loginButtonFallback
-          )}
+        <div className={twMerge(DESKTOP_NAV_CLASS, 'items-center gap-2')}>
+          {renderAuthControls()}
         </div>
         <button
           type="button"
@@ -778,7 +828,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           aria-controls="primary-mobile-menu"
           className={twMerge(
             'inline-flex h-9 w-9 items-center justify-center rounded-md',
-            'border border-gray-500/20 text-gray-700 transition-colors hover:bg-gray-500/10',
+            'text-gray-700 transition-colors hover:bg-gray-500/10',
             'dark:text-gray-200',
             MOBILE_NAV_CLASS,
           )}
@@ -832,37 +882,51 @@ export function Navbar({ children }: { children: React.ReactNode }) {
     </div>
   )
 
-  const mobileMenu = mobileMenuOpen ? (
-    <div
-      id="primary-mobile-menu"
-      data-mobile-menu
-      className={twMerge(
-        MOBILE_NAV_CLASS,
-        'fixed left-0 right-0 top-[var(--navbar-height)] z-[90] isolate',
-        'max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto',
-        'border-b border-white/45 bg-white/85 text-base shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
-        'dark:border-white/10 dark:bg-black/75 dark:shadow-black/50',
-      )}
+  const mobileMenu = (
+    <Collapsible
+      open={mobileMenuOpen}
+      onOpenChange={setMobileMenuOpen}
+      className={MOBILE_NAV_CLASS}
     >
-      <div className="border-t border-white/30 dark:border-white/10">
-        <div className="p-2 sm:hidden">
-          <SearchButton className="w-full py-3 text-base [&_svg]:w-5 [&_svg]:h-5" />
+      <CollapsibleContent
+        className={twMerge(
+          'fixed left-0 right-0 top-[var(--navbar-height)] z-[90]',
+          'motion-reduce:transition-none',
+          mobileMenuOpen ? 'pointer-events-auto' : 'pointer-events-none',
+        )}
+      >
+        <div
+          id="primary-mobile-menu"
+          data-mobile-menu
+          aria-hidden={!mobileMenuOpen}
+          className={twMerge(
+            'ts-glass-menu max-h-[calc(100dvh-var(--navbar-height))] overflow-y-auto',
+            'border-b border-white/45 bg-white/80 text-base shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+            'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
+          )}
+        >
+          <div className="border-t border-white/30 dark:border-white/10">
+            <div className="flex items-center justify-end gap-2 p-2">
+              {socialLinks}
+              {renderAuthControls('h-9 px-3 text-sm')}
+            </div>
+            <nav
+              className="grid gap-1.5 px-2 pb-2"
+              aria-label="Mobile navigation"
+            >
+              {NAV_GROUPS.map((group) => (
+                <MobileMenuGroup
+                  key={group.key}
+                  group={group}
+                  onNavigate={() => setMobileMenuOpen(false)}
+                />
+              ))}
+            </nav>
+          </div>
         </div>
-        <nav className="grid gap-1.5 px-2 pb-2" aria-label="Mobile navigation">
-          {NAV_GROUPS.map((group) => (
-            <MobileMenuGroup
-              key={group.key}
-              group={group}
-              onNavigate={() => setMobileMenuOpen(false)}
-            />
-          ))}
-        </nav>
-        <div className="border-t border-gray-500/10 p-3 sm:hidden">
-          {socialLinks}
-        </div>
-      </div>
-    </div>
-  ) : null
+      </CollapsibleContent>
+    </Collapsible>
+  )
 
   return (
     <>
@@ -873,10 +937,9 @@ export function Navbar({ children }: { children: React.ReactNode }) {
         aria-hidden="true"
         data-site-menu-tint
         className={twMerge(
-          DESKTOP_NAV_CLASS,
           'pointer-events-none fixed inset-x-0 bottom-0 top-[var(--navbar-height)] z-[80]',
           'bg-white/45 transition-opacity duration-200 motion-reduce:transition-none dark:bg-black/45',
-          activeMenuKey ? 'opacity-100' : 'opacity-0',
+          siteBackdropActive ? 'opacity-100' : 'opacity-0',
         )}
       />
       <div
@@ -885,7 +948,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           `min-h-[calc(100dvh-var(--navbar-height))] flex flex-col
           min-w-0 w-full transition-[filter] duration-200 motion-reduce:transition-none
           pt-[var(--navbar-height)]`,
-          activeMenuKey ? 'blur-[4px]' : 'filter-none',
+          siteBackdropActive ? 'blur-[4px]' : 'filter-none',
         )}
       >
         <div className="flex-1 min-w-0 flex flex-col w-full min-h-0">
@@ -907,7 +970,7 @@ function DesktopNavTrigger({
   onOpen: () => void
 }) {
   const triggerClassName = twMerge(
-    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-2.5 py-2 text-sm font-bold',
+    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-2 py-2 text-sm font-bold',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
     isOpen && 'bg-gray-500/10 text-gray-950 dark:text-white',
@@ -981,31 +1044,15 @@ function MobileMenuGroup({
         <>
           {group.to ? (
             <div className="flex items-center">
-              <Link
-                to={group.to}
-                onClick={onNavigate}
-                className={twMerge(
-                  'min-w-0 flex-1 px-3 py-3 text-left font-black text-gray-800',
-                  'hover:text-gray-950 focus:outline-none dark:text-gray-200 dark:hover:text-white',
-                  open && 'text-gray-950 dark:text-white',
-                )}
-                preload="intent"
-              >
-                {group.label}
-              </Link>
               <CollapsibleTrigger
                 aria-label={`${open ? 'Collapse' : 'Expand'} ${group.label}`}
                 className={twMerge(
-                  'mr-1 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-gray-600',
-                  'hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none',
-                  'dark:text-gray-300 dark:hover:text-white dark:focus:text-white',
+                  'flex min-w-0 flex-1 items-center px-3 py-3 text-left font-black text-gray-800',
+                  'hover:text-gray-950 focus:outline-none dark:text-gray-200 dark:hover:text-white',
+                  open && 'text-gray-950 dark:text-white',
                 )}
               >
-                {open ? (
-                  <Minus className="h-4 w-4" />
-                ) : (
-                  <Plus className="h-4 w-4" />
-                )}
+                <span className="min-w-0 flex-1 truncate">{group.label}</span>
               </CollapsibleTrigger>
             </div>
           ) : (
@@ -1159,8 +1206,14 @@ function MegaMenuContent({
               'md:grid-cols-2',
           )}
         >
-          {group.sections.map((section) => (
-            <div key={section.label}>
+          {group.sections.map((section, sectionIndex) => (
+            <div
+              key={section.label}
+              className={twMerge(
+                variant === 'mobile' && sectionIndex === 0 && 'pt-1.5',
+                variant === 'mobile' && sectionIndex > 0 && 'pt-3',
+              )}
+            >
               <div className="mb-2 px-2 text-xs font-black uppercase text-gray-500 dark:text-gray-400">
                 {section.label}
               </div>
@@ -1200,6 +1253,12 @@ function LibrariesMenuContent({
   variant: 'desktop' | 'mobile'
 }) {
   const libraryMenuGroups = getLibraryMenuGroups()
+  const allLibrariesItem: NavMenuItem = {
+    label: 'All Libraries',
+    to: '/libraries',
+    description: 'Browse the full set of public packages.',
+    icon: Grid2X2,
+  }
 
   return (
     <div
@@ -1217,6 +1276,14 @@ function LibrariesMenuContent({
               : 'grid gap-3',
           )}
         >
+          {variant === 'mobile' ? (
+            <MenuItemLink
+              item={allLibrariesItem}
+              onNavigate={onNavigate}
+              variant="mobile"
+              compact
+            />
+          ) : null}
           {libraryMenuGroups.map((group) => (
             <LibraryMenuGroup
               key={group.id}
@@ -1227,21 +1294,19 @@ function LibrariesMenuContent({
           ))}
         </div>
       </div>
-      <MenuRail
-        rail={{
-          eyebrow: 'Browse',
-          title: 'All TanStack libraries',
-          description:
-            'Filter by framework and compare the full set of public packages.',
-          item: {
-            label: 'All Libraries',
-            to: '/libraries',
-            icon: Grid2X2,
-          },
-        }}
-        onNavigate={onNavigate}
-        variant={variant}
-      />
+      {variant === 'desktop' ? (
+        <MenuRail
+          rail={{
+            eyebrow: 'Browse',
+            title: 'All TanStack libraries',
+            description:
+              'Filter by framework and compare the full set of public packages.',
+            item: allLibrariesItem,
+          }}
+          onNavigate={onNavigate}
+          variant={variant}
+        />
+      ) : null}
     </div>
   )
 }
@@ -1265,15 +1330,21 @@ function LibraryMenuGroup({
       )}
     >
       <div className="mb-1.5 px-1">
-        <Link
-          to="/stack/$category"
-          params={{ category: categorySlug }}
-          onClick={onNavigate}
-          className="inline-flex rounded px-1 py-0.5 text-xs font-black uppercase text-gray-500 hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none dark:text-gray-400 dark:hover:text-white dark:focus:text-white"
-          preload="intent"
-        >
-          {group.label}
-        </Link>
+        {variant === 'desktop' ? (
+          <Link
+            to="/stack/$category"
+            params={{ category: categorySlug }}
+            onClick={onNavigate}
+            className="inline-flex rounded px-1 py-0.5 text-xs font-black uppercase text-gray-500 hover:bg-gray-500/10 hover:text-gray-950 focus:bg-gray-500/10 focus:text-gray-950 focus:outline-none dark:text-gray-400 dark:hover:text-white dark:focus:text-white"
+            preload="intent"
+          >
+            {group.label}
+          </Link>
+        ) : (
+          <div className="px-1 py-0.5 text-xs font-black uppercase text-gray-500 dark:text-gray-400">
+            {group.label}
+          </div>
+        )}
       </div>
       <div className="grid gap-0.5">
         {group.libraries.map((library) => (
@@ -1506,7 +1577,7 @@ function SocialStack() {
           type="button"
           aria-label="TanStack social channels"
           title="Social channels"
-          className="inline-flex h-9 items-center pl-1 pr-2"
+          className="inline-flex h-9 items-center px-0"
         >
           <span className="relative inline-flex items-center">
             {stackTop.map(({ label, Icon }, i) => (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -684,7 +684,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
 
 function DesktopNavTrigger({ group }: { group: NavMenuGroup }) {
   const triggerClassName = twMerge(
-    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium',
+    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-[13px] font-medium',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -156,17 +156,6 @@ const NAV_GROUPS = [
     label: 'Libraries',
     to: '/libraries',
     sections: [],
-    rail: {
-      eyebrow: 'Browse',
-      title: 'All TanStack libraries',
-      description:
-        'Filter the ecosystem by framework and find the right package faster.',
-      item: {
-        label: 'All Libraries',
-        to: '/libraries',
-        icon: Grid2X2,
-      },
-    },
   },
   {
     key: 'learn',

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -564,7 +564,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           aria-label="Primary navigation"
           className={twMerge(
             DESKTOP_NAV_CLASS,
-            'relative shrink-0 items-center gap-1',
+            'relative shrink-0 items-center gap-0',
           )}
         >
           {NAV_GROUPS.map((group) => (
@@ -684,7 +684,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
 
 function DesktopNavTrigger({ group }: { group: NavMenuGroup }) {
   const triggerClassName = twMerge(
-    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-2 py-2 text-sm font-bold',
+    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-bold',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -684,7 +684,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
 
 function DesktopNavTrigger({ group }: { group: NavMenuGroup }) {
   const triggerClassName = twMerge(
-    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-bold',
+    'ts-mega-trigger inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium',
     'text-gray-700 transition-colors hover:bg-gray-500/10 hover:text-gray-950',
     'dark:text-gray-300 dark:hover:text-white',
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1379,7 +1379,7 @@ function LibraryMenuItem({
       >
         <span
           className={twMerge(
-            'h-4 w-3.5 shrink-0 rounded-[5px] border border-white/50',
+            'h-4 w-3.5 shrink-0 rounded-[5px] border border-white/30',
             library.bgStyle,
           )}
         />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -655,7 +655,8 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   }, [])
 
   const getMegaMenuBgElement = React.useCallback(
-    () => megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-bg') ?? null,
+    () =>
+      megaMenuRef.current?.querySelector<HTMLElement>('.ts-mega-bg') ?? null,
     [],
   )
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -872,7 +872,7 @@ function LibrariesMenuContent({
     <div
       className={twMerge(
         variant === 'desktop'
-          ? 'grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]'
+          ? 'grid gap-4'
           : 'grid gap-3',
       )}
     >
@@ -902,19 +902,6 @@ function LibrariesMenuContent({
           ))}
         </div>
       </div>
-      {variant === 'desktop' ? (
-        <MenuRail
-          rail={{
-            eyebrow: 'Browse',
-            title: 'All TanStack libraries',
-            description:
-              'Filter by framework and compare the full set of public packages.',
-            item: allLibrariesItem,
-          }}
-          onNavigate={onNavigate}
-          variant={variant}
-        />
-      ) : null}
     </div>
   )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { flushSync } from 'react-dom'
 import { twMerge } from 'tailwind-merge'
 const LazyBrandContextMenu = React.lazy(() =>
   import('./BrandContextMenu').then((m) => ({ default: m.BrandContextMenu })),
@@ -107,16 +108,6 @@ type NavMenuKey =
   | 'merch'
   | 'support'
 
-type MegaMenuDirection = 'left' | 'right' | 'down'
-type MegaMenuPanePhase = 'enter' | 'exit' | 'current'
-
-type MegaMenuPane = {
-  id: number
-  key: NavMenuKey
-  phase: MegaMenuPanePhase
-  direction: MegaMenuDirection
-}
-
 type MegaMenuLayout = {
   left: number
   width: number
@@ -158,18 +149,56 @@ type LibraryGroupId = keyof typeof librariesByGroup
 const DESKTOP_NAV_CLASS = 'hidden min-[960px]:flex'
 const MOBILE_NAV_CLASS = 'min-[960px]:hidden'
 const CLOSE_DELAY_MS = 140
-const MEGA_MENU_TRANSITION_MS = 400
+const MEGA_MENU_BG_TRANSITION_MS = 360
 const MEGA_MENU_MAX_WIDTH = 1120
 const MEGA_MENU_MIN_ALIGNED_WIDTH = 960
 const MEGA_MENU_VIEWPORT_PADDING = 16
 const MEGA_MENU_HOVER_BRIDGE_HEIGHT = 32
-const MEGA_MENU_ORDER: Record<NavMenuKey, number> = {
-  libraries: 0,
-  learn: 1,
-  community: 2,
-  tools: 3,
-  merch: 4,
-  support: 5,
+
+function runMegaMenuBgTransition(update: () => void) {
+  if (
+    typeof document === 'undefined' ||
+    typeof window === 'undefined' ||
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ) {
+    update()
+    return
+  }
+
+  const startViewTransition: unknown = Reflect.get(
+    document,
+    'startViewTransition',
+  )
+
+  if (typeof startViewTransition !== 'function') {
+    update()
+    return
+  }
+
+  const removeTransitionClass = () => {
+    document.documentElement.classList.remove('ts-mega-bg-transitioning')
+  }
+
+  document.documentElement.classList.add('ts-mega-bg-transitioning')
+
+  try {
+    const transitionResult: unknown = startViewTransition.call(document, () => {
+      flushSync(update)
+    })
+    const finished =
+      transitionResult && typeof transitionResult === 'object'
+        ? Reflect.get(transitionResult, 'finished')
+        : null
+
+    if (finished instanceof Promise) {
+      finished.finally(removeTransitionClass)
+    } else {
+      window.setTimeout(removeTransitionClass, MEGA_MENU_BG_TRANSITION_MS)
+    }
+  } catch {
+    removeTransitionClass()
+    update()
+  }
 }
 const LIBRARY_MENU_GROUP_IDS: readonly LibraryGroupId[] = [
   'framework',
@@ -495,8 +524,6 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   const [activeMenuKey, setActiveMenuKey] = React.useState<NavMenuKey | null>(
     null,
   )
-  const [megaMenuDirection, setMegaMenuDirection] =
-    React.useState<MegaMenuDirection>('down')
   const [megaMenuLayout, setMegaMenuLayout] = React.useState<MegaMenuLayout>({
     left: MEGA_MENU_VIEWPORT_PADDING,
     width: MEGA_MENU_MAX_WIDTH,
@@ -579,18 +606,16 @@ export function Navbar({ children }: { children: React.ReactNode }) {
       updateMegaMenuLayout()
       const previousKey = activeMenuKeyRef.current
 
-      if (previousKey && previousKey !== key) {
-        setMegaMenuDirection(
-          MEGA_MENU_ORDER[key] > MEGA_MENU_ORDER[previousKey]
-            ? 'right'
-            : 'left',
-        )
-      } else if (!previousKey) {
-        setMegaMenuDirection('down')
+      const commitOpenState = () => {
+        activeMenuKeyRef.current = key
+        setActiveMenuKey(key)
       }
 
-      activeMenuKeyRef.current = key
-      setActiveMenuKey(key)
+      if (previousKey && previousKey !== key) {
+        runMegaMenuBgTransition(commitOpenState)
+      } else {
+        commitOpenState()
+      }
     },
     [cancelMegaMenuClose, updateMegaMenuLayout],
   )
@@ -859,11 +884,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           marginLeft: megaMenuLayout.left,
           width: megaMenuLayout.width,
         }}
-        className={twMerge(
-          'ts-mega-panel ts-glass-menu mt-2 rounded-xl',
-          'border border-white/45 bg-white/80 p-4 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
-          'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
-        )}
+        className="ts-mega-panel mt-2 rounded-xl p-4"
         onPointerEnter={(event) => {
           if (event.pointerType === 'touch') return
           cancelMegaMenuClose()
@@ -873,9 +894,17 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           scheduleMegaMenuClose()
         }}
       >
+        <div
+          key={activeMenuKey ?? 'closed'}
+          aria-hidden="true"
+          className={twMerge(
+            'ts-mega-bg rounded-xl',
+            'border border-white/45 bg-white/80 shadow-2xl shadow-black/15 backdrop-blur-2xl backdrop-saturate-150',
+            'dark:border-white/10 dark:bg-black/70 dark:shadow-black/50',
+          )}
+        />
         <MegaMenuContentTransition
           activeKey={activeMenuKey}
-          direction={megaMenuDirection}
           onNavigate={closeMegaMenu}
         />
       </div>
@@ -1083,95 +1112,24 @@ function MobileMenuGroup({
 
 function MegaMenuContentTransition({
   activeKey,
-  direction,
   onNavigate,
 }: {
   activeKey: NavMenuKey | null
-  direction: MegaMenuDirection
   onNavigate: () => void
 }) {
-  const previousActiveRef = React.useRef<NavMenuKey | null>(null)
-  const paneIdRef = React.useRef(0)
-  const [panes, setPanes] = React.useState<readonly MegaMenuPane[]>([])
+  const group = activeKey ? getMenuGroup(activeKey) : null
 
-  React.useLayoutEffect(() => {
-    if (activeKey === null) {
-      previousActiveRef.current = null
-      setPanes([])
-      return
-    }
-
-    const previousActive = previousActiveRef.current
-    if (previousActive === activeKey) {
-      return
-    }
-
-    const transitionDirection = previousActive ? direction : 'down'
-    const enteringPane: MegaMenuPane = {
-      id: paneIdRef.current + 1,
-      key: activeKey,
-      phase: 'enter',
-      direction: transitionDirection,
-    }
-    paneIdRef.current += 1
-
-    const nextPanes: MegaMenuPane[] = previousActive
-      ? [
-          {
-            id: paneIdRef.current + 1,
-            key: previousActive,
-            phase: 'exit',
-            direction: transitionDirection,
-          },
-          enteringPane,
-        ]
-      : [enteringPane]
-
-    if (previousActive) {
-      paneIdRef.current += 1
-    }
-
-    previousActiveRef.current = activeKey
-    setPanes(nextPanes)
-
-    const timeoutId = window.setTimeout(() => {
-      setPanes([{ ...enteringPane, phase: 'current' }])
-    }, MEGA_MENU_TRANSITION_MS)
-
-    return () => {
-      window.clearTimeout(timeoutId)
-    }
-  }, [activeKey, direction])
-
-  if (panes.length === 0) {
+  if (!group) {
     return null
   }
 
   return (
-    <div className="ts-mega-content">
-      {panes.map((pane) => {
-        const group = getMenuGroup(pane.key)
-
-        if (!group) {
-          return null
-        }
-
-        return (
-          <div
-            key={pane.id}
-            className="ts-mega-pane"
-            data-direction={pane.direction}
-            data-state={pane.phase}
-            aria-hidden={pane.phase === 'exit'}
-          >
-            <MegaMenuContent
-              group={group}
-              onNavigate={onNavigate}
-              variant="desktop"
-            />
-          </div>
-        )
-      })}
+    <div key={activeKey} className="ts-mega-content">
+      <MegaMenuContent
+        group={group}
+        onNavigate={onNavigate}
+        variant="desktop"
+      />
     </div>
   )
 }

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -117,7 +117,6 @@ export function LibraryNavbarTitle({
   libraryId,
 }: {
   libraryId: LandingLibraryId
-  version: string
 }) {
   const library = getLibrary(libraryId)
   const libraryName = library.name.replace('TanStack ', '')

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -115,27 +115,21 @@ export function LibraryLandingLayout({
 
 export function LibraryNavbarTitle({
   libraryId,
-  version,
 }: {
   libraryId: LandingLibraryId
   version: string
 }) {
   const library = getLibrary(libraryId)
   const libraryName = library.name.replace('TanStack ', '')
-  const resolvedVersion = version === 'latest' ? library.latestVersion : version
   const gradientText = `inline-block text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
 
   return (
     <Link
       to="/$libraryId"
       params={{ libraryId: library.id }}
-      className="relative whitespace-nowrap"
+      className="whitespace-nowrap"
     >
-      <span className={gradientText}>{libraryName}</span>{' '}
-      <span className="text-sm absolute right-0 top-0 font-normal normal-case">
-        {resolvedVersion}
-      </span>
-      <span className="text-sm opacity-0 normal-case">{resolvedVersion}</span>
+      <span className={gradientText}>{libraryName}</span>
     </Link>
   )
 }

--- a/src/routes/ai.$version.index.tsx
+++ b/src/routes/ai.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/ai/$version/')({
 })
 
 function AiNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="ai" version={version} />
+  return <LibraryNavbarTitle libraryId="ai" />
 }
 
 function AiLandingRoute() {

--- a/src/routes/cli.$version.index.tsx
+++ b/src/routes/cli.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/cli/$version/')({
 })
 
 function CliNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="cli" version={version} />
+  return <LibraryNavbarTitle libraryId="cli" />
 }
 
 function CliLandingRoute() {

--- a/src/routes/config.$version.index.tsx
+++ b/src/routes/config.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/config/$version/')({
 })
 
 function ConfigNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="config" version={version} />
+  return <LibraryNavbarTitle libraryId="config" />
 }
 
 function ConfigLandingRoute() {

--- a/src/routes/db.$version.index.tsx
+++ b/src/routes/db.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/db/$version/')({
 })
 
 function DbNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="db" version={version} />
+  return <LibraryNavbarTitle libraryId="db" />
 }
 
 function DbLandingRoute() {

--- a/src/routes/devtools.$version.index.tsx
+++ b/src/routes/devtools.$version.index.tsx
@@ -26,9 +26,7 @@ export const Route = createFileRoute('/devtools/$version/')({
 })
 
 function DevtoolsNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="devtools" version={version} />
+  return <LibraryNavbarTitle libraryId="devtools" />
 }
 
 function DevtoolsLandingRoute() {

--- a/src/routes/form.$version.index.tsx
+++ b/src/routes/form.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/form/$version/')({
 })
 
 function FormNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="form" version={version} />
+  return <LibraryNavbarTitle libraryId="form" />
 }
 
 function FormLandingRoute() {

--- a/src/routes/hotkeys.$version.index.tsx
+++ b/src/routes/hotkeys.$version.index.tsx
@@ -26,9 +26,7 @@ export const Route = createFileRoute('/hotkeys/$version/')({
 })
 
 function HotkeysNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="hotkeys" version={version} />
+  return <LibraryNavbarTitle libraryId="hotkeys" />
 }
 
 function HotkeysLandingRoute() {

--- a/src/routes/intent.$version.index.tsx
+++ b/src/routes/intent.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/intent/$version/')({
 })
 
 function IntentNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="intent" version={version} />
+  return <LibraryNavbarTitle libraryId="intent" />
 }
 
 function IntentLandingRoute() {

--- a/src/routes/pacer.$version.index.tsx
+++ b/src/routes/pacer.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/pacer/$version/')({
 })
 
 function PacerNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="pacer" version={version} />
+  return <LibraryNavbarTitle libraryId="pacer" />
 }
 
 function PacerLandingRoute() {

--- a/src/routes/query.$version.index.tsx
+++ b/src/routes/query.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/query/$version/')({
 })
 
 function QueryNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="query" version={version} />
+  return <LibraryNavbarTitle libraryId="query" />
 }
 
 function QueryLandingRoute() {

--- a/src/routes/ranger.$version.index.tsx
+++ b/src/routes/ranger.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/ranger/$version/')({
 })
 
 function RangerNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="ranger" version={version} />
+  return <LibraryNavbarTitle libraryId="ranger" />
 }
 
 function RangerLandingRoute() {

--- a/src/routes/router.$version.index.tsx
+++ b/src/routes/router.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/router/$version/')({
 })
 
 function RouterNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="router" version={version} />
+  return <LibraryNavbarTitle libraryId="router" />
 }
 
 function RouterLandingRoute() {

--- a/src/routes/start.$version.index.tsx
+++ b/src/routes/start.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/start/$version/')({
 })
 
 function StartNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="start" version={version} />
+  return <LibraryNavbarTitle libraryId="start" />
 }
 
 function StartLandingRoute() {

--- a/src/routes/store.$version.index.tsx
+++ b/src/routes/store.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/store/$version/')({
 })
 
 function StoreNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="store" version={version} />
+  return <LibraryNavbarTitle libraryId="store" />
 }
 
 function StoreLandingRoute() {

--- a/src/routes/table.$version.index.tsx
+++ b/src/routes/table.$version.index.tsx
@@ -25,9 +25,7 @@ export const Route = createFileRoute('/table/$version/')({
 })
 
 function TableNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="table" version={version} />
+  return <LibraryNavbarTitle libraryId="table" />
 }
 
 function TableLandingRoute() {

--- a/src/routes/virtual.$version.index.tsx
+++ b/src/routes/virtual.$version.index.tsx
@@ -26,9 +26,7 @@ export const Route = createFileRoute('/virtual/$version/')({
 })
 
 function VirtualNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="virtual" version={version} />
+  return <LibraryNavbarTitle libraryId="virtual" />
 }
 
 function VirtualLandingRoute() {

--- a/src/routes/workflow.$version.index.tsx
+++ b/src/routes/workflow.$version.index.tsx
@@ -26,9 +26,7 @@ export const Route = createFileRoute('/workflow/$version/')({
 })
 
 function WorkflowNavbarTitle() {
-  const { version } = Route.useParams()
-
-  return <LibraryNavbarTitle libraryId="workflow" version={version} />
+  return <LibraryNavbarTitle libraryId="workflow" />
 }
 
 function WorkflowLandingRoute() {

--- a/src/routes/workshops.tsx
+++ b/src/routes/workshops.tsx
@@ -135,7 +135,7 @@ function WorkshopsPage() {
 
           {/* Why Choose TanStack Workshops */}
           <div
-            className="relative bg-gray-50 dark:bg-gray-900 py-32 w-screen -mx-[calc(50vw-50%)] md:w-[calc(100vw-250px)] md:mx-[calc(-50vw+50%+125px)]"
+            className="relative bg-gray-50 dark:bg-gray-900 py-32 w-screen -mx-[calc(50vw-50%)]"
             style={{
               boxShadow: '0 0 80px rgba(0, 0, 0, 0.04)',
             }}
@@ -242,7 +242,7 @@ function WorkshopsPage() {
 
           {/* Instructors Section */}
           <div
-            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)] md:w-[calc(100vw-250px)] md:mx-[calc(-50vw+50%+125px)]"
+            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)]"
             style={{
               boxShadow: '0 0 80px rgba(0, 0, 0, 0.04)',
             }}
@@ -323,7 +323,7 @@ function WorkshopsPage() {
 
           {/* Topics Covered */}
           <div
-            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)] md:w-[calc(100vw-250px)] md:mx-[calc(-50vw+50%+125px)]"
+            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)]"
             style={{
               boxShadow: '0 0 80px rgba(0, 0, 0, 0.04)',
             }}
@@ -401,7 +401,7 @@ function WorkshopsPage() {
 
           {/* Testimonials Section */}
           <div
-            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)] md:w-[calc(100vw-250px)] md:mx-[calc(-50vw+50%+125px)]"
+            className="relative bg-gray-50 dark:bg-gray-900 py-20 w-screen -mx-[calc(50vw-50%)]"
             style={{
               boxShadow: '0 0 80px rgba(0, 0, 0, 0.04)',
             }}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -242,7 +242,7 @@ button {
   .ts-mega-dropdown {
     position: fixed;
     right: 1rem;
-    left: 0;
+    left: 1rem;
     top: calc(var(--navbar-height) - 0.625rem);
     width: auto;
     padding-top: calc(1rem + 0.625rem);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -152,40 +152,48 @@ button {
 }
 
 .ts-mega-trigger:hover::after,
-.ts-mega-trigger[data-open='true']::after {
+.ts-mega-trigger-wrap:focus-within > .ts-mega-trigger::after {
   opacity: 0.55;
   transform: scaleX(1);
 }
 
-.ts-mega-panel {
-  position: relative;
-  isolation: isolate;
-  overflow: visible;
+.ts-mega-dropdown {
+  position: absolute;
+  left: -1rem;
+  top: 100%;
+  z-index: 90;
+  width: min(calc(100vw - 1rem), 70rem);
+  padding-top: 1rem;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   transform: translate3d(0, -8px, 0) scale(0.985);
   transform-origin: 50% 0;
   transition:
     opacity 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
-    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
-  will-change: opacity, transform;
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    visibility 0s linear 160ms;
 }
 
-.ts-mega-panel[data-open='true'] {
+.ts-mega-trigger-wrap:hover > .ts-mega-dropdown,
+.ts-mega-trigger-wrap:focus-within > .ts-mega-dropdown {
   opacity: 1;
+  visibility: visible;
   pointer-events: auto;
   transform: translate3d(0, 0, 0) scale(1);
+  transition-delay: 0s;
 }
 
-.ts-mega-bg {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
+.ts-mega-dropdown-panel {
+  position: relative;
   isolation: isolate;
-  overflow: hidden;
-  pointer-events: none;
-  transform-origin: top left;
-  will-change: transform;
+  background-color: rgb(255 255 255 / 0.94);
+  backdrop-filter: blur(100px) saturate(1.9);
+  -webkit-backdrop-filter: blur(100px) saturate(1.9);
+}
+
+.dark .ts-mega-dropdown-panel {
+  background-color: rgb(0 0 0 / 0.88);
 }
 
 .ts-glass-menu {
@@ -198,8 +206,7 @@ button {
   z-index: 1;
 }
 
-.ts-glass-menu::after,
-.ts-mega-bg::after {
+.ts-glass-menu::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -217,8 +224,7 @@ button {
     inset 0 -1px 0 rgb(0 0 0 / 0.04);
 }
 
-.dark .ts-glass-menu::after,
-.dark .ts-mega-bg::after {
+.dark .ts-glass-menu::after {
   background: linear-gradient(
     135deg,
     rgb(255 255 255 / 0.12),
@@ -230,25 +236,34 @@ button {
     inset 0 -1px 0 rgb(255 255 255 / 0.04);
 }
 
-.ts-mega-panel::before {
-  content: '';
-  position: absolute;
-  inset: -24px 0 auto 0;
-  z-index: 2;
-  height: 28px;
-  background: transparent;
-  pointer-events: auto;
+@media (max-width: 1280px) {
+  .ts-mega-dropdown {
+    position: fixed;
+    right: 1rem;
+    left: 0;
+    top: var(--navbar-height);
+    width: auto;
+  }
 }
 
-.ts-mega-content {
-  position: relative;
-  z-index: 2;
-  border-radius: inherit;
+@media (min-width: 960px) {
+  body:has(.ts-mega-trigger-wrap:hover > .ts-mega-dropdown)
+    [data-site-menu-tint],
+  body:has(.ts-mega-trigger-wrap:focus-within > .ts-mega-dropdown)
+    [data-site-menu-tint] {
+    opacity: 1;
+  }
+
+  body:has(.ts-mega-trigger-wrap:hover > .ts-mega-dropdown) [data-site-content],
+  body:has(.ts-mega-trigger-wrap:focus-within > .ts-mega-dropdown)
+    [data-site-content] {
+    filter: blur(4px);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .ts-mega-trigger::after,
-  .ts-mega-panel {
+  .ts-mega-dropdown {
     transition: none;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -208,6 +208,46 @@ button {
   transform: translate3d(0, 0, 0) scale(1);
 }
 
+.ts-mega-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  isolation: isolate;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.ts-mega-panel[data-open='true'] .ts-mega-bg {
+  view-transition-name: ts-mega-bg;
+}
+
+.ts-mega-bg-transitioning::view-transition-old(root),
+.ts-mega-bg-transitioning::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+.ts-mega-bg-transitioning::view-transition-old(root) {
+  display: none;
+}
+
+.ts-mega-bg-transitioning::view-transition-group(root) {
+  z-index: 1;
+}
+
+.ts-mega-bg-transitioning::view-transition-group(ts-mega-bg) {
+  z-index: 0;
+  animation-duration: 360ms;
+  animation-timing-function: cubic-bezier(0.42, 0, 0.18, 1);
+}
+
+.ts-mega-bg-transitioning::view-transition-old(ts-mega-bg),
+.ts-mega-bg-transitioning::view-transition-new(ts-mega-bg) {
+  animation-duration: 360ms;
+  animation-timing-function: cubic-bezier(0.42, 0, 0.18, 1);
+  mix-blend-mode: normal;
+}
+
 .ts-glass-menu {
   position: relative;
   isolation: isolate;
@@ -218,7 +258,8 @@ button {
   z-index: 1;
 }
 
-.ts-glass-menu::after {
+.ts-glass-menu::after,
+.ts-mega-bg::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -236,7 +277,8 @@ button {
     inset 0 -1px 0 rgb(0 0 0 / 0.04);
 }
 
-.dark .ts-glass-menu::after {
+.dark .ts-glass-menu::after,
+.dark .ts-mega-bg::after {
   background: linear-gradient(
     135deg,
     rgb(255 255 255 / 0.12),
@@ -252,149 +294,22 @@ button {
   content: '';
   position: absolute;
   inset: -24px 0 auto 0;
+  z-index: 2;
   height: 28px;
   background: transparent;
   pointer-events: auto;
 }
 
 .ts-mega-content {
-  --ts-mega-column-shift: 18rem;
-  --ts-mega-slide-duration: 400ms;
-  --ts-mega-slide-easing: cubic-bezier(0.42, 0, 0.18, 1);
   position: relative;
-  z-index: 1;
-  display: grid;
-  overflow: hidden;
+  z-index: 2;
   border-radius: inherit;
-}
-
-.ts-mega-pane {
-  grid-area: 1 / 1;
-  min-width: 0;
-  transform: translate3d(0, 0, 0);
-  will-change: opacity, transform;
-}
-
-.ts-mega-pane[data-state='current'] {
-  opacity: 1;
-}
-
-.ts-mega-pane[data-state='exit'] {
-  pointer-events: none;
-}
-
-.ts-mega-pane[data-state='enter'][data-direction='right'] {
-  animation: ts-mega-enter-right var(--ts-mega-slide-duration)
-    var(--ts-mega-slide-easing) both;
-}
-
-.ts-mega-pane[data-state='exit'][data-direction='right'] {
-  animation: ts-mega-exit-right var(--ts-mega-slide-duration)
-    var(--ts-mega-slide-easing) both;
-}
-
-.ts-mega-pane[data-state='enter'][data-direction='left'] {
-  animation: ts-mega-enter-left var(--ts-mega-slide-duration)
-    var(--ts-mega-slide-easing) both;
-}
-
-.ts-mega-pane[data-state='exit'][data-direction='left'] {
-  animation: ts-mega-exit-left var(--ts-mega-slide-duration)
-    var(--ts-mega-slide-easing) both;
-}
-
-.ts-mega-pane[data-state='enter'][data-direction='down'] {
-  animation: ts-mega-enter-down 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-.ts-mega-pane[data-state='exit'][data-direction='down'] {
-  animation: ts-mega-exit-down 240ms cubic-bezier(0.5, 0, 0.75, 0) both;
-}
-
-@keyframes ts-mega-enter-right {
-  from {
-    opacity: 0;
-    transform: translate3d(var(--ts-mega-column-shift), 0, 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes ts-mega-exit-right {
-  from {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    opacity: 0;
-    transform: translate3d(calc(var(--ts-mega-column-shift) * -1), 0, 0);
-  }
-}
-
-@keyframes ts-mega-enter-left {
-  from {
-    opacity: 0;
-    transform: translate3d(calc(var(--ts-mega-column-shift) * -1), 0, 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes ts-mega-exit-left {
-  from {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    opacity: 0;
-    transform: translate3d(var(--ts-mega-column-shift), 0, 0);
-  }
-}
-
-@keyframes ts-mega-enter-down {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 8px, 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes ts-mega-exit-down {
-  from {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-  to {
-    opacity: 0;
-    transform: translate3d(0, -6px, 0);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .ts-mega-trigger::after,
   .ts-mega-panel {
     transition: none;
-  }
-
-  .ts-mega-content {
-    overflow: visible;
-  }
-
-  .ts-mega-pane {
-    animation: none !important;
-    opacity: 1;
-    transform: none;
-  }
-
-  .ts-mega-pane[data-state='exit'] {
-    display: none;
   }
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -157,37 +157,6 @@ button {
   transform: scaleX(1);
 }
 
-.ts-mega-fallback {
-  position: absolute;
-  left: 0;
-  top: 100%;
-  z-index: 90;
-  display: none;
-  width: min(calc(100vw - 2rem), 70rem);
-  padding-top: 0.5rem;
-}
-
-.ts-mega-trigger-wrap:hover > .ts-mega-fallback,
-.ts-mega-trigger-wrap:focus-within > .ts-mega-fallback {
-  display: block;
-}
-
-.ts-nav-hydrated .ts-mega-trigger-wrap:hover > .ts-mega-fallback,
-.ts-nav-hydrated .ts-mega-trigger-wrap:focus-within > .ts-mega-fallback,
-.ts-nav-hydrated .ts-mega-fallback {
-  display: none;
-}
-
-@media (max-width: 1280px) {
-  .ts-mega-fallback {
-    position: fixed;
-    right: 1rem;
-    left: 1rem;
-    top: var(--navbar-height);
-    width: auto;
-  }
-}
-
 .ts-mega-panel {
   position: relative;
   isolation: isolate;
@@ -215,37 +184,8 @@ button {
   isolation: isolate;
   overflow: hidden;
   pointer-events: none;
-}
-
-.ts-mega-panel[data-open='true'] .ts-mega-bg {
-  view-transition-name: ts-mega-bg;
-}
-
-.ts-mega-bg-transitioning::view-transition-old(root),
-.ts-mega-bg-transitioning::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
-}
-
-.ts-mega-bg-transitioning::view-transition-old(root) {
-  display: none;
-}
-
-.ts-mega-bg-transitioning::view-transition-group(root) {
-  z-index: 1;
-}
-
-.ts-mega-bg-transitioning::view-transition-group(ts-mega-bg) {
-  z-index: 0;
-  animation-duration: 360ms;
-  animation-timing-function: cubic-bezier(0.42, 0, 0.18, 1);
-}
-
-.ts-mega-bg-transitioning::view-transition-old(ts-mega-bg),
-.ts-mega-bg-transitioning::view-transition-new(ts-mega-bg) {
-  animation-duration: 360ms;
-  animation-timing-function: cubic-bezier(0.42, 0, 0.18, 1);
-  mix-blend-mode: normal;
+  transform-origin: top left;
+  will-change: transform;
 }
 
 .ts-glass-menu {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -126,6 +126,278 @@ button {
   @apply cursor-pointer;
 }
 
+.ts-mega-trigger {
+  position: relative;
+  isolation: isolate;
+}
+
+.ts-mega-trigger-wrap {
+  display: inline-flex;
+}
+
+.ts-mega-trigger::after {
+  content: '';
+  position: absolute;
+  right: 0.625rem;
+  bottom: 0.3rem;
+  left: 0.625rem;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.35;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition:
+    opacity 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.ts-mega-trigger:hover::after,
+.ts-mega-trigger[data-open='true']::after {
+  opacity: 0.55;
+  transform: scaleX(1);
+}
+
+.ts-mega-fallback {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  z-index: 90;
+  display: none;
+  width: min(calc(100vw - 2rem), 70rem);
+  padding-top: 0.5rem;
+}
+
+.ts-mega-trigger-wrap:hover > .ts-mega-fallback,
+.ts-mega-trigger-wrap:focus-within > .ts-mega-fallback {
+  display: block;
+}
+
+.ts-nav-hydrated .ts-mega-trigger-wrap:hover > .ts-mega-fallback,
+.ts-nav-hydrated .ts-mega-trigger-wrap:focus-within > .ts-mega-fallback,
+.ts-nav-hydrated .ts-mega-fallback {
+  display: none;
+}
+
+@media (max-width: 1280px) {
+  .ts-mega-fallback {
+    position: fixed;
+    right: 1rem;
+    left: 1rem;
+    top: var(--navbar-height);
+    width: auto;
+  }
+}
+
+.ts-mega-panel {
+  position: relative;
+  isolation: isolate;
+  overflow: visible;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, -8px, 0) scale(0.985);
+  transform-origin: 50% 0;
+  transition:
+    opacity 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: opacity, transform;
+}
+
+.ts-mega-panel[data-open='true'] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.ts-glass-menu {
+  position: relative;
+  isolation: isolate;
+}
+
+.ts-glass-menu > * {
+  position: relative;
+  z-index: 1;
+}
+
+.ts-glass-menu::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    135deg,
+    rgb(255 255 255 / 0.36),
+    rgb(255 255 255 / 0.12) 38%,
+    rgb(255 255 255 / 0) 72%
+  );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.5),
+    inset 0 -1px 0 rgb(0 0 0 / 0.04);
+}
+
+.dark .ts-glass-menu::after {
+  background: linear-gradient(
+    135deg,
+    rgb(255 255 255 / 0.12),
+    rgb(255 255 255 / 0.05) 38%,
+    rgb(255 255 255 / 0) 72%
+  );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.14),
+    inset 0 -1px 0 rgb(255 255 255 / 0.04);
+}
+
+.ts-mega-panel::before {
+  content: '';
+  position: absolute;
+  inset: -24px 0 auto 0;
+  height: 28px;
+  background: transparent;
+  pointer-events: auto;
+}
+
+.ts-mega-content {
+  --ts-mega-column-shift: 18rem;
+  --ts-mega-slide-duration: 400ms;
+  --ts-mega-slide-easing: cubic-bezier(0.42, 0, 0.18, 1);
+  position: relative;
+  z-index: 1;
+  display: grid;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.ts-mega-pane {
+  grid-area: 1 / 1;
+  min-width: 0;
+  transform: translate3d(0, 0, 0);
+  will-change: opacity, transform;
+}
+
+.ts-mega-pane[data-state='current'] {
+  opacity: 1;
+}
+
+.ts-mega-pane[data-state='exit'] {
+  pointer-events: none;
+}
+
+.ts-mega-pane[data-state='enter'][data-direction='right'] {
+  animation: ts-mega-enter-right var(--ts-mega-slide-duration)
+    var(--ts-mega-slide-easing) both;
+}
+
+.ts-mega-pane[data-state='exit'][data-direction='right'] {
+  animation: ts-mega-exit-right var(--ts-mega-slide-duration)
+    var(--ts-mega-slide-easing) both;
+}
+
+.ts-mega-pane[data-state='enter'][data-direction='left'] {
+  animation: ts-mega-enter-left var(--ts-mega-slide-duration)
+    var(--ts-mega-slide-easing) both;
+}
+
+.ts-mega-pane[data-state='exit'][data-direction='left'] {
+  animation: ts-mega-exit-left var(--ts-mega-slide-duration)
+    var(--ts-mega-slide-easing) both;
+}
+
+.ts-mega-pane[data-state='enter'][data-direction='down'] {
+  animation: ts-mega-enter-down 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ts-mega-pane[data-state='exit'][data-direction='down'] {
+  animation: ts-mega-exit-down 240ms cubic-bezier(0.5, 0, 0.75, 0) both;
+}
+
+@keyframes ts-mega-enter-right {
+  from {
+    opacity: 0;
+    transform: translate3d(var(--ts-mega-column-shift), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ts-mega-exit-right {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate3d(calc(var(--ts-mega-column-shift) * -1), 0, 0);
+  }
+}
+
+@keyframes ts-mega-enter-left {
+  from {
+    opacity: 0;
+    transform: translate3d(calc(var(--ts-mega-column-shift) * -1), 0, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ts-mega-exit-left {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate3d(var(--ts-mega-column-shift), 0, 0);
+  }
+}
+
+@keyframes ts-mega-enter-down {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes ts-mega-exit-down {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate3d(0, -6px, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ts-mega-trigger::after,
+  .ts-mega-panel {
+    transition: none;
+  }
+
+  .ts-mega-content {
+    overflow: visible;
+  }
+
+  .ts-mega-pane {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+
+  .ts-mega-pane[data-state='exit'] {
+    display: none;
+  }
+}
+
 @layer base {
   html,
   body {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -142,7 +142,7 @@ button {
   bottom: 0.3rem;
   left: 0.625rem;
   height: 1px;
-  background: currentColor;
+  background: currentcolor;
   opacity: 0.35;
   transform: scaleX(0);
   transform-origin: left;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -133,6 +133,8 @@ button {
 
 .ts-mega-trigger-wrap {
   display: inline-flex;
+  align-self: stretch;
+  align-items: center;
 }
 
 .ts-mega-trigger::after {
@@ -241,8 +243,9 @@ button {
     position: fixed;
     right: 1rem;
     left: 0;
-    top: var(--navbar-height);
+    top: calc(var(--navbar-height) - 0.625rem);
     width: auto;
+    padding-top: calc(1rem + 0.625rem);
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the left-nav structure with a top mega-menu hierarchy for Libraries, Learn, Community, Tools, Merch, and Support.
- Groups library links by stack category, links category labels to their stack pages, and keeps Libraries as a direct link to /libraries.
- Simplifies the mobile menu with collapsible groups, subtle section borders, and fixed positioning.
- Adds a pre-hydration desktop hover fallback, glass menu styling, site blur/tint on hover, and keeps the active dropdown hover area scoped to the card.
- Removes the library version suffix from the navbar title area and adjusts workshop full-width sections for the simplified layout.

## Validation

- pnpm test
- In-app browser DOM checks for top-level nav labels, Support/About merge, Libraries/category hrefs, and dropdown pointer-event scoping.

Note: pnpm test passes with existing lint warnings in shop/admin utility files unrelated to this navigation change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned navigation with a typed, data-driven responsive mega-menu (desktop glass overlay + mobile drawer), including grouped resources and “Docs” links.
* **Style**
  * Added an animated navigation underline and smoother mega-menu panel/background transitions, with reduced-motion support.
* **Bug Fixes**
  * Navbar titles are now consistent across versioned routes (no longer dependent on the selected version).
* **Chores**
  * Adjusted spacing for full-width “w-screen” workshop sections for more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->