### PR TITLE
Remove library versions from nav title

### DIFF
--- a/src/routes/_library/$libraryId/route.tsx
+++ b/src/routes/_library/$libraryId/route.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
-import { notFound, Outlet, useParams } from '@tanstack/react-router'
+import { notFound, Outlet } from '@tanstack/react-router'
 import { Scarf } from '~/components/Scarf'
 import { findLibrary, LibraryId } from '~/libraries'
 import { seo } from '~/utils/seo'
@@ -58,7 +58,6 @@ export const Route = createFileRoute('/_library/$libraryId')({
   staticData: {
     Title: () => {
       const { libraryId } = Route.useParams()
-      const { version } = useParams({ strict: false })
       const library = findLibrary(libraryId)
 
       if (!library) {
@@ -66,22 +65,14 @@ export const Route = createFileRoute('/_library/$libraryId')({
       }
 
       const libraryName = library.name.replace('TanStack ', '')
-      const resolvedVersion =
-        version === 'latest' ? library.latestVersion : version!
       const gradientText = `inline-block text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
       return (
         <Link
           to={`/$libraryId`}
           params={{ libraryId }}
-          className="relative whitespace-nowrap"
+          className="whitespace-nowrap"
         >
-          <span className={`${gradientText}`}>{libraryName}</span>{' '}
-          <span className="text-sm absolute right-0 top-0 font-normal normal-case">
-            {resolvedVersion}
-          </span>
-          <span className="text-sm opacity-0 normal-case">
-            {resolvedVersion}
-          </span>
+          <span className={gradientText}>{libraryName}</span>
         </Link>
       )
     },


### PR DESCRIPTION
## Summary
- remove resolved library version text from the navbar title
- keep the library name/title in place after the TanStack logo

## Tests
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Simplified the library title display logic, removing version parameter handling to streamline the user interface while maintaining the core library name display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->