### PR TITLE
Add Joi to validation npm stats

### DIFF
--- a/src/routes/stats/npm/-comparisons.ts
+++ b/src/routes/stats/npm/-comparisons.ts
@@ -894,6 +894,10 @@ export function getPopularComparisons(): v.InferInput<
           color: '#06b6d4',
         },
         {
+          packages: [{ name: 'joi' }],
+          color: '#8b5cf6',
+        },
+        {
           packages: [{ name: '@sinclair/typebox' }],
           color: '#d946ef',
         },


### PR DESCRIPTION
Adds `joi` to the Validation npm stats comparison group.

Tests:
- `pnpm oxlint --type-aware --disable-nested-config "src/routes/stats/npm/-comparisons.ts"`
- `pnpm run test` (commit hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Joi to the Validation comparison package list, so it now appears as an available option in that view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->