### PR TITLE
Add Marko framework support (marko-virtual) to the site

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -6,6 +6,7 @@ import htmlIconUrl from '~/images/file-icons/html.svg?url'
 import jsonIconUrl from '~/images/file-icons/json.svg?url'
 import svelteIconUrl from '~/images/file-icons/svelte.svg?url'
 import vueIconUrl from '~/images/file-icons/vue.svg?url'
+import markoIconUrl from '~/images/file-icons/marko.svg?url'
 import textIconUrl from '~/images/file-icons/txt.svg?url'
 import type { GitHubFileNode } from '~/utils/documents.server'
 import { twMerge } from 'tailwind-merge'
@@ -30,6 +31,8 @@ const getFileIconPath = (filename: string) => {
       return svelteIconUrl
     case 'vue':
       return vueIconUrl
+    case 'marko':
+      return markoIconUrl
     default:
       return textIconUrl
   }

--- a/src/components/markdown/codeBlock.shared.tsx
+++ b/src/components/markdown/codeBlock.shared.tsx
@@ -86,6 +86,10 @@ export function getCodeBlockLanguageFromFilePath(filePath: string) {
   if (['prettierrc', 'babelrc', 'webmanifest'].includes(ext)) return 'json'
   if (['env', 'example'].includes(ext)) return 'sh'
 
+  // Marko is HTML-based; @tanstack/highlight has no Marko grammar, so fall
+  // back to html for reasonable tag/attribute/string coloring.
+  if (ext === 'marko') return 'html'
+
   if (
     [
       'gitignore',

--- a/src/images/file-icons/marko.svg
+++ b/src/images/file-icons/marko.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -583 2560 2560">
+  <style>stop:not([stop-color]){stop-color:inherit}</style>
+  <path fill="#8dc220" d="M1281 0h361l-427 697H854z"/>
+  <path fill="url(#a)" d="M427 0h361L361 697l427 697H427L0 698z"/>
+  <linearGradient id="a" x2="0" y2="1">
+    <stop offset=".685" stop-color="#44bfef"/>
+    <stop offset="1" stop-color="#2073ba"/>
+  </linearGradient>
+  <path fill="#00ac71" d="M854 697h361L788 0H427z"/>
+  <path fill="url(#b)" d="M1642 0h-361l428 697-428 697h361l428-697z"/>
+  <linearGradient id="b" x2="0" y2="1" stop-color="#f9bc00">
+    <stop offset=".5"/>
+    <stop offset=".5" stop-color="#e95506"/>
+    <stop offset=".833"/>
+  </linearGradient>
+  <path fill="url(#c)" d="M1493 246h-361L855 698h361z"/>
+  <linearGradient id="c" x2="0" y2="1" stop-color="#8ac23e">
+    <stop offset="0" stop-opacity="0"/>
+    <stop offset="1"/>
+  </linearGradient>
+  <path fill="url(#d)" d="M1005 452h361L1642 0h-361z"/>
+  <linearGradient id="d" x2="0" y2="1" stop-color="#698932">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#e)" d="M1919 452h-361L1281 0h361z"/>
+  <linearGradient id="e" x2="0" y2="1" stop-color="#ffed01">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#f)" d="M150 452h361L788 0H427z"/>
+  <linearGradient id="f" x2="0" y2="1" stop-color="#00828b">
+    <stop offset="0"/>
+    <stop offset=".833" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#g)" d="M638 246H277L0 698h361z"/>
+  <linearGradient id="g" x2="0" y2="1" stop-color="#88d0f1">
+    <stop offset="0" stop-opacity="0"/>
+    <stop offset="1"/>
+  </linearGradient>
+  <path fill="url(#h)" d="M1065 452H704L427 0h361z"/>
+  <linearGradient id="h" x2="0" y2="1" stop-color="#8ed0e1">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#i)" d="M2132 0h-361l427 697-428 697h361l428-697z"/>
+  <linearGradient id="i" x2="0" y2="1" stop-color="#df1b1c">
+    <stop offset="0" stop-color="#e02a89"/>
+    <stop offset=".31"/>
+    <stop offset=".5"/>
+    <stop offset=".5" stop-color="#7f1e4f"/>
+    <stop offset=".833"/>
+  </linearGradient>
+</svg>

--- a/src/images/marko-logo.svg
+++ b/src/images/marko-logo.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1394">
+  <style>stop:not([stop-color]){stop-color:inherit}</style>
+  <path fill="#8dc220" d="M1281 0h361l-427 697H854z"/>
+  <path fill="url(#a)" d="M427 0h361L361 697l427 697H427L0 698z"/>
+  <linearGradient id="a" x2="0" y2="1">
+    <stop offset=".685" stop-color="#44bfef"/>
+    <stop offset="1" stop-color="#2073ba"/>
+  </linearGradient>
+  <path fill="#00ac71" d="M854 697h361L788 0H427z"/>
+  <path fill="url(#b)" d="M1642 0h-361l428 697-428 697h361l428-697z"/>
+  <linearGradient id="b" x2="0" y2="1" stop-color="#f9bc00">
+    <stop offset=".5"/>
+    <stop offset=".5" stop-color="#e95506"/>
+    <stop offset=".833"/>
+  </linearGradient>
+  <path fill="url(#c)" d="M1493 246h-361L855 698h361z"/>
+  <linearGradient id="c" x2="0" y2="1" stop-color="#8ac23e">
+    <stop offset="0" stop-opacity="0"/>
+    <stop offset="1"/>
+  </linearGradient>
+  <path fill="url(#d)" d="M1005 452h361L1642 0h-361z"/>
+  <linearGradient id="d" x2="0" y2="1" stop-color="#698932">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#e)" d="M1919 452h-361L1281 0h361z"/>
+  <linearGradient id="e" x2="0" y2="1" stop-color="#ffed01">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#f)" d="M150 452h361L788 0H427z"/>
+  <linearGradient id="f" x2="0" y2="1" stop-color="#00828b">
+    <stop offset="0"/>
+    <stop offset=".833" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#g)" d="M638 246H277L0 698h361z"/>
+  <linearGradient id="g" x2="0" y2="1" stop-color="#88d0f1">
+    <stop offset="0" stop-opacity="0"/>
+    <stop offset="1"/>
+  </linearGradient>
+  <path fill="url(#h)" d="M1065 452H704L427 0h361z"/>
+  <linearGradient id="h" x2="0" y2="1" stop-color="#8ed0e1">
+    <stop offset="0"/>
+    <stop offset="1" stop-opacity="0"/>
+  </linearGradient>
+  <path fill="url(#i)" d="M2132 0h-361l427 697-428 697h361l428-697z"/>
+  <linearGradient id="i" x2="0" y2="1" stop-color="#df1b1c">
+    <stop offset="0" stop-color="#e02a89"/>
+    <stop offset=".31"/>
+    <stop offset=".5"/>
+    <stop offset=".5" stop-color="#7f1e4f"/>
+    <stop offset=".833"/>
+  </linearGradient>
+</svg>

--- a/src/libraries/frameworks.tsx
+++ b/src/libraries/frameworks.tsx
@@ -2,6 +2,7 @@ import alpineLogo from '../images/alpine-logo.svg'
 import angularLogo from '../images/angular-logo.svg'
 import jsLogo from '../images/js-logo.svg'
 import litLogo from '../images/lit-logo.svg'
+import markoLogo from '../images/marko-logo.svg'
 import qwikLogo from '../images/qwik-logo.svg'
 import preactLogo from '../images/preact-logo.svg'
 import reactLogo from '../images/react-logo.svg'
@@ -52,6 +53,13 @@ export const frameworkOptions = [
     logo: svelteLogo,
     color: 'bg-orange-600',
     fontColor: 'text-orange-600',
+  },
+  {
+    label: 'Marko',
+    value: 'marko',
+    logo: markoLogo,
+    color: 'bg-cyan-500',
+    fontColor: 'text-cyan-500',
   },
   {
     label: 'Qwik',

--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -428,7 +428,7 @@ export const virtual: LibrarySlim = {
   to: '/virtual',
   tagline: 'Headless UI for Virtualizing Large Element Lists',
   description:
-    'Virtualize only the visible content for massive scrollable DOM nodes at 60FPS in TS/JS, React, Vue, Solid, Svelte, Lit & Angular while retaining 100% control over markup and styles.',
+    'Virtualize only the visible content for massive scrollable DOM nodes at 60FPS in TS/JS, React, Vue, Solid, Svelte, Lit, Angular & Marko while retaining 100% control over markup and styles.',
   bgStyle: 'bg-purple-500',
   borderStyle: 'border-purple-500/50',
   textStyle: 'text-purple-500',
@@ -438,7 +438,7 @@ export const virtual: LibrarySlim = {
   bgRadial: 'from-purple-500 via-violet-600/50 to-transparent',
   badge: undefined,
   repo: 'tanstack/virtual',
-  frameworks: ['react', 'solid', 'vue', 'svelte', 'lit', 'angular'],
+  frameworks: ['react', 'solid', 'vue', 'svelte', 'lit', 'angular', 'marko'],
   corePackageName: '@tanstack/virtual-core',
   npmPackageNames: ['@tanstack/virtual-core', 'react-virtual'],
   latestVersion: 'v3',

--- a/src/libraries/types.ts
+++ b/src/libraries/types.ts
@@ -7,6 +7,7 @@ export type Framework =
   | 'angular'
   | 'alpine'
   | 'lit'
+  | 'marko'
   | 'preact'
   | 'qwik'
   | 'react'

--- a/src/libraries/virtual.tsx
+++ b/src/libraries/virtual.tsx
@@ -7,7 +7,7 @@ const textStyles = 'text-violet-700 dark:text-violet-400'
 
 export const virtualProject = {
   ...virtual,
-  description: `Virtualize only the visible content for massive scrollable DOM nodes at 60FPS in TS/JS, React, Vue, Solid, Svelte, Lit & Angular while retaining 100% control over markup and styles.`,
+  description: `Virtualize only the visible content for massive scrollable DOM nodes at 60FPS in TS/JS, React, Vue, Solid, Svelte, Lit, Angular & Marko while retaining 100% control over markup and styles.`,
   latestBranch: 'main',
   bgRadial: 'from-purple-500 via-violet-600/50 to-transparent',
   textColor: 'text-purple-600',

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -42,6 +42,7 @@ const frameworkLabels: Record<Framework, string> = {
   angular: 'Angular',
   alpine: 'Alpine',
   lit: 'Lit',
+  marko: 'Marko',
   preact: 'Preact',
   qwik: 'Qwik',
   react: 'React',

--- a/src/utils/npm-packages.ts
+++ b/src/utils/npm-packages.ts
@@ -26,6 +26,7 @@ export const frameworkMeta: Record<Framework, { name: string; color: string }> =
     solid: { name: 'Solid', color: '#2C4F7C' },
     vue: { name: 'Vue', color: '#42B883' },
     svelte: { name: 'Svelte', color: '#FF3E00' },
+    marko: { name: 'Marko', color: '#44bfef' },
     angular: { name: 'Angular', color: '#DD0031' },
     alpine: { name: 'Alpine', color: '#77C1D2' },
     lit: { name: 'Lit', color: '#325CFF' },

--- a/src/utils/repo-path.ts
+++ b/src/utils/repo-path.ts
@@ -1,6 +1,6 @@
 export const MAX_REPO_PATH_LENGTH = 512
 
-const REPO_PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9._$-]+$/
+const REPO_PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9._$+-]+$/
 
 export function isValidRepoPath(path: string) {
   if (path === '') {


### PR DESCRIPTION
## Summary
 
Registers Marko as a supported framework on tanstack.com so the new TanStack Virtual Marko adapter (`@tanstack/marko-virtual`) is surfaced across the site: the framework picker, per-framework docs routing, the libraries-by-framework pages, and the Virtual landing/branding.
 
The Marko docs, sidebar config, and example apps already live in the Virtual repo (TanStack/virtual#1156, merged). This PR is the website-side work that makes them reachable, plus a couple of small fixes for Marko's file conventions that surfaced while testing.
 
## Changes
 
### Framework registration + branding
 
- `src/libraries/types.ts` — add `'marko'` to the `Framework` union (the single source of truth every other spot keys off).
- `src/libraries/frameworks.tsx` — add the Marko entry to `frameworkOptions` (logo, label, cyan accent matching the Marko mark).
- `src/libraries/libraries.ts` — add `'marko'` to the Virtual library's `frameworks` and mention it in the description.
- `src/libraries/virtual.tsx` — mention Marko in the landing description.
- `src/utils/npm-packages.ts` — add a `marko` entry to `frameworkMeta` (required by the exhaustive `Record<Framework, …>`).
- `src/utils/llms.ts` — add a `marko` entry to `frameworkLabels` (same reason).
- `src/images/marko-logo.svg` — the official Marko mark (icon-only, from `marko-js/branding`), matching the other framework logos in the picker.
### Fixes for Marko's conventions (found while testing)
 
- `src/utils/repo-path.ts` — allow `+` in repo path segments. Marko Run names files with a leading `+` (`+page.marko`, `+layout.marko`, `+handler.js`); without this, every Marko example failed path validation with "invalid path" in the example source viewer.
- `src/components/FileExplorer.tsx` + `src/images/file-icons/marko.svg` — show a Marko icon for `.marko` files in the Code Explorer tree (previously the generic text icon).
- `src/components/markdown/codeBlock.shared.tsx` — map `.marko` → `html` for syntax highlighting. `@tanstack/highlight` ships no Marko grammar, so html gives reasonable coloring for the tag/attribute-heavy example files. Partial by design: Marko-specific syntax such as `<let/>`, tag parameters `|{ }|`, and `${}` interpolation isn't tokenized specially.
## How to test
 
With the Virtual repo available (sibling checkout in dev, or remote docs), on the Virtual section:
 
- Marko appears in the framework dropdown with its logo; `/libraries/marko` lists Virtual.
- Getting Started → "Marko Virtual" renders the adapter doc.
- The Examples tab loads for Marko (fixed, variable, dynamic, grid, infinite-scroll, smooth-scroll, window).
- `.marko` files show the Marko icon in the Code Explorer tree and are syntax-highlighted.
## Notes / follow-ups (not in this repo)
 
- `@tanstack/marko-virtual` isn't published to npm yet, so the interactive CodeSandbox/StackBlitz sandboxes for the Marko examples don't boot (the example `package.json`s use `workspace:*`, and there's nothing on npm to install). Once the package is published, the Marko examples should be pinned to that version like the other frameworks. Tracked in the Virtual repo.
- The shared `docs/installation.md` in the Virtual repo has no Marko section, so `installation#marko` (the framework tile target) lands with no anchor to scroll to. A one-section addition there closes that gap.
## Screenshots
 
<!-- attach: framework dropdown showing Marko, the Marko Virtual doc page, and a Marko examples page -->
<img width="2980" height="2074" alt="image" src="https://github.com/user-attachments/assets/b089f9df-d32c-446b-8969-f9fe2ef6fb36" />
<img width="2702" height="2066" alt="image" src="https://github.com/user-attachments/assets/6c66319e-c019-4c09-85a2-850396355810" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Marko across the app, including framework selection, labeling, metadata, and library descriptions.
  * Marko files now show a dedicated file icon, and code highlighting falls back appropriately for Marko files.

* **Bug Fixes**
  * Updated repository path validation to allow `+` characters in individual path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->