### PR TITLE
feat: add drag & drop npm stats preset

### DIFF
--- a/src/routes/stats/npm/-comparisons.ts
+++ b/src/routes/stats/npm/-comparisons.ts
@@ -934,5 +934,59 @@ export function getPopularComparisons(): v.InferInput<
         },
       ],
     },
+    {
+      title: 'Drag & Drop',
+      packageGroups: [
+        {
+          label: 'dnd-kit',
+          packages: [{ name: '@dnd-kit/core' }],
+          color: '#eb2f06',
+        },
+        {
+          label: 'Pragmatic DnD',
+          packages: [{ name: '@atlaskit/pragmatic-drag-and-drop' }],
+          color: '#0652dd',
+        },
+        {
+          label: 'React DnD',
+          packages: [{ name: 'react-dnd' }],
+          color: '#10ac84',
+        },
+        {
+          label: 'SortableJS',
+          packages: [
+            { name: 'sortablejs' },
+            { name: 'react-sortablejs' },
+            { name: 'vuedraggable' },
+            { name: 'vue-draggable-next' },
+            { name: 'vue-draggable-plus' },
+          ],
+          color: '#f39c12',
+        },
+        {
+          label: 'Hello Pangea DnD',
+          packages: [
+            { name: '@hello-pangea/dnd' },
+            { name: 'react-beautiful-dnd' },
+          ],
+          color: '#8854d0',
+        },
+        {
+          label: 'React Draggable',
+          packages: [{ name: 'react-draggable' }],
+          color: '#20bf6b',
+        },
+        {
+          label: 'React Grid Layout',
+          packages: [{ name: 'react-grid-layout' }],
+          color: '#d81b60',
+        },
+        {
+          label: 'React Rnd',
+          packages: [{ name: 'react-rnd' }],
+          color: '#a55d35',
+        },
+      ],
+    },
   ] as const
 }


### PR DESCRIPTION
This PR adds a new **Drag & Drop** preset comparing the most popular modern and classic drag-and-drop libraries in the JavaScript/React ecosystem.

The comparison includes:
1. **dnd-kit** (`@dnd-kit/core`)
2. **Pragmatic DnD** (`@atlaskit/pragmatic-drag-and-drop`)
3. **React DnD** (`react-dnd`)
4. **SortableJS** (Combined core + cross-framework wrappers)
5. **Hello Pangea DnD** (Combined fork + deprecated original)
6. **React Draggable** (`react-draggable`)
7. **React Grid Layout** (`react-grid-layout`)
8. **React Rnd** (`react-rnd`)

### Key Design Decisions

#### 1. Combo Logic (Wrapper/Version Consolidation)
To represent the true reach of the underlying engines without double-counting, we applied two distinct rules for library grouping:
* **Combined mutually exclusive wrappers (SortableJS):** We combined `sortablejs` (vanilla core), `react-sortablejs` (React wrapper), `vuedraggable` (Vue 2 wrapper), `vue-draggable-next` (Vue 3 wrapper), and `vue-draggable-plus` (Vue 3 wrapper) under the `SortableJS` line. Since a project typically installs only one of these, combining them gives an accurate measure of total SortableJS engine adoption.
* **Combined legacy forks (Hello Pangea / Beautiful DnD):** We combined `react-beautiful-dnd` (deprecated) and `@hello-pangea/dnd` (its active community fork/successor) under a single line. This represents the continuous adoption of this specific layout engine layout flow.
* **Excluded monorepo sub-modules (e.g. dnd-kit):** We only targeted core packages (like `@dnd-kit/core`). We did not combine sub-modules (like `@dnd-kit/sortable`) because they are installed alongside the core package in the same project; combining them would double-count downloads and inflate the chart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Drag & Drop** comparison section with popular drag-and-drop package options.
  * Included several well-known libraries in the comparison, each shown with its own label and color for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->