### PR TITLE
fix: bound docs manifest fan-out to stop long hangs on redirect-miss docs requests

### DIFF
--- a/src/utils/docs.functions.ts
+++ b/src/utils/docs.functions.ts
@@ -3,19 +3,12 @@ import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import removeMarkdown from 'remove-markdown'
 import * as v from 'valibot'
-import {
-  extractFrontMatter,
-  fetchApiContents,
-  fetchRepoFile,
-  isRecoverableGitHubContentError,
-  shouldUseLocalDocsFiles,
-} from '~/utils/documents.server'
 import { extractFrameworksFromMarkdown } from './markdown/filterFrameworkContent'
-import { getCachedDocsArtifact } from './github-content-cache.server'
 import { buildRedirectManifest, type RedirectManifestEntry } from './redirects'
 import { isValidRepoPath, MAX_REPO_PATH_LENGTH } from './repo-path'
 import { removeLeadingSlash } from './utils'
 import type { DocsRedirectManifest } from './docs-redirects'
+import type { GitHubFileNode } from './documents.server'
 
 export type DocsTreeNode = {
   path: string
@@ -123,6 +116,14 @@ const temporarilyUnavailableMarkdown = `# Content temporarily unavailable
 
 We are having trouble fetching this document from GitHub right now. Please try again in a minute.`
 
+async function loadDocumentsServerModule() {
+  return import('./documents.server')
+}
+
+async function loadGitHubContentCacheServerModule() {
+  return import('./github-content-cache.server')
+}
+
 function buildUnavailableFile(filePath: string) {
   if (filePath.toLowerCase().endsWith('.md')) {
     return temporarilyUnavailableMarkdown
@@ -136,6 +137,9 @@ async function readRepoFileOrFallback(
   branch: string,
   filePath: string,
 ) {
+  const { fetchRepoFile, isRecoverableGitHubContentError } =
+    await loadDocumentsServerModule()
+
   try {
     return await fetchRepoFile(repo, branch, filePath)
   } catch (error) {
@@ -183,6 +187,8 @@ export async function collectRedirectEntriesForFile(
     onCanonicalPath: (canonicalPath: string) => void
   },
 ): Promise<Array<RedirectManifestEntry>> {
+  const { extractFrontMatter, isRecoverableGitHubContentError } =
+    await loadDocumentsServerModule()
   const canonicalPath = getCanonicalDocsPath(node.path, opts.docsRoot)
 
   if (canonicalPath === null) {
@@ -238,6 +244,7 @@ async function buildDocsManifest({
   branch: string
   docsRoot: string
 }): Promise<DocsManifest> {
+  const { fetchApiContents, fetchRepoFile } = await loadDocumentsServerModule()
   const nodes = await fetchApiContents(repo, branch, docsRoot)
 
   if (!nodes) {
@@ -279,6 +286,7 @@ async function buildDocsPathManifest({
   branch: string
   docsRoot: string
 }): Promise<DocsManifest> {
+  const { fetchApiContents } = await loadDocumentsServerModule()
   const nodes = await fetchApiContents(repo, branch, docsRoot)
 
   if (!nodes) {
@@ -302,6 +310,11 @@ export const fetchDocsManifest = createServerFn({ method: 'GET' })
   .validator(docsManifestInput)
   .handler(async ({ data }) => {
     const { repo, branch, docsRoot } = data
+    const [{ shouldUseLocalDocsFiles }, { getCachedDocsArtifact }] =
+      await Promise.all([
+        loadDocumentsServerModule(),
+        loadGitHubContentCacheServerModule(),
+      ])
 
     if (shouldUseLocalDocsFiles()) {
       return buildDocsManifest({ repo, branch, docsRoot })
@@ -322,6 +335,11 @@ export const fetchDocsPathManifest = createServerFn({ method: 'GET' })
   .validator(docsManifestInput)
   .handler(async ({ data }) => {
     const { repo, branch, docsRoot } = data
+    const [{ shouldUseLocalDocsFiles }, { getCachedDocsArtifact }] =
+      await Promise.all([
+        loadDocumentsServerModule(),
+        loadGitHubContentCacheServerModule(),
+      ])
 
     if (shouldUseLocalDocsFiles()) {
       return buildDocsPathManifest({ repo, branch, docsRoot })
@@ -341,6 +359,7 @@ export const fetchDocsPathManifest = createServerFn({ method: 'GET' })
 export const fetchDocsRedirect = createServerFn({ method: 'GET' })
   .validator(docsRedirectInput)
   .handler(async ({ data }) => {
+    const { isRecoverableGitHubContentError } = await loadDocumentsServerModule()
     let manifest: DocsManifest
 
     try {
@@ -389,6 +408,7 @@ export const fetchDocs = createServerFn({ method: 'GET' })
       throw notFound()
     }
 
+    const { extractFrontMatter } = await loadDocumentsServerModule()
     const frontMatter = extractFrontMatter(file)
     const description =
       frontMatter.userDescription ?? removeMarkdown(frontMatter.excerpt ?? '')
@@ -446,7 +466,9 @@ export const fetchRepoDirectoryContents = createServerFn({
   .validator(repoDirectoryInput)
   .handler(async ({ data }: { data: RepoDirectoryRequest }) => {
     const { repo, branch, startingPath } = data
-    let githubContents: Awaited<ReturnType<typeof fetchApiContents>>
+    const { fetchApiContents, isRecoverableGitHubContentError } =
+      await loadDocumentsServerModule()
+    let githubContents: Array<GitHubFileNode> | null
 
     try {
       githubContents = await fetchApiContents(repo, branch, startingPath)

--- a/src/utils/docs.functions.ts
+++ b/src/utils/docs.functions.ts
@@ -359,7 +359,8 @@ export const fetchDocsPathManifest = createServerFn({ method: 'GET' })
 export const fetchDocsRedirect = createServerFn({ method: 'GET' })
   .validator(docsRedirectInput)
   .handler(async ({ data }) => {
-    const { isRecoverableGitHubContentError } = await loadDocumentsServerModule()
+    const { isRecoverableGitHubContentError } =
+      await loadDocumentsServerModule()
     let manifest: DocsManifest
 
     try {

--- a/src/utils/docs.functions.ts
+++ b/src/utils/docs.functions.ts
@@ -17,7 +17,7 @@ import { isValidRepoPath, MAX_REPO_PATH_LENGTH } from './repo-path'
 import { removeLeadingSlash } from './utils'
 import type { DocsRedirectManifest } from './docs-redirects'
 
-type DocsTreeNode = {
+export type DocsTreeNode = {
   path: string
   children?: Array<DocsTreeNode>
 }
@@ -92,6 +92,33 @@ const docsRedirectInput = v.object({
   docsPaths: v.array(v.pipe(v.string(), v.maxLength(512))),
 })
 
+// Matches RAW_FETCH_CONCURRENCY in github-example.server.ts.
+const DOCS_MANIFEST_FETCH_CONCURRENCY = 6
+
+export async function mapWithConcurrency<T, TResult>(
+  values: Array<T>,
+  concurrency: number,
+  fn: (value: T) => Promise<TResult>,
+) {
+  const results = new Array<TResult>(values.length)
+  let index = 0
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (index < values.length) {
+        const currentIndex = index
+        index += 1
+        results[currentIndex] = await fn(values[currentIndex])
+      }
+    },
+  )
+
+  await Promise.all(workers)
+
+  return results
+}
+
 const temporarilyUnavailableMarkdown = `# Content temporarily unavailable
 
 We are having trouble fetching this document from GitHub right now. Please try again in a minute.`
@@ -146,6 +173,62 @@ function isDocsManifest(value: unknown): value is DocsManifest {
   )
 }
 
+// Extracted so tests can inject a fake fetchFile without hitting real
+// GitHub network/cache.
+export async function collectRedirectEntriesForFile(
+  node: DocsTreeNode,
+  opts: {
+    docsRoot: string
+    fetchFile: (filePath: string) => Promise<string | null>
+    onCanonicalPath: (canonicalPath: string) => void
+  },
+): Promise<Array<RedirectManifestEntry>> {
+  const canonicalPath = getCanonicalDocsPath(node.path, opts.docsRoot)
+
+  if (canonicalPath === null) {
+    return []
+  }
+
+  opts.onCanonicalPath(canonicalPath)
+
+  let file: string | null
+  try {
+    file = await opts.fetchFile(node.path)
+  } catch (error) {
+    if (!isRecoverableGitHubContentError(error)) {
+      throw error
+    }
+
+    return []
+  }
+
+  if (!file) {
+    return []
+  }
+
+  const frontMatter = extractFrontMatter(file)
+  const entries: Array<RedirectManifestEntry> = []
+
+  for (const redirectFrom of frontMatter.data.redirectFrom ?? []) {
+    const normalizedRedirect = normalizeDocsRedirectPath(
+      redirectFrom,
+      opts.docsRoot,
+    )
+
+    if (!normalizedRedirect || normalizedRedirect === canonicalPath) {
+      continue
+    }
+
+    entries.push({
+      from: normalizedRedirect,
+      to: canonicalPath,
+      source: node.path,
+    })
+  }
+
+  return entries
+}
+
 async function buildDocsManifest({
   repo,
   branch,
@@ -165,46 +248,23 @@ async function buildDocsManifest({
     node.path.endsWith('.md'),
   )
   const paths = new Set<string>()
-  const redirects: Array<RedirectManifestEntry> = []
 
-  for (const node of markdownFiles) {
-    const canonicalPath = getCanonicalDocsPath(node.path, docsRoot)
-
-    if (canonicalPath === null) {
-      continue
-    }
-
-    paths.add(canonicalPath)
-
-    const file = await fetchRepoFile(repo, branch, node.path)
-
-    if (!file) {
-      continue
-    }
-
-    const frontMatter = extractFrontMatter(file)
-
-    for (const redirectFrom of frontMatter.data.redirectFrom ?? []) {
-      const normalizedRedirect = normalizeDocsRedirectPath(
-        redirectFrom,
+  // A recoverable error on one file must not fail the whole manifest build
+  // (see collectRedirectEntriesForFile).
+  const redirectsByFile = await mapWithConcurrency(
+    markdownFiles,
+    DOCS_MANIFEST_FETCH_CONCURRENCY,
+    (node) =>
+      collectRedirectEntriesForFile(node, {
         docsRoot,
-      )
-
-      if (!normalizedRedirect || normalizedRedirect === canonicalPath) {
-        continue
-      }
-
-      redirects.push({
-        from: normalizedRedirect,
-        to: canonicalPath,
-        source: node.path,
-      })
-    }
-  }
+        fetchFile: (filePath) => fetchRepoFile(repo, branch, filePath),
+        onCanonicalPath: (canonicalPath) => paths.add(canonicalPath),
+      }),
+  )
 
   return {
     paths: Array.from(paths),
-    redirects: buildRedirectManifest(redirects, {
+    redirects: buildRedirectManifest(redirectsByFile.flat(), {
       label: `docs redirects for ${repo}@${branch}:${docsRoot}`,
     }),
   }

--- a/tests/docs-manifest-concurrency.test.ts
+++ b/tests/docs-manifest-concurrency.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  collectRedirectEntriesForFile,
+  mapWithConcurrency,
+  type DocsTreeNode,
+} from '../src/utils/docs.functions'
+import { GitHubContentError } from '../src/utils/documents.server'
+
+test('mapWithConcurrency preserves result order regardless of completion order', async () => {
+  const delays = [30, 5, 20, 1, 15]
+
+  const results = await mapWithConcurrency(delays, 3, async (delay) => {
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    return delay
+  })
+
+  assert.deepEqual(results, delays)
+})
+
+test('mapWithConcurrency bounds concurrency instead of running everything in parallel', async () => {
+  const items = Array.from({ length: 12 }, (_, index) => index)
+  let inFlight = 0
+  let maxInFlight = 0
+
+  await mapWithConcurrency(items, 4, async () => {
+    inFlight += 1
+    maxInFlight = Math.max(maxInFlight, inFlight)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    inFlight -= 1
+  })
+
+  assert.ok(
+    maxInFlight <= 4,
+    `expected at most 4 concurrent calls, saw ${maxInFlight}`,
+  )
+  assert.equal(maxInFlight, 4, 'expected concurrency to reach the cap')
+})
+
+test('mapWithConcurrency runs in a bounded number of batches, not one call per item', async () => {
+  const items = Array.from({ length: 18 }, (_, index) => index)
+  const perItemDelayMs = 20
+  const concurrency = 6
+
+  const start = Date.now()
+  await mapWithConcurrency(items, concurrency, async () => {
+    await new Promise((resolve) => setTimeout(resolve, perItemDelayMs))
+  })
+  const elapsed = Date.now() - start
+
+  const sequentialWorstCase = items.length * perItemDelayMs
+  assert.ok(
+    elapsed < sequentialWorstCase / 2,
+    `expected concurrent execution well under ${sequentialWorstCase}ms, took ${elapsed}ms`,
+  )
+})
+
+console.log('docs manifest concurrency tests passed')
+
+test('collectRedirectEntriesForFile returns no entries (not a rejection) when the file fetch throws a recoverable GitHub error', async () => {
+  const node: DocsTreeNode = { path: 'docs/guide/old-page.md' }
+  const paths: Array<string> = []
+
+  const entries = await collectRedirectEntriesForFile(node, {
+    docsRoot: 'docs',
+    fetchFile: async () => {
+      throw new GitHubContentError('rate-limit', 'GitHub rate limited this file')
+    },
+    onCanonicalPath: (path) => paths.push(path),
+  })
+
+  assert.deepEqual(entries, [])
+  assert.deepEqual(paths, ['guide/old-page'])
+})
+
+test('collectRedirectEntriesForFile rethrows non-recoverable errors instead of silently swallowing them', async () => {
+  const node: DocsTreeNode = { path: 'docs/guide/old-page.md' }
+
+  await assert.rejects(
+    () =>
+      collectRedirectEntriesForFile(node, {
+        docsRoot: 'docs',
+        fetchFile: async () => {
+          throw new TypeError('this is a real bug, not a flaky GitHub call')
+        },
+        onCanonicalPath: () => {},
+      }),
+    TypeError,
+  )
+})
+
+test('a mix of one failing file and several succeeding files still produces every succeeding redirect', async () => {
+  const nodes: Array<DocsTreeNode> = [
+    { path: 'docs/guide/a.md' },
+    { path: 'docs/guide/flaky.md' },
+    { path: 'docs/guide/b.md' },
+  ]
+
+  const fileContents: Record<string, string> = {
+    'docs/guide/a.md': '---\nredirect_from:\n  - guide/old-a\n---\n# A',
+    'docs/guide/b.md': '---\nredirect_from:\n  - guide/old-b\n---\n# B',
+  }
+
+  const paths: Array<string> = []
+
+  const results = await mapWithConcurrency(nodes, 3, (node) =>
+    collectRedirectEntriesForFile(node, {
+      docsRoot: 'docs',
+      fetchFile: async (filePath) => {
+        if (filePath === 'docs/guide/flaky.md') {
+          throw new GitHubContentError('server', 'GitHub 5xx for this file')
+        }
+
+        return fileContents[filePath] ?? null
+      },
+      onCanonicalPath: (path) => paths.push(path),
+    }),
+  )
+
+  // The whole build did not reject just because one file was flaky.
+  assert.deepEqual(
+    results.flat().map((entry) => entry.from),
+    ['guide/old-a', 'guide/old-b'],
+  )
+  // All three files' paths were still recorded, including the flaky one.
+  assert.deepEqual(paths.sort(), ['guide/a', 'guide/b', 'guide/flaky'])
+})
+
+console.log('buildDocsManifest per-file fault tolerance tests passed')

--- a/tests/docs-manifest-concurrency.test.ts
+++ b/tests/docs-manifest-concurrency.test.ts
@@ -64,7 +64,10 @@ test('collectRedirectEntriesForFile returns no entries (not a rejection) when th
   const entries = await collectRedirectEntriesForFile(node, {
     docsRoot: 'docs',
     fetchFile: async () => {
-      throw new GitHubContentError('rate-limit', 'GitHub rate limited this file')
+      throw new GitHubContentError(
+        'rate-limit',
+        'GitHub rate limited this file',
+      )
     },
     onCanonicalPath: (path) => paths.push(path),
   })


### PR DESCRIPTION
## Problem

Any docs request for a path missing from the lightweight path manifest (typo, dead link, aggregation page, or literally any nonexistent slug) falls through to `buildDocsManifest`, which fetches every markdown file in the library's docs tree one at a time to read redirect frontmatter. For `tanstack/query` that's 494 sequential GitHub round-trips with no concurrency and no per-file fault tolerance.

Reproduced against production: a docs path with no `.md` sibling hangs 45-90s+ with zero bytes returned, both with and without `Accept: text/markdown`. A single recoverable GitHub error (rate limit, 5xx, transient network failure) on any one file also rejected the entire manifest build, which could cascade into a real 404 for completely unrelated docs pages.

## Fix

- Bound the per-file fetch fan-out to concurrency 6 (matches `RAW_FETCH_CONCURRENCY` used elsewhere in this codebase) instead of fully sequential.
- One file's recoverable fetch error now skips that file's redirect entries instead of failing the whole manifest build.

## Not in scope

There's a second, separate slow path (`fetchApiContentsRemoteFromContentsApi`, a sequential per-directory GitHub Contents API fallback) that this PR does not touch. Flagging for a follow-up rather than guessing at a fix without production visibility into how often it fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved docs redirect manifest generation with bounded concurrency for faster builds.
  * Added fault-tolerant per-file redirect extraction that flattens valid redirect entries into the final manifest.

* **Bug Fixes**
  * Recoverable document fetch issues (such as rate limiting) no longer fail the overall manifest build.
  * Canonical docs paths are still recorded even when a file’s content can’t be retrieved.

* **Tests**
  * Added tests covering concurrency limits, stable output ordering, and recoverable vs non-recoverable fetch error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->