### PR TITLE
Fix sponsor hydrate wrapper sizing

### DIFF
--- a/src/components/LazySponsorSection.tsx
+++ b/src/components/LazySponsorSection.tsx
@@ -40,7 +40,7 @@ export function LazySponsorSection({
       <div className="space-y-8">
         <h3 className="text-3xl font-bold">{title}</h3>
         <div
-          className="relative mx-auto flex w-full flex-wrap overflow-hidden"
+          className="relative mx-auto flex w-full flex-wrap overflow-hidden [&>div]:h-full [&>div]:w-full"
           style={{ aspectRatio, maxWidth: packMaxWidth }}
         >
           <Hydrate


### PR DESCRIPTION
## Summary

- Size the `Hydrate` wrapper inside the sponsor pack aspect-ratio container.
- Restores non-zero `ParentSize` measurements so OSS sponsor bubbles render after the deferred hydration migration.

## Validation

- `pnpm build`
- `pnpm test`
- Browser smoke check on `/#sponsors`: 140 visible `.spon-link` anchors rendered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sponsor section layout to better utilize available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->