### PR TITLE
feat(partners): rich AG Grid partner page with subpages

### DIFF
--- a/src/components/AgGridPartner.tsx
+++ b/src/components/AgGridPartner.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react'
+import { Link } from '@tanstack/react-router'
+import { Check } from 'lucide-react'
+import { CodeBlock } from '~/components/markdown/CodeBlock'
+import { trackEvent } from '~/utils/analytics'
+
+/**
+ * Shared building blocks for the AG Grid partner page and its subpages
+ * (`/partners/ag-grid/*`). Keeping links, tracking, and small UI helpers in one
+ * place keeps every page consistent and the sponsor UTM tags in sync.
+ */
+
+const UTM = 'utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+
+export const AG_GRID_LINKS = {
+  home: `https://www.ag-grid.com/?${UTM}`,
+  reactGrid: `https://www.ag-grid.com/react-data-grid/?${UTM}`,
+  docs: `https://www.ag-grid.com/react-data-grid/getting-started/?${UTM}`,
+  rowGrouping: `https://www.ag-grid.com/react-data-grid/grouping/?${UTM}`,
+  pivoting: `https://www.ag-grid.com/react-data-grid/pivoting/?${UTM}`,
+  serverSide: `https://www.ag-grid.com/react-data-grid/server-side-model/?${UTM}`,
+  integratedCharts: `https://www.ag-grid.com/react-data-grid/integrated-charts/?${UTM}`,
+  agCharts: `https://www.ag-grid.com/charts/?${UTM}`,
+  pricing: `https://www.ag-grid.com/license-pricing/?${UTM}`,
+  studio: `https://www.ag-grid.com/studio/?${UTM}`,
+  studioTrial: `https://www.ag-grid.com/studio/license-pricing/?tab=trial&${UTM}`,
+  studioDemos: `https://www.ag-grid.com/studio/example/?${UTM}`,
+  studioQuickStart: `https://www.ag-grid.com/studio/react/quick-start/?${UTM}`,
+} as const
+
+export function trackAgGridClick(destinationHost = 'ag-grid.com') {
+  trackEvent('partner_clicked', {
+    partner_id: 'ag-grid',
+    placement: 'detail',
+    destination: 'external',
+    destination_host: destinationHost,
+  })
+}
+
+export function CheckBadge() {
+  return (
+    <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+      <Check className="h-2.5 w-2.5" strokeWidth={3} />
+    </span>
+  )
+}
+
+export function AgGridCodeExample({
+  code,
+  lang,
+  title,
+}: {
+  code: string
+  lang: string
+  title: string
+}) {
+  return (
+    <CodeBlock dataCodeTitle={title}>
+      <code className={`language-${lang}`}>{code}</code>
+    </CodeBlock>
+  )
+}
+
+type SubpageLinkTo =
+  | '/partners/ag-grid'
+  | '/partners/ag-grid/studio'
+  | '/partners/ag-grid/vs-tanstack-table'
+  | '/partners/ag-grid/enterprise'
+  | '/partners/ag-grid/getting-started'
+
+const SUBPAGES: Array<{ to: SubpageLinkTo; label: string; desc: string }> = [
+  {
+    to: '/partners/ag-grid',
+    label: 'Overview',
+    desc: 'AG Grid + TanStack Table, at a glance',
+  },
+  {
+    to: '/partners/ag-grid/getting-started',
+    label: 'React quickstart',
+    desc: 'Add AG Grid to a TanStack app in minutes',
+  },
+  {
+    to: '/partners/ag-grid/vs-tanstack-table',
+    label: 'vs TanStack Table',
+    desc: 'When to choose which grid',
+  },
+  {
+    to: '/partners/ag-grid/enterprise',
+    label: 'Enterprise features',
+    desc: 'Pivoting, grouping, and the server-side row model',
+  },
+  {
+    to: '/partners/ag-grid/studio',
+    label: 'AG Grid Studio',
+    desc: 'Embedded analytics dashboards',
+  },
+]
+
+/** Card grid linking to the sibling AG Grid pages. Skips the current page. */
+export function AgGridSubpageNav({ current }: { current: SubpageLinkTo }) {
+  const items = SUBPAGES.filter((page) => page.to !== current)
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {items.map((page) => (
+        <Link
+          key={page.to}
+          to={page.to}
+          className="group rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-400 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-500"
+        >
+          <div className="text-sm font-semibold group-hover:text-blue-500">
+            {page.label}
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+            {page.desc}
+          </p>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+/** Shared breadcrumb: Partners / AG Grid / <current page>. */
+export function AgGridBreadcrumb({ current }: { current?: string }) {
+  return (
+    <nav className="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <Link to="/partners" className="transition-colors hover:text-blue-500">
+        Partners
+      </Link>
+      <span>/</span>
+      {current ? (
+        <>
+          <Link
+            to="/partners/ag-grid"
+            className="transition-colors hover:text-blue-500"
+          >
+            AG Grid
+          </Link>
+          <span>/</span>
+          <span className="text-gray-900 dark:text-white">{current}</span>
+        </>
+      ) : (
+        <span className="text-gray-900 dark:text-white">AG Grid</span>
+      )}
+    </nav>
+  )
+}
+
+/** Section heading + intro shared across subpages. */
+export function AgGridSectionIntro({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+        {title}
+      </h2>
+      <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+        {children}
+      </p>
+    </>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,6 +57,7 @@ import { Route as ShopSearchRouteImport } from './routes/shop.search'
 import { Route as ShopCartRouteImport } from './routes/shop.cart'
 import { Route as ShopHandleRouteImport } from './routes/shop.$handle'
 import { Route as PartnersRailwayRouteImport } from './routes/partners.railway'
+import { Route as PartnersAgGridRouteImport } from './routes/partners.ag-grid'
 import { Route as PartnersPartnerRouteImport } from './routes/partners.$partner'
 import { Route as OauthTokenRouteImport } from './routes/oauth/token'
 import { Route as OauthRegisterRouteImport } from './routes/oauth/register'
@@ -82,6 +83,7 @@ import { Route as AccountFeedbackRouteImport } from './routes/account/feedback'
 import { Route as DotwellKnownOauthAuthorizationServerRouteImport } from './routes/[.]well-known/oauth-authorization-server'
 import { Route as LibraryLibraryIdRouteRouteImport } from './routes/_library/$libraryId/route'
 import { Route as StatsNpmIndexRouteImport } from './routes/stats/npm/index'
+import { Route as PartnersAgGridIndexRouteImport } from './routes/partners.ag-grid.index'
 import { Route as IntentRegistryIndexRouteImport } from './routes/intent/registry/index'
 import { Route as ApiMcpIndexRouteImport } from './routes/api/mcp/index'
 import { Route as AdminShowcasesIndexRouteImport } from './routes/admin/showcases.index'
@@ -96,6 +98,10 @@ import { Route as ShopProductsHandleRouteImport } from './routes/shop.products.$
 import { Route as ShopPoliciesHandleRouteImport } from './routes/shop.policies.$handle'
 import { Route as ShopPagesHandleRouteImport } from './routes/shop.pages.$handle'
 import { Route as ShopCollectionsHandleRouteImport } from './routes/shop.collections.$handle'
+import { Route as PartnersAgGridVsTanstackTableRouteImport } from './routes/partners.ag-grid.vs-tanstack-table'
+import { Route as PartnersAgGridStudioRouteImport } from './routes/partners.ag-grid.studio'
+import { Route as PartnersAgGridGettingStartedRouteImport } from './routes/partners.ag-grid.getting-started'
+import { Route as PartnersAgGridEnterpriseRouteImport } from './routes/partners.ag-grid.enterprise'
 import { Route as IntentRegistryPackageNameRouteImport } from './routes/intent/registry/$packageName'
 import { Route as AuthProviderStartRouteImport } from './routes/auth/$provider/start'
 import { Route as ApiOgChar123Char125DotpngRouteImport } from './routes/api/og/{$}[.]png'
@@ -402,6 +408,11 @@ const PartnersRailwayRoute = PartnersRailwayRouteImport.update({
   path: '/railway',
   getParentRoute: () => PartnersRoute,
 } as any)
+const PartnersAgGridRoute = PartnersAgGridRouteImport.update({
+  id: '/ag-grid',
+  path: '/ag-grid',
+  getParentRoute: () => PartnersRoute,
+} as any)
 const PartnersPartnerRoute = PartnersPartnerRouteImport.update({
   id: '/$partner',
   path: '/$partner',
@@ -528,6 +539,11 @@ const StatsNpmIndexRoute = StatsNpmIndexRouteImport.update({
   path: '/stats/npm/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PartnersAgGridIndexRoute = PartnersAgGridIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => PartnersAgGridRoute,
+} as any)
 const IntentRegistryIndexRoute = IntentRegistryIndexRouteImport.update({
   id: '/intent/registry/',
   path: '/intent/registry/',
@@ -598,6 +614,29 @@ const ShopCollectionsHandleRoute = ShopCollectionsHandleRouteImport.update({
   path: '/collections/$handle',
   getParentRoute: () => ShopRoute,
 } as any)
+const PartnersAgGridVsTanstackTableRoute =
+  PartnersAgGridVsTanstackTableRouteImport.update({
+    id: '/vs-tanstack-table',
+    path: '/vs-tanstack-table',
+    getParentRoute: () => PartnersAgGridRoute,
+  } as any)
+const PartnersAgGridStudioRoute = PartnersAgGridStudioRouteImport.update({
+  id: '/studio',
+  path: '/studio',
+  getParentRoute: () => PartnersAgGridRoute,
+} as any)
+const PartnersAgGridGettingStartedRoute =
+  PartnersAgGridGettingStartedRouteImport.update({
+    id: '/getting-started',
+    path: '/getting-started',
+    getParentRoute: () => PartnersAgGridRoute,
+  } as any)
+const PartnersAgGridEnterpriseRoute =
+  PartnersAgGridEnterpriseRouteImport.update({
+    id: '/enterprise',
+    path: '/enterprise',
+    getParentRoute: () => PartnersAgGridRoute,
+  } as any)
 const IntentRegistryPackageNameRoute =
   IntentRegistryPackageNameRouteImport.update({
     id: '/intent/registry/$packageName',
@@ -1029,6 +1068,7 @@ export interface FileRoutesByFullPath {
   '/oauth/register': typeof OauthRegisterRoute
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
+  '/partners/ag-grid': typeof PartnersAgGridRouteWithChildren
   '/partners/railway': typeof PartnersRailwayRoute
   '/shop/$handle': typeof ShopHandleRoute
   '/shop/cart': typeof ShopCartRoute
@@ -1069,6 +1109,10 @@ export interface FileRoutesByFullPath {
   '/api/og/{$}.png': typeof ApiOgChar123Char125DotpngRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
   '/intent/registry/$packageName': typeof IntentRegistryPackageNameRouteWithChildren
+  '/partners/ag-grid/enterprise': typeof PartnersAgGridEnterpriseRoute
+  '/partners/ag-grid/getting-started': typeof PartnersAgGridGettingStartedRoute
+  '/partners/ag-grid/studio': typeof PartnersAgGridStudioRoute
+  '/partners/ag-grid/vs-tanstack-table': typeof PartnersAgGridVsTanstackTableRoute
   '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
   '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/policies/$handle': typeof ShopPoliciesHandleRoute
@@ -1083,6 +1127,7 @@ export interface FileRoutesByFullPath {
   '/admin/showcases/': typeof AdminShowcasesIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
   '/intent/registry/': typeof IntentRegistryIndexRoute
+  '/partners/ag-grid/': typeof PartnersAgGridIndexRoute
   '/stats/npm/': typeof StatsNpmIndexRoute
   '/$libraryId/$version/docs': typeof LibraryLibraryIdVersionDocsRouteWithChildren
   '/$libraryId/$version/llms.txt': typeof LibraryLibraryIdVersionLlmsDottxtRoute
@@ -1214,6 +1259,10 @@ export interface FileRoutesByTo {
   '/api/mcp/$': typeof ApiMcpSplatRoute
   '/api/og/{$}.png': typeof ApiOgChar123Char125DotpngRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
+  '/partners/ag-grid/enterprise': typeof PartnersAgGridEnterpriseRoute
+  '/partners/ag-grid/getting-started': typeof PartnersAgGridGettingStartedRoute
+  '/partners/ag-grid/studio': typeof PartnersAgGridStudioRoute
+  '/partners/ag-grid/vs-tanstack-table': typeof PartnersAgGridVsTanstackTableRoute
   '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
   '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/policies/$handle': typeof ShopPoliciesHandleRoute
@@ -1228,6 +1277,7 @@ export interface FileRoutesByTo {
   '/admin/showcases': typeof AdminShowcasesIndexRoute
   '/api/mcp': typeof ApiMcpIndexRoute
   '/intent/registry': typeof IntentRegistryIndexRoute
+  '/partners/ag-grid': typeof PartnersAgGridIndexRoute
   '/stats/npm': typeof StatsNpmIndexRoute
   '/$libraryId/$version/llms.txt': typeof LibraryLibraryIdVersionLlmsDottxtRoute
   '/api/auth/callback/$provider': typeof ApiAuthCallbackProviderRoute
@@ -1329,6 +1379,7 @@ export interface FileRoutesById {
   '/oauth/register': typeof OauthRegisterRoute
   '/oauth/token': typeof OauthTokenRoute
   '/partners/$partner': typeof PartnersPartnerRoute
+  '/partners/ag-grid': typeof PartnersAgGridRouteWithChildren
   '/partners/railway': typeof PartnersRailwayRoute
   '/shop/$handle': typeof ShopHandleRoute
   '/shop/cart': typeof ShopCartRoute
@@ -1369,6 +1420,10 @@ export interface FileRoutesById {
   '/api/og/{$}.png': typeof ApiOgChar123Char125DotpngRoute
   '/auth/$provider/start': typeof AuthProviderStartRoute
   '/intent/registry/$packageName': typeof IntentRegistryPackageNameRouteWithChildren
+  '/partners/ag-grid/enterprise': typeof PartnersAgGridEnterpriseRoute
+  '/partners/ag-grid/getting-started': typeof PartnersAgGridGettingStartedRoute
+  '/partners/ag-grid/studio': typeof PartnersAgGridStudioRoute
+  '/partners/ag-grid/vs-tanstack-table': typeof PartnersAgGridVsTanstackTableRoute
   '/shop/collections/$handle': typeof ShopCollectionsHandleRoute
   '/shop/pages/$handle': typeof ShopPagesHandleRoute
   '/shop/policies/$handle': typeof ShopPoliciesHandleRoute
@@ -1383,6 +1438,7 @@ export interface FileRoutesById {
   '/admin/showcases/': typeof AdminShowcasesIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
   '/intent/registry/': typeof IntentRegistryIndexRoute
+  '/partners/ag-grid/': typeof PartnersAgGridIndexRoute
   '/stats/npm/': typeof StatsNpmIndexRoute
   '/_library/$libraryId/$version/docs': typeof LibraryLibraryIdVersionDocsRouteWithChildren
   '/_library/$libraryId/$version/llms.txt': typeof LibraryLibraryIdVersionLlmsDottxtRoute
@@ -1485,6 +1541,7 @@ export interface FileRouteTypes {
     | '/oauth/register'
     | '/oauth/token'
     | '/partners/$partner'
+    | '/partners/ag-grid'
     | '/partners/railway'
     | '/shop/$handle'
     | '/shop/cart'
@@ -1525,6 +1582,10 @@ export interface FileRouteTypes {
     | '/api/og/{$}.png'
     | '/auth/$provider/start'
     | '/intent/registry/$packageName'
+    | '/partners/ag-grid/enterprise'
+    | '/partners/ag-grid/getting-started'
+    | '/partners/ag-grid/studio'
+    | '/partners/ag-grid/vs-tanstack-table'
     | '/shop/collections/$handle'
     | '/shop/pages/$handle'
     | '/shop/policies/$handle'
@@ -1539,6 +1600,7 @@ export interface FileRouteTypes {
     | '/admin/showcases/'
     | '/api/mcp/'
     | '/intent/registry/'
+    | '/partners/ag-grid/'
     | '/stats/npm/'
     | '/$libraryId/$version/docs'
     | '/$libraryId/$version/llms.txt'
@@ -1670,6 +1732,10 @@ export interface FileRouteTypes {
     | '/api/mcp/$'
     | '/api/og/{$}.png'
     | '/auth/$provider/start'
+    | '/partners/ag-grid/enterprise'
+    | '/partners/ag-grid/getting-started'
+    | '/partners/ag-grid/studio'
+    | '/partners/ag-grid/vs-tanstack-table'
     | '/shop/collections/$handle'
     | '/shop/pages/$handle'
     | '/shop/policies/$handle'
@@ -1684,6 +1750,7 @@ export interface FileRouteTypes {
     | '/admin/showcases'
     | '/api/mcp'
     | '/intent/registry'
+    | '/partners/ag-grid'
     | '/stats/npm'
     | '/$libraryId/$version/llms.txt'
     | '/api/auth/callback/$provider'
@@ -1784,6 +1851,7 @@ export interface FileRouteTypes {
     | '/oauth/register'
     | '/oauth/token'
     | '/partners/$partner'
+    | '/partners/ag-grid'
     | '/partners/railway'
     | '/shop/$handle'
     | '/shop/cart'
@@ -1824,6 +1892,10 @@ export interface FileRouteTypes {
     | '/api/og/{$}.png'
     | '/auth/$provider/start'
     | '/intent/registry/$packageName'
+    | '/partners/ag-grid/enterprise'
+    | '/partners/ag-grid/getting-started'
+    | '/partners/ag-grid/studio'
+    | '/partners/ag-grid/vs-tanstack-table'
     | '/shop/collections/$handle'
     | '/shop/pages/$handle'
     | '/shop/policies/$handle'
@@ -1838,6 +1910,7 @@ export interface FileRouteTypes {
     | '/admin/showcases/'
     | '/api/mcp/'
     | '/intent/registry/'
+    | '/partners/ag-grid/'
     | '/stats/npm/'
     | '/_library/$libraryId/$version/docs'
     | '/_library/$libraryId/$version/llms.txt'
@@ -2301,6 +2374,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PartnersRailwayRouteImport
       parentRoute: typeof PartnersRoute
     }
+    '/partners/ag-grid': {
+      id: '/partners/ag-grid'
+      path: '/ag-grid'
+      fullPath: '/partners/ag-grid'
+      preLoaderRoute: typeof PartnersAgGridRouteImport
+      parentRoute: typeof PartnersRoute
+    }
     '/partners/$partner': {
       id: '/partners/$partner'
       path: '/$partner'
@@ -2476,6 +2556,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StatsNpmIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/partners/ag-grid/': {
+      id: '/partners/ag-grid/'
+      path: '/'
+      fullPath: '/partners/ag-grid/'
+      preLoaderRoute: typeof PartnersAgGridIndexRouteImport
+      parentRoute: typeof PartnersAgGridRoute
+    }
     '/intent/registry/': {
       id: '/intent/registry/'
       path: '/intent/registry'
@@ -2573,6 +2660,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/shop/collections/$handle'
       preLoaderRoute: typeof ShopCollectionsHandleRouteImport
       parentRoute: typeof ShopRoute
+    }
+    '/partners/ag-grid/vs-tanstack-table': {
+      id: '/partners/ag-grid/vs-tanstack-table'
+      path: '/vs-tanstack-table'
+      fullPath: '/partners/ag-grid/vs-tanstack-table'
+      preLoaderRoute: typeof PartnersAgGridVsTanstackTableRouteImport
+      parentRoute: typeof PartnersAgGridRoute
+    }
+    '/partners/ag-grid/studio': {
+      id: '/partners/ag-grid/studio'
+      path: '/studio'
+      fullPath: '/partners/ag-grid/studio'
+      preLoaderRoute: typeof PartnersAgGridStudioRouteImport
+      parentRoute: typeof PartnersAgGridRoute
+    }
+    '/partners/ag-grid/getting-started': {
+      id: '/partners/ag-grid/getting-started'
+      path: '/getting-started'
+      fullPath: '/partners/ag-grid/getting-started'
+      preLoaderRoute: typeof PartnersAgGridGettingStartedRouteImport
+      parentRoute: typeof PartnersAgGridRoute
+    }
+    '/partners/ag-grid/enterprise': {
+      id: '/partners/ag-grid/enterprise'
+      path: '/enterprise'
+      fullPath: '/partners/ag-grid/enterprise'
+      preLoaderRoute: typeof PartnersAgGridEnterpriseRouteImport
+      parentRoute: typeof PartnersAgGridRoute
     }
     '/intent/registry/$packageName': {
       id: '/intent/registry/$packageName'
@@ -3265,14 +3380,36 @@ const BuilderRouteChildren: BuilderRouteChildren = {
 const BuilderRouteWithChildren =
   BuilderRoute._addFileChildren(BuilderRouteChildren)
 
+interface PartnersAgGridRouteChildren {
+  PartnersAgGridEnterpriseRoute: typeof PartnersAgGridEnterpriseRoute
+  PartnersAgGridGettingStartedRoute: typeof PartnersAgGridGettingStartedRoute
+  PartnersAgGridStudioRoute: typeof PartnersAgGridStudioRoute
+  PartnersAgGridVsTanstackTableRoute: typeof PartnersAgGridVsTanstackTableRoute
+  PartnersAgGridIndexRoute: typeof PartnersAgGridIndexRoute
+}
+
+const PartnersAgGridRouteChildren: PartnersAgGridRouteChildren = {
+  PartnersAgGridEnterpriseRoute: PartnersAgGridEnterpriseRoute,
+  PartnersAgGridGettingStartedRoute: PartnersAgGridGettingStartedRoute,
+  PartnersAgGridStudioRoute: PartnersAgGridStudioRoute,
+  PartnersAgGridVsTanstackTableRoute: PartnersAgGridVsTanstackTableRoute,
+  PartnersAgGridIndexRoute: PartnersAgGridIndexRoute,
+}
+
+const PartnersAgGridRouteWithChildren = PartnersAgGridRoute._addFileChildren(
+  PartnersAgGridRouteChildren,
+)
+
 interface PartnersRouteChildren {
   PartnersPartnerRoute: typeof PartnersPartnerRoute
+  PartnersAgGridRoute: typeof PartnersAgGridRouteWithChildren
   PartnersRailwayRoute: typeof PartnersRailwayRoute
   PartnersIndexRoute: typeof PartnersIndexRoute
 }
 
 const PartnersRouteChildren: PartnersRouteChildren = {
   PartnersPartnerRoute: PartnersPartnerRoute,
+  PartnersAgGridRoute: PartnersAgGridRouteWithChildren,
   PartnersRailwayRoute: PartnersRailwayRoute,
   PartnersIndexRoute: PartnersIndexRoute,
 }

--- a/src/routes/partners.ag-grid.enterprise.tsx
+++ b/src/routes/partners.ag-grid.enterprise.tsx
@@ -1,0 +1,332 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  ArrowUpRight,
+  BarChart3,
+  Clipboard,
+  FileSpreadsheet,
+  FolderTree,
+  Grid3x3,
+  Layers,
+  Plus,
+  Rows3,
+  Server,
+  SlidersHorizontal,
+} from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { seo } from '~/utils/seo'
+import { trackEvent } from '~/utils/analytics'
+import {
+  AG_GRID_LINKS,
+  AgGridBreadcrumb,
+  AgGridCodeExample,
+  AgGridSubpageNav,
+  trackAgGridClick,
+} from '~/components/AgGridPartner'
+
+const ENTERPRISE_SNIPPET = `import { AgGridReact } from 'ag-grid-react'
+import { ModuleRegistry } from 'ag-grid-community'
+import {
+  AllEnterpriseModule,
+  LicenseManager,
+} from 'ag-grid-enterprise'
+
+// Register once, at app startup.
+ModuleRegistry.registerModules([AllEnterpriseModule])
+LicenseManager.setLicenseKey(process.env.AG_GRID_LICENSE_KEY!)
+
+export function AnalyticsGrid({ rows }: { rows: Array<Trade> }) {
+  return (
+    <div style={{ height: 600 }}>
+      <AgGridReact
+        rowData={rows}
+        rowGroupPanelShow="always"
+        pivotMode
+        columnDefs={[
+          { field: 'desk', rowGroup: true },
+          { field: 'region', pivot: true },
+          { field: 'pnl', aggFunc: 'sum' },
+        ]}
+      />
+    </div>
+  )
+}
+`
+
+type FeatureIcon = React.ComponentType<{ className?: string }>
+
+const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
+  {
+    Icon: Layers,
+    title: 'Row grouping & aggregation',
+    desc: 'Group by any column and roll up sums, averages, and custom aggregations, with a drag-to-group panel for users.',
+  },
+  {
+    Icon: Grid3x3,
+    title: 'Pivoting',
+    desc: 'Pivot rows into columns interactively — the spreadsheet move your analysts expect, without reshaping data server-side.',
+  },
+  {
+    Icon: Server,
+    title: 'Server-side row model',
+    desc: 'Sort, filter, group, and paginate millions of rows straight from your backend. The grid only requests what it renders.',
+  },
+  {
+    Icon: BarChart3,
+    title: 'Integrated charts',
+    desc: 'Let users select a range and chart it in place with AG Charts — no separate charting stack to wire up.',
+  },
+  {
+    Icon: FileSpreadsheet,
+    title: 'Excel export',
+    desc: 'Export styled, multi-sheet Excel files including groups, formatting, and formulas, straight from the grid.',
+  },
+  {
+    Icon: Rows3,
+    title: 'Master / detail',
+    desc: 'Expand any row into a nested detail grid for drill-down views without a separate page or modal.',
+  },
+  {
+    Icon: FolderTree,
+    title: 'Tree data',
+    desc: 'Render hierarchical data — file systems, org charts, nested categories — with lazy loading built in.',
+  },
+  {
+    Icon: Clipboard,
+    title: 'Range selection & clipboard',
+    desc: 'Excel-style range selection, fill handle, and clipboard interop so power users feel at home.',
+  },
+  {
+    Icon: SlidersHorizontal,
+    title: 'Tool panels & status bar',
+    desc: 'Built-in columns and filters tool panels plus an aggregation status bar for rich, self-service data exploration.',
+  },
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'What do I get with AG Grid Enterprise?',
+    a: 'Enterprise adds row grouping and aggregation, pivoting, the server-side row model, integrated charts, Excel export, master/detail, tree data, range selection with a fill handle, tool panels, and a status bar — on top of everything in the free Community edition.',
+  },
+  {
+    q: 'How is Enterprise licensed?',
+    a: 'AG Grid Enterprise requires a commercial license. You install ag-grid-enterprise and call LicenseManager.setLicenseKey() once at startup. Without a key it still runs for evaluation, showing a watermark and console notice. Licenses are per-developer and cover production use.',
+  },
+  {
+    q: 'How many rows can the server-side row model handle?',
+    a: 'The server-side row model is designed for datasets that are too large to load at once. Because the grid only requests the rows, groups, and pages it needs, it comfortably drives grids over millions of rows backed by your API or database.',
+  },
+  {
+    q: 'Can I use TanStack Query with the server-side row model?',
+    a: 'Yes. A common pattern is to have your getRows datasource call a TanStack Query-backed endpoint. Query owns fetching and caching; AG Grid owns the sorting, filtering, grouping, and pagination requests it sends.',
+  },
+]
+
+const PAGE_TITLE = 'AG Grid Enterprise — Features for Large-Scale Data Grids'
+const PAGE_DESCRIPTION =
+  'AG Grid Enterprise adds row grouping, pivoting, the server-side row model, integrated charts, Excel export, master/detail, and tree data on top of the free Community edition. Drive grids over millions of rows in your TanStack app.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: { '@type': 'Answer', text: faq.a },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/ag-grid/enterprise')({
+  head: () => ({
+    meta: seo({
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      keywords:
+        'ag grid enterprise, server-side row model, ag grid pivoting, ag grid row grouping, integrated charts, ag grid excel export',
+      image: 'https://tanstack.com/og.png',
+    }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getFaqJsonLd()),
+      },
+    ],
+  }),
+  component: AgGridEnterprisePage,
+})
+
+function AgGridEnterprisePage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'ag-grid',
+      placement: 'detail',
+    })
+  }, [])
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <AgGridBreadcrumb current="Enterprise" />
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-8 dark:border-gray-800">
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
+            AG Grid Enterprise
+          </span>
+          <h1 className="mt-3 text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            When a table isn't
+            <br />
+            enough anymore
+          </h1>
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            Enterprise unlocks the heavy-duty features teams reach for at scale
+            — pivoting, row grouping, a server-side row model for millions of
+            rows, integrated charts, and Excel export — all on top of the free
+            Community edition.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.pricing}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              See Enterprise pricing
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.serverSide}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              variant="ghost"
+              size="lg"
+            >
+              Server-side row model docs
+            </Button>
+          </div>
+        </section>
+
+        {/* Features */}
+        <section className="py-10">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            What Enterprise adds
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Everything below is opt-in and tree-shakeable through module
+            registration.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {features.map(({ Icon, title, desc }) => (
+              <Card key={title} className="p-5 shadow-none">
+                <Icon className="mb-3 h-5 w-5 text-gray-500 dark:text-gray-400" />
+                <div className="text-sm font-semibold">{title}</div>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+          <p className="mt-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+            Integrated charts are powered by{' '}
+            <a
+              href={AG_GRID_LINKS.agCharts}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="underline decoration-dotted underline-offset-2 hover:text-blue-500"
+            >
+              AG Charts
+            </a>{' '}
+            — 30+ chart types, with free Community and Enterprise editions.
+          </p>
+        </section>
+
+        {/* Setup */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Turn on Enterprise
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Install the Enterprise package, register the modules, and set your
+            license key once at startup. Then features like pivoting and
+            grouping are just column definitions.
+          </p>
+          <div className="mt-6">
+            <AgGridCodeExample
+              code={ENTERPRISE_SNIPPET}
+              lang="tsx"
+              title="AnalyticsGrid.tsx"
+            />
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Enterprise FAQ
+          </h2>
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Explore more */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Explore more
+          </h2>
+          <div className="mt-6">
+            <AgGridSubpageNav current="/partners/ag-grid/enterprise" />
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/src/routes/partners.ag-grid.getting-started.tsx
+++ b/src/routes/partners.ag-grid.getting-started.tsx
@@ -1,0 +1,338 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { ArrowUpRight, Plus } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { seo } from '~/utils/seo'
+import { trackEvent } from '~/utils/analytics'
+import {
+  AG_GRID_LINKS,
+  AgGridBreadcrumb,
+  AgGridCodeExample,
+  AgGridSubpageNav,
+  trackAgGridClick,
+} from '~/components/AgGridPartner'
+
+const INSTALL_SNIPPET = `# Free, MIT-licensed Community edition
+npm install ag-grid-react ag-grid-community
+`
+
+const GRID_SNIPPET = `import { useState } from 'react'
+import { AgGridReact } from 'ag-grid-react'
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'
+
+// Register the Community modules once, at startup.
+ModuleRegistry.registerModules([AllCommunityModule])
+
+export function CarGrid() {
+  const [rowData] = useState([
+    { make: 'Tesla', model: 'Model Y', price: 64950 },
+    { make: 'Ford', model: 'F-Series', price: 33850 },
+    { make: 'Toyota', model: 'Corolla', price: 29600 },
+  ])
+  const [columnDefs] = useState([
+    { field: 'make' },
+    { field: 'model' },
+    { field: 'price' },
+  ])
+
+  // A container height is required — the grid virtualizes its rows.
+  return (
+    <div style={{ height: 400 }}>
+      <AgGridReact rowData={rowData} columnDefs={columnDefs} />
+    </div>
+  )
+}
+`
+
+const QUERY_SNIPPET = `import { useQuery } from '@tanstack/react-query'
+import { AgGridReact } from 'ag-grid-react'
+
+export function CarsRoute() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ['cars'],
+    queryFn: () => fetch('/api/cars').then((r) => r.json()),
+  })
+
+  return (
+    <div style={{ height: 500 }}>
+      <AgGridReact
+        rowData={data}
+        loading={isLoading}
+        columnDefs={[{ field: 'make' }, { field: 'model' }, { field: 'price' }]}
+        defaultColDef={{ sortable: true, filter: true, resizable: true }}
+      />
+    </div>
+  )
+}
+`
+
+const steps: Array<{ num: string; title: string; desc: string }> = [
+  {
+    num: '01',
+    title: 'Create a TanStack app',
+    desc: 'Start from a TanStack Start or Router app — AG Grid renders on the client after hydration, so any route works.',
+  },
+  {
+    num: '02',
+    title: 'Install AG Grid',
+    desc: 'Add the free Community packages: ag-grid-react and ag-grid-community.',
+  },
+  {
+    num: '03',
+    title: 'Register modules and render',
+    desc: 'Register the Community modules once, then render AgGridReact with columnDefs, rowData, and a container height.',
+  },
+  {
+    num: '04',
+    title: 'Wire up data with TanStack Query',
+    desc: 'Feed rowData from a Query result. Query owns fetching and caching; the grid owns sorting, filtering, and display.',
+  },
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'Does AG Grid need a container height?',
+    a: 'Yes. AG Grid virtualizes rows, so it needs a bounded height to know how many to render. Give the wrapping element an explicit height (for example height: 500px) or a flex layout that constrains it. DomLayout autoHeight is available for small, non-virtualized grids.',
+  },
+  {
+    q: 'Does AG Grid render on the server with TanStack Start?',
+    a: 'AG Grid is a client-side component and mounts after hydration. Your TanStack Start route can server-render the surrounding page and data; the grid itself initializes in the browser. Load row data with a loader or TanStack Query and pass it in as rowData.',
+  },
+  {
+    q: 'How do I add sorting and filtering?',
+    a: 'Set a defaultColDef with sortable, filter, and resizable to enable them across all columns, or configure them per column. These are part of the free Community edition.',
+  },
+  {
+    q: 'How do I upgrade to Enterprise features?',
+    a: 'Install ag-grid-enterprise, register the Enterprise modules, and call LicenseManager.setLicenseKey() once. Features like pivoting and the server-side row model then become column and grid options. See the Enterprise page for details.',
+  },
+]
+
+const PAGE_TITLE = 'AG Grid + TanStack — React Quickstart'
+const PAGE_DESCRIPTION =
+  'Add AG Grid to a TanStack Start or Router app in minutes. Install the free Community packages, register modules, render a grid, and wire up data with TanStack Query. Copy-paste React code included.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: { '@type': 'Answer', text: faq.a },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/ag-grid/getting-started')({
+  head: () => ({
+    meta: seo({
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      keywords:
+        'ag grid react tanstack, ag grid getting started, ag grid tanstack query, ag grid tanstack start, react data grid tutorial',
+      image: 'https://tanstack.com/og.png',
+    }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getFaqJsonLd()),
+      },
+    ],
+  }),
+  component: AgGridQuickstartPage,
+})
+
+function AgGridQuickstartPage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'ag-grid',
+      placement: 'detail',
+    })
+  }, [])
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <AgGridBreadcrumb current="React quickstart" />
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-8 dark:border-gray-800">
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
+            React quickstart
+          </span>
+          <h1 className="mt-3 text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            Add AG Grid to your
+            <br />
+            TanStack app
+          </h1>
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            AG Grid is a client-side React component, so it drops into any
+            TanStack Start or Router route. Install the free Community packages,
+            render a grid, and feed it with TanStack Query.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.docs}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Open the official docs
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            Community is free forever and MIT-licensed. No credit card required.
+          </p>
+        </section>
+
+        {/* Steps */}
+        <section className="py-10">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Four steps to a working grid
+          </h2>
+          <div className="mt-6 flex flex-col gap-3">
+            {steps.map(({ num, title, desc }) => (
+              <Card
+                key={num}
+                className="flex items-start gap-5 p-4 shadow-none md:p-5"
+              >
+                <div className="min-w-[28px] pt-0.5 font-mono text-xs font-bold text-gray-400 dark:text-gray-500">
+                  {num}
+                </div>
+                <div>
+                  <div className="text-sm font-semibold">{title}</div>
+                  <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                    {desc}
+                  </p>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* Install + render */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Install and render
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Two packages, one module registration, and a grid with columns and
+            rows.
+          </p>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <AgGridCodeExample
+              code={INSTALL_SNIPPET}
+              lang="bash"
+              title="terminal"
+            />
+            <AgGridCodeExample
+              code={GRID_SNIPPET}
+              lang="tsx"
+              title="CarGrid.tsx"
+            />
+          </div>
+        </section>
+
+        {/* TanStack Query */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Wire up data with TanStack Query
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Let Query handle fetching and caching, then pass the result straight
+            into the grid as rowData.
+          </p>
+          <div className="mt-6">
+            <AgGridCodeExample
+              code={QUERY_SNIPPET}
+              lang="tsx"
+              title="CarsRoute.tsx"
+            />
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.docs}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Read the full quickstart
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button as="a" href="/query" variant="ghost">
+              Explore TanStack Query
+            </Button>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Quickstart FAQ
+          </h2>
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Explore more */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Explore more
+          </h2>
+          <div className="mt-6">
+            <AgGridSubpageNav current="/partners/ag-grid/getting-started" />
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/src/routes/partners.ag-grid.index.tsx
+++ b/src/routes/partners.ag-grid.index.tsx
@@ -1,0 +1,753 @@
+import * as React from 'react'
+import { Link, createFileRoute } from '@tanstack/react-router'
+import {
+  ArrowUpRight,
+  BarChart3,
+  Check,
+  FileSpreadsheet,
+  FolderTree,
+  Grid3x3,
+  Layers,
+  LayoutDashboard,
+  Palette,
+  Plus,
+  Rows3,
+  Server,
+} from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { CodeBlock } from '~/components/markdown/CodeBlock'
+import { seo } from '~/utils/seo'
+import { getPartnerById, PartnerImage } from '~/utils/partners'
+import { getPartnerJsonLd } from '~/utils/partner-pages'
+import { trackEvent } from '~/utils/analytics'
+import { AgGridSubpageNav } from '~/components/AgGridPartner'
+
+const UTM = 'utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+const AG_GRID_HREF = `https://www.ag-grid.com/react-data-grid/?${UTM}`
+const AG_GRID_DOCS_HREF = `https://www.ag-grid.com/react-data-grid/getting-started/?${UTM}`
+const AG_GRID_PRICING_HREF = `https://www.ag-grid.com/license-pricing/?${UTM}`
+const AG_STUDIO_HREF = `https://www.ag-grid.com/studio/?${UTM}`
+const AG_STUDIO_TRIAL_HREF = `https://www.ag-grid.com/studio/license-pricing/?tab=trial&${UTM}`
+
+const INSTALL_SNIPPET = `# Community edition — free and MIT-licensed
+npm install ag-grid-react ag-grid-community
+`
+
+const GRID_SNIPPET = `import { useState } from 'react'
+import { AgGridReact } from 'ag-grid-react'
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'
+
+ModuleRegistry.registerModules([AllCommunityModule])
+
+export function CarGrid() {
+  const [rowData] = useState([
+    { make: 'Tesla', model: 'Model Y', price: 64950 },
+    { make: 'Ford', model: 'F-Series', price: 33850 },
+    { make: 'Toyota', model: 'Corolla', price: 29600 },
+  ])
+  const [columnDefs] = useState([
+    { field: 'make' },
+    { field: 'model' },
+    { field: 'price' },
+  ])
+
+  // A container height is required — the grid virtualizes rows.
+  return (
+    <div style={{ height: 400 }}>
+      <AgGridReact rowData={rowData} columnDefs={columnDefs} />
+    </div>
+  )
+}
+`
+
+type FeatureIcon = React.ComponentType<{ className?: string }>
+
+const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
+  {
+    Icon: Layers,
+    title: 'Row grouping & aggregation',
+    desc: 'Group rows by any column and roll up totals, averages, and custom aggregations across millions of records.',
+  },
+  {
+    Icon: Grid3x3,
+    title: 'Pivoting',
+    desc: 'Pivot rows into columns on the fly, just like a spreadsheet, without reshaping your data on the server.',
+  },
+  {
+    Icon: Server,
+    title: 'Server-side row model',
+    desc: 'Stream, sort, filter, and group huge datasets straight from your backend — the grid only fetches what it renders.',
+  },
+  {
+    Icon: FileSpreadsheet,
+    title: 'Excel export',
+    desc: 'Export styled, multi-sheet Excel files directly from the grid, including grouping and formatting.',
+  },
+  {
+    Icon: BarChart3,
+    title: 'Integrated charts',
+    desc: 'Turn any selection into an interactive chart powered by AG Charts, without leaving the grid.',
+  },
+  {
+    Icon: Rows3,
+    title: 'Master / detail',
+    desc: 'Expand any row into a nested detail grid for drill-down views without a separate page or modal.',
+  },
+  {
+    Icon: FolderTree,
+    title: 'Tree data',
+    desc: 'Render hierarchical data — file systems, org charts, nested categories — with lazy loading built in.',
+  },
+  {
+    Icon: Palette,
+    title: 'Theming engine',
+    desc: 'A modern theming API with design tokens, shared with AG Grid Studio so grids and dashboards match.',
+  },
+]
+
+const steps: Array<{ num: string; title: string; code: string }> = [
+  {
+    num: '01',
+    title: 'Install the Community packages',
+    code: 'npm install ag-grid-react ag-grid-community',
+  },
+  {
+    num: '02',
+    title: 'Register the Community modules',
+    code: 'ModuleRegistry.registerModules([AllCommunityModule])',
+  },
+  {
+    num: '03',
+    title: 'Render a grid with columns and row data',
+    code: '<AgGridReact rowData={rows} columnDefs={cols} />',
+  },
+  {
+    num: '04',
+    title: 'Unlock Enterprise when you need it',
+    code: 'npm install ag-grid-enterprise',
+  },
+]
+
+// Instead of Railway-style customer testimonials, AG Grid's most useful
+// section is the honest "when to choose which" guidance — the founding goal
+// of the TanStack Table + AG Grid partnership.
+const chooseTanStackTable: Array<string> = [
+  'You want a headless grid you style and compose yourself',
+  'You need a tiny bundle and full control over the DOM',
+  'You are building a bespoke table UI with your own design system',
+  'You want the same core across React, Vue, Solid, Svelte, Qwik, and Angular',
+]
+
+const chooseAgGrid: Array<string> = [
+  'You need enterprise features like pivoting or a server-side row model out of the box',
+  'You are handling hundreds of thousands to millions of rows',
+  'You want Excel export, integrated charts, and range selection without building them',
+  'You need a batteries-included grid your team can ship this week',
+]
+
+const libDetails: Array<{ label: string; desc: string }> = [
+  {
+    label: 'TanStack Table',
+    desc: 'AG Grid is the official open-source partner of TanStack Table. Reach for Table when you want a headless grid, and AG Grid when you need a batteries-included one.',
+  },
+  {
+    label: 'TanStack Query',
+    desc: "Feed AG Grid's server-side row model from a Query-backed API. Query owns fetching and caching; the grid owns sorting, filtering, and grouping at scale.",
+  },
+  {
+    label: 'TanStack Start',
+    desc: 'AG Grid renders on the client after hydration inside a TanStack Start app — drop it into any route with a container height and column definitions.',
+  },
+  {
+    label: 'TanStack Virtual',
+    desc: 'AG Grid ships its own row and column virtualization. Use TanStack Virtual for custom virtualized surfaces outside of a grid.',
+  },
+]
+
+const studioFeatures: Array<{ title: string; desc: string }> = [
+  {
+    title: 'Drag & drop dashboards',
+    desc: 'Rearrange and resize charts, grids, and KPI tiles in real time — no rebuild required.',
+  },
+  {
+    title: 'Widget gallery',
+    desc: 'Pre-built bar, line, area, pie, and scatter charts, plus grids and KPI tiles ready to drop in.',
+  },
+  {
+    title: 'AI assistant',
+    desc: 'Ask questions of your data in natural language and generate dashboards on the fly.',
+  },
+  {
+    title: 'Edit and view modes',
+    desc: 'Configure in edit mode, then hand a clean, read-only reporting view to stakeholders.',
+  },
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'Is AG Grid free?',
+    a: 'AG Grid Community is free and MIT-licensed for commercial use, and covers sorting, filtering, editing, virtualization, and custom cell rendering. AG Grid Enterprise and AG Grid Studio require a commercial license and add features like pivoting, the server-side row model, integrated charts, and embedded dashboards.',
+  },
+  {
+    q: 'What is the difference between AG Grid and TanStack Table?',
+    a: 'TanStack Table is a headless library: it gives you the state and logic for a table and you bring the markup and styles. AG Grid is a full, batteries-included data grid with its own rendering and enterprise features. They are complementary — that is why AG Grid is the official open-source partner of TanStack Table.',
+  },
+  {
+    q: 'What is AG Grid Studio?',
+    a: 'AG Grid Studio is an embedded analytics toolkit for building drag-and-drop dashboards on top of AG Grid and AG Charts. It handles data processing over hundreds of thousands of rows, ships a widget gallery, and includes an AI assistant. It offers a 45-day free trial with full features and no watermarks.',
+  },
+  {
+    q: 'Does AG Grid work with TanStack Start?',
+    a: 'Yes. AG Grid is a client-side React component, so it renders inside any TanStack Start route after hydration. Install ag-grid-react and ag-grid-community, register the Community modules, and give the grid a container with an explicit height.',
+  },
+  {
+    q: 'Can I use AG Grid with TanStack Query?',
+    a: "Yes. A common pattern is to let TanStack Query own data fetching and caching while AG Grid's server-side row model requests only the rows it needs to display. Query handles the network; the grid handles sorting, filtering, and grouping at scale.",
+  },
+  {
+    q: 'How many rows can AG Grid handle?',
+    a: 'AG Grid virtualizes both rows and columns, so it renders only what is on screen. With the client-side row model it comfortably handles tens of thousands of rows, and with the Enterprise server-side row model it streams millions of rows straight from your backend.',
+  },
+]
+
+const PAGE_TITLE = 'AG Grid for TanStack — Official Table Partner'
+const PAGE_DESCRIPTION =
+  'AG Grid is the official open-source partner of TanStack Table: a batteries-included enterprise data grid with row grouping, pivoting, a server-side row model, Excel export, and integrated charts. Plus AG Grid Studio for embedded analytics dashboards. Learn when to choose AG Grid vs TanStack Table.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.a,
+      },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/ag-grid/')({
+  head: () => {
+    const partner = getPartnerById('ag-grid')
+
+    return {
+      meta: seo({
+        title: PAGE_TITLE,
+        description: PAGE_DESCRIPTION,
+        keywords:
+          'ag grid tanstack, ag grid vs tanstack table, ag grid react, enterprise data grid, ag grid studio, ag grid partner, tanstack table alternative',
+        image: 'https://tanstack.com/og.png',
+      }),
+      scripts: [
+        ...(partner
+          ? [
+              {
+                type: 'application/ld+json',
+                children: JSON.stringify(getPartnerJsonLd(partner)),
+              },
+            ]
+          : []),
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify(getFaqJsonLd()),
+        },
+      ],
+    }
+  },
+  component: AgGridPartnerPage,
+})
+
+function CheckBadge() {
+  return (
+    <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+      <Check className="h-2.5 w-2.5" strokeWidth={3} />
+    </span>
+  )
+}
+
+function trackAgGridClick(destinationHost = 'ag-grid.com') {
+  trackEvent('partner_clicked', {
+    partner_id: 'ag-grid',
+    placement: 'detail',
+    destination: 'external',
+    destination_host: destinationHost,
+  })
+}
+
+function AgGridCodeExample({
+  code,
+  lang,
+  title,
+}: {
+  code: string
+  lang: string
+  title: string
+}) {
+  return (
+    <CodeBlock dataCodeTitle={title}>
+      <code className={`language-${lang}`}>{code}</code>
+    </CodeBlock>
+  )
+}
+
+function AgGridPartnerPage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'ag-grid',
+      placement: 'detail',
+    })
+  }, [])
+
+  const partner = getPartnerById('ag-grid')
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <nav className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <Link
+            to="/partners"
+            className="transition-colors hover:text-blue-500"
+          >
+            Partners
+          </Link>
+          <span>/</span>
+          <span className="text-gray-900 dark:text-white">AG Grid</span>
+        </nav>
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-10 dark:border-gray-800">
+          <div className="mb-5 flex items-center gap-4">
+            {partner ? (
+              <div className="flex h-12 w-44 items-center justify-start">
+                <PartnerImage
+                  config={partner.image}
+                  alt="AG Grid"
+                  className="max-h-10 w-auto"
+                />
+              </div>
+            ) : null}
+            <div>
+              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
+                Official Table Partner · Data Grid
+              </span>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  Community edition is free & MIT-licensed
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <h1 className="text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            The enterprise data grid,
+            <br />
+            alongside TanStack Table
+          </h1>
+
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            AG Grid is the official open-source partner of TanStack Table. When
+            a headless table needs to become a full data grid — pivoting,
+            grouping, a server-side row model for millions of rows — AG Grid
+            picks up where Table leaves off, across React, Angular, Vue, and
+            vanilla JavaScript.
+          </p>
+
+          <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
+            "Together we strive to educate the ecosystem about the differences
+            between the two libraries and when to choose which." — the TanStack
+            Table &amp; AG Grid partnership
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_DOCS_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Get started free
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button as="a" href="#how-it-works" variant="ghost" size="lg">
+              See how it works
+            </Button>
+          </div>
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            Community is free forever. No credit card required.
+          </p>
+        </section>
+
+        {/* Stats */}
+        <section className="grid grid-cols-2 gap-x-8 gap-y-5 border-b border-gray-200 py-7 sm:flex sm:flex-wrap sm:gap-10 dark:border-gray-800">
+          {[
+            ['MIT', 'Community license'],
+            ['4', 'Frameworks supported'],
+            ['1M+', 'Rows with server-side model'],
+            ['45-day', 'AG Grid Studio trial'],
+          ].map(([value, label]) => (
+            <div key={label}>
+              <div className="text-2xl font-bold tracking-tight">{value}</div>
+              <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                {label}
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {/* Features */}
+        <section className="py-10">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            What AG Grid brings to the table
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Everything in Community is free and MIT-licensed. Enterprise adds
+            the heavy-duty features teams reach for when a basic table UI is no
+            longer enough.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {features.map(({ Icon, title, desc }) => (
+              <Card key={title} className="p-5 shadow-none">
+                <Icon className="mb-3 h-5 w-5 text-gray-500 dark:text-gray-400" />
+                <div className="text-sm font-semibold">{title}</div>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section
+          id="how-it-works"
+          className="border-t border-gray-200 py-10 dark:border-gray-800"
+        >
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            From install to grid in 4 steps
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            AG Grid is a client-side React component. Install Community,
+            register the modules, and render a grid — then reach for Enterprise
+            when you need it.
+          </p>
+
+          <div className="mt-6 flex flex-col gap-3">
+            {steps.map(({ num, title, code }) => (
+              <Card
+                key={num}
+                className="flex items-start gap-5 p-4 shadow-none md:p-5"
+              >
+                <div className="min-w-[28px] pt-0.5 font-mono text-xs font-bold text-gray-400 dark:text-gray-500">
+                  {num}
+                </div>
+                <div>
+                  <div className="text-sm font-semibold">{title}</div>
+                  <code className="mt-2 inline-block rounded-md bg-gray-100 px-2.5 py-1 font-mono text-xs dark:bg-gray-800">
+                    {code}
+                  </code>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <AgGridCodeExample
+              code={INSTALL_SNIPPET}
+              lang="bash"
+              title="terminal"
+            />
+            <AgGridCodeExample
+              code={GRID_SNIPPET}
+              lang="tsx"
+              title="CarGrid.tsx"
+            />
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_DOCS_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Read the React quickstart
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              variant="ghost"
+            >
+              Explore the docs
+            </Button>
+          </div>
+        </section>
+
+        {/* When to choose which */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            TanStack Table vs AG Grid — when to choose which
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            The two libraries share a problem space but take opposite
+            approaches. This is the honest guidance at the heart of the
+            partnership.
+          </p>
+
+          <div className="mt-6 grid gap-3 md:grid-cols-2">
+            <Card className="p-5 shadow-none">
+              <div className="text-sm font-semibold">
+                Reach for TanStack Table when…
+              </div>
+              <ul className="mt-4 flex flex-col gap-2.5">
+                {chooseTanStackTable.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+                  >
+                    <CheckBadge />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+            <Card className="p-5 shadow-none">
+              <div className="text-sm font-semibold">
+                Reach for AG Grid when…
+              </div>
+              <ul className="mt-4 flex flex-col gap-2.5">
+                {chooseAgGrid.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+                  >
+                    <CheckBadge />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        </section>
+
+        {/* Library fit */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Fits into your TanStack stack
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            AG Grid slots alongside the TanStack libraries you already use —
+            from Table to Query to Start.
+          </p>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {libDetails.map(({ label, desc }) => (
+              <Card key={label} className="p-4 shadow-none">
+                <div className="flex items-start gap-2">
+                  <CheckBadge />
+                  <span className="text-sm font-semibold">{label}</span>
+                </div>
+                <p className="mt-2 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* AG Grid Studio spotlight */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <div className="mb-2 flex items-center gap-2">
+            <LayoutDashboard className="h-5 w-5 text-orange-500" />
+            <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-orange-600 dark:text-orange-400">
+              AG Grid Studio
+            </span>
+          </div>
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Embedded analytics. Built to perform.
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            AG Grid Studio adds drag-and-drop dashboards, charts, grids, and
+            filters to your app without building analytics from scratch. It
+            shares a theming engine with AG Grid, so everything matches out of
+            the box.
+          </p>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {studioFeatures.map(({ title, desc }) => (
+              <Card key={title} className="p-4 shadow-none">
+                <div className="text-sm font-semibold">{title}</div>
+                <p className="mt-1 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={AG_STUDIO_TRIAL_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Start a 45-day free trial
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_STUDIO_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              variant="ghost"
+            >
+              Explore AG Grid Studio
+            </Button>
+          </div>
+        </section>
+
+        {/* Explore subpages */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Go deeper
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Detailed guides for getting started, comparing grids, and unlocking
+            Enterprise and Studio.
+          </p>
+          <div className="mt-6">
+            <AgGridSubpageNav current="/partners/ag-grid" />
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Frequently asked questions
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Common questions from TanStack developers evaluating AG Grid.
+          </p>
+
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mt-6 rounded-2xl bg-gray-950 px-6 py-10 text-center md:px-10 md:py-12 dark:bg-gray-900">
+          <div className="inline-block rounded-full bg-white/5 px-3 py-1 text-[11px] text-gray-400">
+            Official TanStack Table open-source partner
+          </div>
+          <h2 className="mt-4 text-2xl font-black tracking-tight text-white md:text-3xl">
+            Ready to build with AG Grid?
+          </h2>
+          <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-gray-400">
+            Start free with Community, unlock Enterprise when you need it, and
+            add embedded dashboards with AG Grid Studio.
+          </p>
+
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_DOCS_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-white text-gray-950 border-white hover:bg-gray-100"
+            >
+              Get started free
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_PRICING_HREF}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-transparent text-white border-gray-700 hover:bg-white/5"
+            >
+              See pricing
+            </Button>
+          </div>
+        </section>
+
+        <p className="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
+          AG Grid is the official open-source partner of TanStack Table.{' '}
+          <Link
+            to="/partners"
+            className="underline decoration-dotted underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            Browse all TanStack partners
+          </Link>
+          .{' '}
+          <a
+            href={AG_GRID_HREF}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => trackAgGridClick()}
+            className="underline decoration-dotted underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            ag-grid.com
+          </a>
+        </p>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/src/routes/partners.ag-grid.studio.tsx
+++ b/src/routes/partners.ag-grid.studio.tsx
@@ -1,0 +1,410 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  ArrowUpRight,
+  Boxes,
+  Gauge,
+  LayoutDashboard,
+  Palette,
+  Plus,
+  Sparkles,
+  SplitSquareVertical,
+} from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { seo } from '~/utils/seo'
+import { trackEvent } from '~/utils/analytics'
+import {
+  AG_GRID_LINKS,
+  AgGridBreadcrumb,
+  AgGridCodeExample,
+  AgGridSubpageNav,
+  CheckBadge,
+  trackAgGridClick,
+} from '~/components/AgGridPartner'
+
+const QUICKSTART_SNIPPET = `import { AgStudio } from 'ag-studio-react'
+
+// Each source is an id plus an array of plain row objects.
+const sources = [
+  {
+    id: 'sales',
+    data: [
+      { region: 'EMEA', product: 'Grid', revenue: 128000 },
+      { region: 'AMER', product: 'Charts', revenue: 96500 },
+      { region: 'APAC', product: 'Studio', revenue: 71200 },
+    ],
+  },
+]
+
+export function Dashboard() {
+  // Render inside a sized parent; "edit" mode lets users build reports.
+  return (
+    <div style={{ height: '100vh', width: '100%' }}>
+      <AgStudio data={{ sources }} mode="edit" />
+    </div>
+  )
+}
+`
+
+type FeatureIcon = React.ComponentType<{ className?: string }>
+
+const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
+  {
+    Icon: LayoutDashboard,
+    title: 'Drag & drop widgets',
+    desc: 'Rearrange and resize charts, grids, and KPI tiles in real time. Build a dashboard by moving pieces, not writing layout code.',
+  },
+  {
+    Icon: SplitSquareVertical,
+    title: 'Edit and view modes',
+    desc: 'Configure everything in edit mode, then hand a clean, read-only reporting view to stakeholders.',
+  },
+  {
+    Icon: Gauge,
+    title: 'High-performance data',
+    desc: 'Process hundreds of thousands of rows in the browser with joins, aggregations, and computed columns.',
+  },
+  {
+    Icon: Boxes,
+    title: 'Widget gallery',
+    desc: 'Pre-built bar, line, area, pie, and scatter charts, plus grids and KPI tiles, ready to drop into any dashboard.',
+  },
+  {
+    Icon: Sparkles,
+    title: 'AI assistant',
+    desc: 'Explore your data in natural language and generate whole dashboards from a prompt.',
+  },
+  {
+    Icon: Palette,
+    title: 'Shared theming',
+    desc: 'Studio shares a theming engine with AG Grid, so your dashboards and grids look like one product out of the box.',
+  },
+]
+
+const fitPoints: Array<string> = [
+  'Embed dashboards inside a TanStack Start or Router app as a client-side React component',
+  'Feed widgets from a TanStack Query-backed API, then let Studio handle joins and aggregations',
+  'Reuse your AG Grid theme so embedded analytics match the rest of your product',
+  'Give non-technical users self-service reporting without building analytics infrastructure',
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'How much does AG Grid Studio cost?',
+    a: 'AG Grid Studio requires a commercial license for production use. You can start with a 45-day free trial that includes full features with no watermarks or restrictions, plus direct engineering support during the trial.',
+  },
+  {
+    q: 'How is Studio different from AG Grid Enterprise?',
+    a: 'AG Grid Enterprise is the data grid component with features like pivoting and the server-side row model. AG Grid Studio is a higher-level toolkit for building complete drag-and-drop analytics dashboards — charts, grids, filters, and KPI tiles — on top of AG Grid and AG Charts.',
+  },
+  {
+    q: 'How much data can Studio handle?',
+    a: 'Studio is built for performance and processes hundreds of thousands of rows in the browser, with joins, aggregations, and computed columns. For very large datasets you can pre-aggregate on your backend and feed the results into Studio.',
+  },
+  {
+    q: 'Does Studio work with React and TanStack?',
+    a: 'Yes. Studio supports React, Angular, Vue, and vanilla JavaScript, so it embeds inside a TanStack Start or Router app as a standard client-side component.',
+  },
+]
+
+const PAGE_TITLE = 'AG Grid Studio — Embedded Analytics for TanStack Apps'
+const PAGE_DESCRIPTION =
+  'AG Grid Studio is an embedded-analytics toolkit for building drag-and-drop dashboards on top of AG Grid and AG Charts. Widget gallery, AI assistant, edit and view modes, and a shared theming engine — with a 45-day free trial. Embed it in any TanStack Start or Router app.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: { '@type': 'Answer', text: faq.a },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/ag-grid/studio')({
+  head: () => ({
+    meta: seo({
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      keywords:
+        'ag grid studio, embedded analytics react, dashboard toolkit, tanstack dashboards, ag charts, self-service reporting',
+      image: 'https://tanstack.com/og.png',
+    }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getFaqJsonLd()),
+      },
+    ],
+  }),
+  component: AgGridStudioPage,
+})
+
+function AgGridStudioPage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'ag-grid',
+      placement: 'detail',
+    })
+  }, [])
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <AgGridBreadcrumb current="Studio" />
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-8 dark:border-gray-800">
+          <div className="mb-3 flex items-center gap-2">
+            <LayoutDashboard className="h-5 w-5 text-orange-500" />
+            <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-orange-600 dark:text-orange-400">
+              AG Grid Studio
+            </span>
+          </div>
+          <h1 className="text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            Embedded analytics.
+            <br />
+            Built to perform.
+          </h1>
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            AG Grid Studio adds dashboards, charts, grids, and filters to your
+            app without building analytics from scratch. Drag, drop, and ship
+            self-service reporting your users can drive themselves.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studioTrial}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Start a 45-day free trial
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studioDemos}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              variant="ghost"
+              size="lg"
+            >
+              See the demos
+            </Button>
+          </div>
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            Full features during the trial. No watermarks. Engineering support
+            included.
+          </p>
+        </section>
+
+        {/* Features */}
+        <section className="py-10">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Everything you need to build dashboards
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Studio is a complete toolkit for embedded analytics, powered by AG
+            Grid and{' '}
+            <a
+              href={AG_GRID_LINKS.agCharts}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="underline decoration-dotted underline-offset-2 hover:text-blue-500"
+            >
+              AG Charts
+            </a>{' '}
+            under the hood.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {features.map(({ Icon, title, desc }) => (
+              <Card key={title} className="p-5 shadow-none">
+                <Icon className="mb-3 h-5 w-5 text-gray-500 dark:text-gray-400" />
+                <div className="text-sm font-semibold">{title}</div>
+                <p className="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                  {desc}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {/* TanStack fit */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            A natural fit for TanStack apps
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Studio is a client-side React component, so it drops into the apps
+            you already build with TanStack.
+          </p>
+          <Card className="mt-6 p-5 shadow-none md:p-6">
+            <ul className="flex flex-col gap-2.5">
+              {fitPoints.map((point) => (
+                <li
+                  key={point}
+                  className="flex items-start gap-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+                >
+                  <CheckBadge />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </section>
+
+        {/* Quick start */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Render a dashboard in React
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            Install{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[0.85em] dark:bg-gray-800">
+              ag-studio-react
+            </code>
+            , hand{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[0.85em] dark:bg-gray-800">
+              AgStudio
+            </code>{' '}
+            your data sources, and switch on edit mode so users can build
+            reports.
+          </p>
+          <div className="mt-6">
+            <AgGridCodeExample
+              code={QUICKSTART_SNIPPET}
+              lang="tsx"
+              title="Dashboard.tsx"
+            />
+          </div>
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studioQuickStart}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Read the React quickstart
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studioDemos}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              variant="ghost"
+            >
+              Browse example dashboards
+            </Button>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            AG Grid Studio FAQ
+          </h2>
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mt-6 rounded-2xl bg-gray-950 px-6 py-10 text-center md:px-10 md:py-12 dark:bg-gray-900">
+          <h2 className="text-2xl font-black tracking-tight text-white md:text-3xl">
+            Ship analytics without the infrastructure
+          </h2>
+          <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-gray-400">
+            Try AG Grid Studio free for 45 days with full features and no
+            watermarks.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studioTrial}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-white text-gray-950 border-white hover:bg-gray-100"
+            >
+              Start your free trial
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.studio}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              size="lg"
+              className="bg-transparent text-white border-gray-700 hover:bg-white/5"
+            >
+              Explore AG Grid Studio
+            </Button>
+          </div>
+        </section>
+
+        {/* Explore more */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Explore more
+          </h2>
+          <div className="mt-6">
+            <AgGridSubpageNav current="/partners/ag-grid/studio" />
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/src/routes/partners.ag-grid.tsx
+++ b/src/routes/partners.ag-grid.tsx
@@ -1,0 +1,9 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/partners/ag-grid')({
+  component: AgGridLayout,
+})
+
+function AgGridLayout() {
+  return <Outlet />
+}

--- a/src/routes/partners.ag-grid.vs-tanstack-table.tsx
+++ b/src/routes/partners.ag-grid.vs-tanstack-table.tsx
@@ -1,0 +1,317 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { ArrowUpRight, Plus } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+import { Footer } from '~/components/Footer'
+import { Card } from '~/components/Card'
+import { Button } from '~/ui'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/Collapsible'
+import { seo } from '~/utils/seo'
+import { trackEvent } from '~/utils/analytics'
+import {
+  AG_GRID_LINKS,
+  AgGridBreadcrumb,
+  AgGridSubpageNav,
+  CheckBadge,
+  trackAgGridClick,
+} from '~/components/AgGridPartner'
+
+const chooseTanStackTable: Array<string> = [
+  'You want a headless grid — you own the markup, styles, and design system',
+  'Bundle size and full DOM control matter more than built-in features',
+  'You are composing a bespoke table UI, not shipping a spreadsheet replacement',
+  'You want the same core across React, Vue, Solid, Svelte, Qwik, Angular, and Lit',
+  'Your dataset fits comfortably in the client-side model (tens of thousands of rows)',
+  'You are happy to wire up sorting, grouping, and virtualization yourself',
+]
+
+const chooseAgGrid: Array<string> = [
+  'You need enterprise features like pivoting or a server-side row model out of the box',
+  'You are handling hundreds of thousands to millions of rows',
+  'You want Excel export, integrated charts, and range selection without building them',
+  'Master/detail, tree data, and clipboard support are requirements, not nice-to-haves',
+  'You want a batteries-included grid your whole team can ship this week',
+  'You need commercial support behind the grid at the center of your product',
+]
+
+type Row = { feature: string; table: string; agGrid: string }
+
+const comparison: Array<Row> = [
+  {
+    feature: 'Architecture',
+    table: 'Headless (bring your own UI)',
+    agGrid: 'Full component with built-in UI',
+  },
+  {
+    feature: 'License',
+    table: 'MIT (free)',
+    agGrid: 'Community MIT · Enterprise commercial',
+  },
+  {
+    feature: 'Styling',
+    table: 'Your CSS / design system',
+    agGrid: 'Theming engine with design tokens',
+  },
+  {
+    feature: 'Row virtualization',
+    table: 'Pair with TanStack Virtual',
+    agGrid: 'Built in (rows and columns)',
+  },
+  {
+    feature: 'Row grouping & pivoting',
+    table: 'Build it yourself',
+    agGrid: 'Enterprise, built in',
+  },
+  {
+    feature: 'Server-side row model',
+    table: 'Build it yourself',
+    agGrid: 'Enterprise, built in',
+  },
+  {
+    feature: 'Excel export & charts',
+    table: 'Bring your own',
+    agGrid: 'Enterprise, built in',
+  },
+  {
+    feature: 'Best for',
+    table: 'Custom, lightweight tables',
+    agGrid: 'Large-scale enterprise data grids',
+  },
+]
+
+const faqs: Array<{ q: string; a: string }> = [
+  {
+    q: 'Are AG Grid and TanStack Table competitors?',
+    a: 'No — they are partners. AG Grid is the official open-source partner of TanStack Table. They solve the same broad problem with opposite philosophies: TanStack Table is headless and composable, AG Grid is full-featured and batteries-included. Many teams use both in the same product.',
+  },
+  {
+    q: 'Can I migrate from TanStack Table to AG Grid?',
+    a: 'Yes. Because both are column-and-row driven, your column definitions and row data map over cleanly. TanStack Table column defs become AG Grid columnDefs, and your data array becomes rowData. The main shift is that AG Grid renders the UI for you instead of you rendering it.',
+  },
+  {
+    q: 'Which one is faster?',
+    a: 'It depends on the workload. TanStack Table is a thin logic layer, so raw overhead is minimal, but you supply the rendering and virtualization. AG Grid ships heavily optimized rendering, virtualization, and a server-side row model designed for very large datasets out of the box.',
+  },
+  {
+    q: 'Can I use both in the same app?',
+    a: 'Absolutely. A common pattern is TanStack Table for lightweight, custom-styled tables and AG Grid for the heavy data-grid surfaces that need pivoting, grouping, or millions of rows.',
+  },
+]
+
+const PAGE_TITLE = 'AG Grid vs TanStack Table — When to Choose Which'
+const PAGE_DESCRIPTION =
+  'AG Grid and TanStack Table are partners, not rivals. TanStack Table is a headless, composable grid; AG Grid is a batteries-included enterprise data grid. Compare architecture, features, licensing, and scale to choose the right one — or use both.'
+
+function getFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: { '@type': 'Answer', text: faq.a },
+    })),
+  }
+}
+
+export const Route = createFileRoute('/partners/ag-grid/vs-tanstack-table')({
+  head: () => ({
+    meta: seo({
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      keywords:
+        'ag grid vs tanstack table, tanstack table vs ag grid, react data grid comparison, headless table, enterprise data grid, react-table alternative',
+      image: 'https://tanstack.com/og.png',
+    }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getFaqJsonLd()),
+      },
+    ],
+  }),
+  component: AgGridVsTablePage,
+})
+
+function AgGridVsTablePage() {
+  const [openFaq, setOpenFaq] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    trackEvent('partner_viewed', {
+      partner_id: 'ag-grid',
+      placement: 'detail',
+    })
+  }, [])
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-16 pt-6 md:px-8">
+        <AgGridBreadcrumb current="vs TanStack Table" />
+
+        {/* Hero */}
+        <section className="border-b border-gray-200 pb-10 pt-8 dark:border-gray-800">
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
+            Partners, not rivals
+          </span>
+          <h1 className="mt-3 text-4xl font-black leading-[1.1] tracking-tight text-gray-950 dark:text-white md:text-5xl">
+            AG Grid vs TanStack Table
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
+            Both libraries live in the same problem space but take opposite
+            approaches. TanStack Table is headless and composable; AG Grid is
+            full-featured and batteries-included. AG Grid is the official
+            open-source partner of TanStack Table — here is how to pick the
+            right one, or use both together.
+          </p>
+        </section>
+
+        {/* When to choose which */}
+        <section className="py-10">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Card className="p-5 shadow-none md:p-6">
+              <div className="text-sm font-semibold">
+                Reach for TanStack Table when…
+              </div>
+              <ul className="mt-4 flex flex-col gap-2.5">
+                {chooseTanStackTable.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+                  >
+                    <CheckBadge />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+            <Card className="p-5 shadow-none md:p-6">
+              <div className="text-sm font-semibold">
+                Reach for AG Grid when…
+              </div>
+              <ul className="mt-4 flex flex-col gap-2.5">
+                {chooseAgGrid.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+                  >
+                    <CheckBadge />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        </section>
+
+        {/* Side-by-side table */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Side by side
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
+            A quick reference across the dimensions teams weigh most.
+          </p>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full min-w-[560px] border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-800">
+                  <th className="py-3 pr-4 font-semibold" />
+                  <th className="py-3 pr-4 font-semibold">TanStack Table</th>
+                  <th className="py-3 font-semibold">AG Grid</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparison.map(({ feature, table, agGrid }) => (
+                  <tr
+                    key={feature}
+                    className="border-b border-gray-100 dark:border-gray-900"
+                  >
+                    <td className="py-3 pr-4 font-medium text-gray-900 dark:text-gray-200">
+                      {feature}
+                    </td>
+                    <td className="py-3 pr-4 text-gray-600 dark:text-gray-400">
+                      {table}
+                    </td>
+                    <td className="py-3 text-gray-600 dark:text-gray-400">
+                      {agGrid}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              as="a"
+              href={AG_GRID_LINKS.reactGrid}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackAgGridClick()}
+              className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
+            >
+              Try AG Grid
+              <ArrowUpRight className="h-4 w-4" />
+            </Button>
+            <Button as="a" href="/table" variant="ghost">
+              Explore TanStack Table
+            </Button>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Common questions
+          </h2>
+          <div className="mt-5 flex flex-col">
+            {faqs.map(({ q, a }, i) => {
+              const isOpen = openFaq === i
+              return (
+                <Collapsible
+                  key={q}
+                  open={isOpen}
+                  onOpenChange={(next) => setOpenFaq(next ? i : null)}
+                  className="border-b border-gray-200 dark:border-gray-800"
+                >
+                  <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 py-4 text-left">
+                    <span className="text-sm font-medium md:text-[15px]">
+                      {q}
+                    </span>
+                    <Plus
+                      className={twMerge(
+                        'h-4 w-4 shrink-0 text-gray-500 transition-transform duration-200 dark:text-gray-400',
+                        isOpen && 'rotate-45',
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="max-w-2xl pb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                      {a}
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Explore more */}
+        <section className="border-t border-gray-200 py-10 dark:border-gray-800">
+          <h2 className="text-2xl font-black tracking-tight md:text-3xl">
+            Explore more
+          </h2>
+          <div className="mt-6">
+            <AgGridSubpageNav current="/partners/ag-grid/vs-tanstack-table" />
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Overview

Replaces the sparse, generic AG Grid partner page with a dedicated, SEO- and AI-search-optimized resource hub at **`/partners/ag-grid`**, modeled on the existing Railway partner page and following repo conventions (Tailwind, `Card`/`Button`/`Collapsible`/`CodeBlock`, `seo()`, `PartnerImage`, `trackEvent`, FAQ + partner JSON-LD).

The main page is a layout + index so **subpages branch off it**:

| Route | What it covers |
|---|---|
| `/partners/ag-grid` | Overview — partnership framing, Enterprise features, Studio spotlight, "when to choose which", FAQ |
| `/partners/ag-grid/getting-started` | React quickstart — install, render, wire up with TanStack Query |
| `/partners/ag-grid/vs-tanstack-table` | Honest "when to choose which" comparison + side-by-side table |
| `/partners/ag-grid/enterprise` | Row grouping, pivoting, server-side row model, integrated charts (AG Charts), Excel export |
| `/partners/ag-grid/studio` | Embedded-analytics dashboards — real `ag-studio-react` quickstart, demos, trial |

## Why

AG Grid is the official open-source partner of TanStack Table. The old page was just a title, two-sentence blurb, and a visit button. This turns it into a developer-credible, conversion-focused hub that also ranks for queries like *"ag grid vs tanstack table"* and *"ag grid react tanstack"*, and is structured for AI-search agents via FAQ JSON-LD.

## Notes for reviewers

- **Shared module** `src/components/AgGridPartner.tsx` holds all external links, click tracking, and small UI helpers so the **sponsor UTM tags stay in sync** across every page. All AG Grid links carry `?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page`.
- **No invented testimonials.** Unlike some partner-page drafts, the customer-quote section was replaced with the authentic TanStack Table vs AG Grid comparison.
- **Content sanity-check before merge:** copy and stats (MIT Community, 45-day Studio trial, `ag-studio-react` API shape, "1M+ rows") are synthesized from ag-grid.com. Each page links to the authoritative source, but a quick factual pass is worth it before this goes public.
- **Badge:** uses "Official Table Partner" framing rather than a tier label (repo has AG Grid as `silver`). Easy to switch to a tier badge if preferred.
- The existing partner-card "Learn More" button in `src/utils/partners.tsx` still points to `/blog/ag-grid-partnership` — not repointed here; happy to do so in a follow-up.
- Verified: all 5 routes serve 200, `tsc`/lint/unit tests green (pre-commit hook), no console errors, light + dark mode checked in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)