### PR TITLE
Fix docs router link freeze

### DIFF
--- a/src/components/DocsLayout.tsx
+++ b/src/components/DocsLayout.tsx
@@ -848,6 +848,8 @@ export function DocsLayout({
     })
   }, [groupInitialOpenState])
 
+  const libraryHomePath = `/${libraryId}/${version}`
+
   const menuItems = menuConfig.map((group, i) => {
     const groupKey = `${i}:${String(group.label)}`
 
@@ -919,8 +921,7 @@ export function DocsLayout({
                   </a>
                 ) : isHomeLink ? (
                   <Link
-                    to="/$libraryId/$version"
-                    params={{ libraryId, version }}
+                    to={libraryHomePath}
                     onClick={() => {
                       detailsRef.current.removeAttribute('open')
                     }}

--- a/src/components/markdown/MarkdownLink.tsx
+++ b/src/components/markdown/MarkdownLink.tsx
@@ -29,6 +29,24 @@ function isRoutableInternalLink(link: string) {
   )
 }
 
+function normalizeRoutableInternalPathname(pathname: string) {
+  const routerFrameworkMatch = pathname.match(
+    /^\/router\/([^/]+)\/docs\/framework\/[^/]+\/(.+)$/,
+  )
+
+  if (!routerFrameworkMatch) {
+    return pathname
+  }
+
+  const [, version, docsPath] = routerFrameworkMatch
+
+  if (!version || !docsPath || docsPath.startsWith('examples/')) {
+    return pathname
+  }
+
+  return `/router/${version}/docs/${docsPath}`
+}
+
 export function MarkdownLink({
   href: hrefProp,
   ...rest
@@ -37,14 +55,16 @@ export function MarkdownLink({
 
   if (isRoutableInternalLink(href)) {
     const [hrefWithoutHash, hash] = href.split('#')
-    const hrefWithoutMd = hrefWithoutHash.replace('.md', '')
+    const hrefWithoutMd = normalizeRoutableInternalPathname(
+      hrefWithoutHash.replace('.md', ''),
+    )
 
     return (
       <Link
         {...rest}
         to={hrefWithoutMd}
         hash={hash}
-        preload={undefined}
+        preload={false}
         ref={undefined}
       />
     )
@@ -73,7 +93,7 @@ export function MarkdownLink({
       unsafeRelative="path"
       to={hrefWithoutMd}
       hash={hash}
-      preload={undefined}
+      preload={false}
       ref={undefined}
     />
   )


### PR DESCRIPTION
## Summary

- Canonicalizes Router framework docs links emitted from markdown so aliases like /router/latest/docs/framework/react/overview render as /router/latest/docs/overview.
- Disables TanStack Router intent preloading for markdown links with preload=false instead of falling back to the app default.
- Avoids repeated generated-path warnings for docs Home links by using the concrete library home path.

## Root Cause

Markdown links were passing preload=undefined, which still inherited the router's defaultPreload: intent. The affected Start docs link also targeted Router's framework alias route, which redirects to the canonical Router docs path. Hover/click could enter that client-side redirect/preload path and hang the tab.

## Validation

- Reproduced the pre-fix hang locally from /start/latest/docs/framework/react/guide/routing to the Router overview link.
- Verified after the change that hover remains responsive and click lands on /router/latest/docs/overview.
- Ran pnpm test successfully. Existing unrelated lint warnings remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation path computation in documentation layouts for more reliable routing
  * Enhanced internal link path normalization to ensure consistent navigation across documentation pages
  * Optimized link preloading behavior to improve navigation performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->