### PR TITLE
fix: add missing copy actions to builder

### DIFF
--- a/src/components/ApplicationStarter.tsx
+++ b/src/components/ApplicationStarter.tsx
@@ -766,6 +766,71 @@ export function ApplicationStarter({
                             ))}
                           </div>
                         </StarterCustomizationSection>
+                        {showActionSection ? (
+                          <div className="flex flex-col gap-4 mt-4">
+                            {!showCliExportActions ? (
+                              <div className="flex flex-wrap items-center gap-3">
+                                {!selectedHostingDeployPartner
+                                  ? renderActionAnchor({
+                                      action: 'netlify',
+                                      className:
+                                        'border-[#00AD9F] bg-[#00AD9F] text-white hover:bg-[#009a8e]',
+                                      href: netlifyStartHref,
+                                      icon: <Rocket className="h-4 w-4" />,
+                                      label: secondaryActionLabel,
+                                      onTrack: () => {
+                                        trackActivation({
+                                          action: 'netlify_start',
+                                          surface: 'result_panel',
+                                          provider: 'netlify',
+                                        })
+                                      },
+                                      size: 'sm',
+                                    })
+                                  : null}
+
+                                {renderActionAnchor({
+                                  action: 'codex',
+                                  className:
+                                    'border-gray-900 bg-gray-900 text-white hover:bg-gray-800 dark:border-gray-100 dark:bg-gray-100 dark:text-gray-950 dark:hover:bg-gray-200',
+                                  href: codexStartHref,
+                                  icon: (
+                                    <span className="relative h-4 w-4 shrink-0">
+                                      <img
+                                        src={openaiDarkLogo}
+                                        alt=""
+                                        aria-hidden="true"
+                                        className="h-4 w-4 dark:hidden"
+                                      />
+                                      <img
+                                        src={openaiLightLogo}
+                                        alt=""
+                                        aria-hidden="true"
+                                        className="hidden h-4 w-4 dark:block"
+                                      />
+                                    </span>
+                                  ),
+                                  label: 'Open in Codex',
+                                  onTrack: () => {
+                                    trackActivation({
+                                      action: 'open_codex',
+                                      surface: 'result_panel',
+                                    })
+                                  },
+                                  size: 'sm',
+                                })}
+                              </div>
+                            ) : null}
+
+                            <div className="flex flex-wrap items-center gap-3">
+                              {renderSelectedHostingDeployButton()}
+                              {renderCopyPromptButton()}
+                              {showCliExportActions
+                                ? renderCopyCliCommandButton()
+                                : null}
+                            </div>
+                          </div>
+                        ) : null}
                       </div>
                     </StarterTooltipProvider>
                   ) : null}


### PR DESCRIPTION
## Summary

Adds the missing **Copy Prompt** and **Copy CLI Command** buttons to the TanStack Start builder, matching the behavior of the Builder page.

Fixes #1030

## Changes

- Added the **Copy Prompt** button to the Start builder
- Added the **Copy CLI Command** button to the Start builder
- Reused the existing copy behavior to keep the Start builder consistent with the Builder page

## Testing

- Verified both buttons are rendered on the Start builder
- Verified the generated prompt is copied correctly
- Verified the generated CLI command is copied correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the compact action area to show more result-panel actions when available.
  * Added a new “Open in Codex” link and a Netlify start action when applicable.
  * Added a grouped row for deploy, copy prompt, and optional CLI command actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->