### PR TITLE
fix:style: join community button's discord and youtube overlay so the whole button is clickable

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -249,7 +249,7 @@ function Index() {
                 href="https://discord.com/invite/WrRKjPJ"
                 target="_blank"
                 rel="noreferrer"
-                className="w-full mt-4 bg-white border-white hover:bg-gray-100 text-discord justify-center shadow-lg text-sm"
+                className="z-1 w-full mt-4 bg-white border-white hover:bg-gray-100 text-discord justify-center shadow-lg text-sm"
               >
                 Join TanStack Discord
               </Button>
@@ -292,7 +292,7 @@ function Index() {
                 href="https://youtube.com/@tan_stack"
                 target="_blank"
                 rel="noreferrer"
-                className="w-full mt-4 bg-white border-white hover:bg-gray-100 text-red-600 justify-center shadow-lg text-sm"
+                className="z-1 w-full mt-4 bg-white border-white hover:bg-gray-100 text-red-600 justify-center shadow-lg text-sm"
               >
                 <Play className="w-4 h-4" />
                 Subscribe on YouTube


### PR DESCRIPTION
In the current docs website on the home page the "Join TanStack Discord" and "Subscribe To Youtube" buttons are not clickable throughout it's length due to the image sitting above the button, this is a very small things but it annoyed me so I have opened up a PR, feel free to close if not relevant.

Bug Video:

https://github.com/user-attachments/assets/0be28dde-b5ba-43ec-92f8-aa3c556a3f4f

Fix Video: 

https://github.com/user-attachments/assets/93409911-06c6-45cc-a715-ecfdeacb266f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the home page’s Discord and YouTube call-to-action buttons so they appear correctly layered in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->