### PR TITLE
Lazy load merch nav products

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -999,10 +999,41 @@ function MerchMenuContent({
   onNavigate: () => void
   variant: 'desktop' | 'mobile'
 }) {
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const [shouldLoad, setShouldLoad] = React.useState(false)
   const [products, setProducts] = React.useState<Array<ProductListItem>>([])
   const [loading, setLoading] = React.useState(true)
 
   React.useEffect(() => {
+    const root = rootRef.current
+    const triggerWrap =
+      variant === 'desktop'
+        ? root?.closest<HTMLElement>('.ts-mega-trigger-wrap')
+        : null
+    const target = triggerWrap ?? root
+
+    if (!target) {
+      return
+    }
+
+    const load = () => {
+      setShouldLoad(true)
+    }
+
+    target.addEventListener('pointerenter', load)
+    target.addEventListener('focusin', load)
+
+    return () => {
+      target.removeEventListener('pointerenter', load)
+      target.removeEventListener('focusin', load)
+    }
+  }, [variant])
+
+  React.useEffect(() => {
+    if (!shouldLoad) {
+      return
+    }
+
     let cancelled = false
 
     async function loadProducts() {
@@ -1036,7 +1067,7 @@ function MerchMenuContent({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [shouldLoad])
 
   const allMerchItem: NavMenuItem = {
     label: 'All Merch',
@@ -1047,6 +1078,7 @@ function MerchMenuContent({
 
   return (
     <div
+      ref={rootRef}
       className={twMerge(variant === 'desktop' ? 'grid gap-4' : 'grid gap-3')}
     >
       <section>
@@ -1059,7 +1091,7 @@ function MerchMenuContent({
             variant === 'desktop' && 'md:grid-cols-3',
           )}
         >
-          {loading
+          {shouldLoad && loading
             ? Array.from({ length: 3 }, (_, index) => (
                 <div
                   key={index}


### PR DESCRIPTION
## Summary
- lazy-load merch dropdown products only after the merch menu is interacted with
- prevents hidden CSS-rendered merch panels from fetching Shopify products on unrelated pages

## Tests
- CI=true pnpm test:tsc
- pnpm run test via pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the merch mega-menu to load products only when users interact with it, reducing initial load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->