### PR TITLE
Stabilize login modal context during dev HMR

### DIFF
--- a/src/contexts/LoginModalContext.tsx
+++ b/src/contexts/LoginModalContext.tsx
@@ -10,9 +10,17 @@ interface LoginModalContextValue {
   closeLoginModal: () => void
 }
 
-const LoginModalContext = React.createContext<LoginModalContextValue | null>(
-  null,
-)
+declare global {
+  var __tanstackLoginModalContext:
+    | React.Context<LoginModalContextValue | null>
+    | undefined
+}
+
+const LoginModalContext =
+  import.meta.env.DEV && typeof window !== 'undefined'
+    ? (globalThis.__tanstackLoginModalContext ??=
+        React.createContext<LoginModalContextValue | null>(null))
+    : React.createContext<LoginModalContextValue | null>(null)
 
 export function useLoginModal() {
   const context = React.useContext(LoginModalContext)


### PR DESCRIPTION
## Summary

Stabilizes the login modal React context object during browser development so Vite/Fast Refresh does not leave preserved consumers reading from a freshly-created context while the provider still belongs to the previous module instance.

## Impact

This should stop the intermittent dev-only `useLoginModal must be used within a LoginModalProvider` error that disappears after a manual refresh. The provider misuse guard still remains for real missing-provider bugs.

## Validation

- `pnpm test`
- Commit hook reran `pnpm run format && pnpm run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context preservation during development hot module reloading to maintain state across reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->