### PR TITLE
feat(landing): shared DS-aligned library landing template + brand/type DS work

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "web",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "db-studio",

--- a/src/components/ds/ds-nav.ts
+++ b/src/components/ds/ds-nav.ts
@@ -13,13 +13,15 @@ export interface DsNavSection {
  *
  * This is the single source of truth for the sidebar. Adding a new page is a
  * two-step change: drop a `ds.<name>.tsx` route in `src/routes` and add an
- * entry here. Keep `Styles` (design tokens) above `Components` (rendered UI).
+ * entry here. Keep `Brand & Styles` (tokens & assets) above `Components`
+ * (rendered UI).
  */
 export const dsNav: Array<DsNavSection> = [
   {
-    title: 'Styles',
+    title: 'Brand & Styles',
     items: [
       { label: 'Overview', to: '/ds' },
+      { label: 'Logos', to: '/ds/logos' },
       { label: 'Colors', to: '/ds/colors' },
       { label: 'Typography', to: '/ds/typography' },
       { label: 'Iconography', to: '/ds/iconography' },
@@ -40,6 +42,7 @@ export const dsNav: Array<DsNavSection> = [
     items: [
       { label: 'Buttons', to: '/ds/buttons' },
       { label: 'Badges', to: '/ds/badges' },
+      { label: 'Eyebrow', to: '/ds/eyebrow' },
       { label: 'Inputs', to: '/ds/inputs' },
       { label: 'Dropdown', to: '/ds/dropdown' },
       { label: 'Avatar', to: '/ds/avatar' },

--- a/src/components/ds/ui/index.tsx
+++ b/src/components/ds/ui/index.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Link } from '@tanstack/react-router'
 import { CaretDown, CircleNotch, User } from '@phosphor-icons/react'
 import type { MarkdownHeading } from '~/utils/markdown'
+import type { LibraryId } from '~/libraries/ids'
 
 /**
  * New-system DS components — built on the Figma semantic tokens (action-*,
@@ -31,12 +32,28 @@ type ButtonColor =
 type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'icon-sm' | 'icon-md'
 type ButtonRounded = 'none' | 'md' | 'lg' | 'full'
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+// Polymorphic: defaults to <button>, but `as={Link}` / `as="a"` lets a CTA
+// render as a link while keeping the button styling. Mirrors the production
+// Button's API (src/ui/Button.tsx) so pages can swap imports 1:1.
+type ButtonOwnProps<TElement extends React.ElementType = 'button'> = {
+  as?: TElement
+  children: React.ReactNode
   variant?: ButtonVariant
   color?: ButtonColor
   size?: ButtonSize
   rounded?: ButtonRounded
+  className?: string
 }
+
+type ButtonProps<TElement extends React.ElementType = 'button'> =
+  ButtonOwnProps<TElement> &
+    Omit<React.ComponentPropsWithRef<TElement>, keyof ButtonOwnProps<TElement>>
+
+type ButtonComponent = <TElement extends React.ElementType = 'button'>(
+  props: ButtonProps<TElement>,
+) => React.ReactNode
+
+type ButtonInnerProps = ButtonOwnProps & Record<string, unknown>
 
 // Color set mapped onto the new palette (brand blue = the teal #013e53).
 const primaryColorStyles: Record<ButtonColor, string> = {
@@ -119,48 +136,49 @@ function getDefaultRounded(size: ButtonSize): ButtonRounded {
   return 'lg'
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button(
-    {
-      children,
-      variant = 'primary',
-      color = 'blue',
-      size,
-      rounded,
-      className,
-      ...rest
-    },
-    ref,
-  ) {
-    const resolvedSize = size ?? getDefaultSize(variant)
-    const resolvedRounded = rounded ?? getDefaultRounded(resolvedSize)
-    const colorStyles =
-      variant === 'primary'
-        ? primaryColorStyles[color]
-        : variant === 'icon'
-          ? iconColorStyles[color]
-          : variant === 'link'
-            ? linkColorStyles[color]
-            : ''
+export const Button: ButtonComponent = React.forwardRef<
+  HTMLElement,
+  ButtonInnerProps
+>(function Button(props, ref) {
+  const {
+    as,
+    children,
+    variant = 'primary',
+    color = 'blue',
+    size,
+    rounded,
+    className,
+    ...rest
+  } = props as ButtonOwnProps & Record<string, unknown>
+  const Component = as || 'button'
+  const resolvedSize = size ?? getDefaultSize(variant)
+  const resolvedRounded = rounded ?? getDefaultRounded(resolvedSize)
+  const colorStyles =
+    variant === 'primary'
+      ? primaryColorStyles[color]
+      : variant === 'icon'
+        ? iconColorStyles[color]
+        : variant === 'link'
+          ? linkColorStyles[color]
+          : ''
 
-    return (
-      <button
-        ref={ref}
-        className={twMerge(
-          baseStyles,
-          variantStyles[variant],
-          sizeStyles[resolvedSize],
-          roundedStyles[resolvedRounded],
-          colorStyles,
-          className,
-        )}
-        {...rest}
-      >
-        {children}
-      </button>
-    )
-  },
-)
+  return React.createElement(
+    Component,
+    {
+      ref,
+      className: twMerge(
+        baseStyles,
+        variantStyles[variant],
+        sizeStyles[resolvedSize],
+        roundedStyles[resolvedRounded],
+        colorStyles,
+        className,
+      ),
+      ...rest,
+    },
+    children,
+  )
+}) as unknown as ButtonComponent
 
 /* ------------------------------------------------------------------ Badge -- */
 
@@ -204,6 +222,83 @@ export function Badge({
     >
       {children}
     </span>
+  )
+}
+
+/* ---------------------------------------------------------------- Eyebrow -- */
+
+type EyebrowTone = 'muted' | 'secondary' | 'accent'
+
+const eyebrowToneStyles: Record<EyebrowTone, string> = {
+  muted: 'text-text-muted',
+  secondary: 'text-text-secondary',
+  accent: 'text-text-accent',
+}
+
+// Libraries that ship a `--color-lib-*` brand token. Written as literal classes
+// so Tailwind's JIT emits each `text-lib-*` utility. Libraries without a brand
+// token (e.g. ranger, config) simply fall back to the neutral tone.
+const eyebrowLibraryStyles: Partial<Record<LibraryId, string>> = {
+  start: 'text-lib-start',
+  router: 'text-lib-router',
+  query: 'text-lib-query',
+  table: 'text-lib-table',
+  db: 'text-lib-db',
+  ai: 'text-lib-ai',
+  form: 'text-lib-form',
+  virtual: 'text-lib-virtual',
+  pacer: 'text-lib-pacer',
+  hotkeys: 'text-lib-hotkeys',
+  store: 'text-lib-store',
+  devtools: 'text-lib-devtools',
+  cli: 'text-lib-cli',
+  intent: 'text-lib-intent',
+}
+
+/**
+ * Section eyebrow / kicker — the small uppercase label that sits above a
+ * heading. Locks in the DS `mono-caps` role (IBM Plex Mono, 12px, +1.5px
+ * tracking) plus the inline icon layout, so every eyebrow across the site stays
+ * on-system instead of hand-stacking `text-xs font-black uppercase`.
+ *
+ * Color resolves in priority order: `library` (brand the eyebrow by the
+ * category it sits within, via that library's `--color-lib-*` token) →
+ * `className` override → `tone` (neutral default). Pass a `library` to brand it,
+ * omit it for a neutral eyebrow.
+ */
+export function Eyebrow({
+  children,
+  icon,
+  tone = 'secondary',
+  library,
+  className,
+}: {
+  children: React.ReactNode
+  icon?: React.ReactNode
+  tone?: EyebrowTone
+  /** Brand the eyebrow by the library/category it's nested within. Falls back
+   *  to `tone` when unset or when the library has no brand token. */
+  library?: LibraryId
+  className?: string
+}) {
+  const color =
+    (library && eyebrowLibraryStyles[library]) ?? eyebrowToneStyles[tone]
+
+  // The `mono-caps` type role is a fixed base — never merged away — so the DS
+  // font/size/tracking can't be overridden. Only color (library / tone /
+  // className) goes through twMerge, which handles standard color utilities
+  // cleanly. This also sidesteps twMerge dropping the custom `text-ds-*` size
+  // when a caller passes a text color.
+  return (
+    <p
+      className={`inline-flex items-center gap-2 font-ds-mono text-ds-mono-caps uppercase ${twMerge(
+        color,
+        className,
+      )}`}
+    >
+      {icon}
+      {children}
+    </p>
   )
 }
 

--- a/src/components/landing/LibraryLanding.tsx
+++ b/src/components/landing/LibraryLanding.tsx
@@ -1,0 +1,418 @@
+import * as React from 'react'
+import { Link, useParams } from '@tanstack/react-router'
+import { ArrowRight, BookOpen } from '@phosphor-icons/react'
+
+import { BottomCTA } from '~/components/BottomCTA'
+import { Footer } from '~/components/Footer'
+import { GithubIcon } from '~/components/icons/GithubIcon'
+import LandingPageGad from '~/components/LandingPageGad'
+import { LandingCommunitySection } from '~/components/LandingCommunitySection'
+import { SponsorSection } from '~/components/SponsorSection'
+import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
+import { LibraryTestimonials } from '~/components/LibraryTestimonials'
+import { LibraryWordmark } from '~/components/LibraryWordmark'
+import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
+import { Eyebrow } from '~/components/ds/ui'
+import { getLibrary } from '~/libraries'
+import type { LibraryId, Testimonial } from '~/libraries/types'
+
+/**
+ * Shared, config-driven landing page for every TanStack library.
+ *
+ * The page structure is identical across libraries; only the copy, the
+ * interactive demo panels, and a small brand accent change. Pass those in via
+ * `LibraryLandingConfig` and let this component own the scaffold, spacing,
+ * neutral theme, and de-noised defaults (one CTA, no superlatives).
+ */
+
+type Kicker = { icon: React.ReactNode; text: string }
+
+/**
+ * The handful of spots where a library's brand color shows through. Everything
+ * else stays neutral zinc so the page reads calm and consistent. Defaults to a
+ * neutral accent when omitted.
+ */
+export type LandingAccent = {
+  /** Kicker eyebrow text color. */
+  kicker: string
+  /** Feature-card / step icon chip background + text. */
+  chip: string
+  /** Proof-pill left border. */
+  pill: string
+  /** Bottom CTA button colors. */
+  cta: string
+}
+
+const NEUTRAL_ACCENT: LandingAccent = {
+  kicker: 'text-zinc-700 dark:text-zinc-300',
+  chip: 'bg-zinc-950 text-white dark:bg-white dark:text-zinc-950',
+  pill: 'border-zinc-950 dark:border-white',
+  cta: 'border-zinc-950 bg-zinc-950 text-white hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200',
+}
+
+export type LibraryFeature = {
+  title: string
+  body: string
+  icon: React.ReactNode
+}
+
+export type LibrarySplitSection = {
+  kicker: Kicker
+  heading: string
+  body: string
+  /** The bespoke demo/illustration panel — the one truly per-library asset. */
+  panel: React.ReactNode
+  /** Which side the panel sits on at lg+. Defaults to `right`. */
+  side?: 'left' | 'right'
+  /** Optional content rendered under the body (e.g. framework pills). */
+  belowBody?: React.ReactNode
+}
+
+export type LibraryLandingConfig = {
+  libraryId: LibraryId
+  accent?: LandingAccent
+  hero: {
+    kicker: Kicker
+    /** Bold one-liner. Keep it plain — no superlatives, no exclamations. */
+    tagline: string
+    description: string
+    /** Agent prompt for the "Copy prompt" button. */
+    prompt: string
+    promptLabel: string
+    proof: Array<{ label: string; value: string }>
+    panel: React.ReactNode
+    /** Optional block under the proof pills (e.g. ecosystem proof strip). */
+    belowProof?: React.ReactNode
+  }
+  why: {
+    kicker: Kicker
+    heading: string
+    intro: string
+    features: Array<LibraryFeature>
+  }
+  sections: Array<LibrarySplitSection>
+  /** Optional full-bleed block rendered after the split sections. */
+  interlude?: React.ReactNode
+  testimonials?: {
+    kicker: Kicker
+    heading: string
+    body: string
+    items: Array<Testimonial>
+  }
+  ecosystem: {
+    kicker?: Kicker
+    heading: string
+    body: string
+    /** Optional extra block inside the ecosystem section (e.g. a banner). */
+    extra?: React.ReactNode
+  }
+}
+
+// Horizontal gutter: 32px minimum, flexing up to 40px at sm+, so section
+// content never sits closer than 32px to the viewport edge.
+const SHELL = 'mx-auto w-full max-w-[80rem] px-6 sm:px-10 xl:max-w-[92rem]'
+const GRID =
+  'mx-auto grid w-full min-w-0 max-w-full gap-10 px-8 py-16 sm:px-10 lg:max-w-[80rem] xl:max-w-[92rem]'
+
+export function LibraryLanding({ config }: { config: LibraryLandingConfig }) {
+  const { libraryId, hero, why, sections, interlude, testimonials, ecosystem } =
+    config
+  const accent = config.accent ?? NEUTRAL_ACCENT
+  const library = getLibrary(libraryId)
+  const { version } = useParams({ strict: false })
+  const resolvedVersion = version ?? library.latestVersion
+
+  return (
+    <div className="w-full min-w-0 overflow-x-hidden bg-zinc-100 text-zinc-950 dark:bg-zinc-950 dark:text-white">
+      {/* Hero */}
+      <section className="max-w-full overflow-hidden border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
+        <div className="mx-auto grid w-full min-w-0 max-w-full gap-10 px-8 py-13 sm:px-10 lg:max-w-[80rem] lg:grid-cols-[0.86fr_1.14fr] lg:items-start lg:py-16 xl:max-w-[92rem]">
+          <div className="min-w-0 max-w-full sm:max-w-3xl">
+            <SectionKicker accent={accent} {...hero.kicker} />
+
+            {/* Small TanStack mark stacked over a large, dominant product name.
+                The mark stays understated — the navbar already carries the brand;
+                here the library is the headline. */}
+            <div className="mt-4">
+              <img
+                src="/images/brand/tanstack-landscape-black.svg"
+                alt="TanStack"
+                className="h-5 w-auto dark:hidden sm:h-6"
+              />
+              <img
+                src="/images/brand/tanstack-landscape-white.svg"
+                alt="TanStack"
+                aria-hidden="true"
+                className="hidden h-5 w-auto dark:block sm:h-6"
+              />
+              <h1 className="mt-0.5 text-6xl leading-[0.9] sm:text-7xl lg:text-8xl">
+                <LibraryWordmark library={library} includeTanStack={false} />
+              </h1>
+            </div>
+
+            <p className="mt-5 max-w-2xl text-ds-heading-4 text-zinc-900 dark:text-zinc-100">
+              {hero.tagline}
+            </p>
+
+            <p className="mt-4 max-w-2xl text-ds-body-lg text-zinc-700 dark:text-zinc-300">
+              {hero.description}
+            </p>
+
+            <LibraryDownloadsMicro
+              animateIncreaseTrend
+              library={library}
+              className="mt-5"
+              label="weekly downloads"
+              period="weekly"
+              showTotals
+            />
+
+            <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <PrimaryLink
+                to="/$libraryId/$version/docs"
+                params={{ libraryId: library.id, version: resolvedVersion }}
+                label="Read the docs"
+                icon={<BookOpen size={16} aria-hidden="true" />}
+              />
+              <LandingCopyPromptButton
+                prompt={hero.prompt}
+                label={hero.promptLabel}
+              />
+            </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+              {hero.proof.map((proof) => (
+                <ProofPill key={proof.label} accent={accent} {...proof} />
+              ))}
+            </div>
+
+            {hero.belowProof}
+          </div>
+
+          {hero.panel}
+        </div>
+      </section>
+
+      {/* Why <library> */}
+      <section className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mx-auto grid w-full min-w-0 max-w-full gap-10 px-8 py-16 sm:px-10 lg:max-w-[80rem] lg:grid-cols-[0.74fr_1.26fr] xl:max-w-[92rem]">
+          <div>
+            <SectionKicker accent={accent} {...why.kicker} />
+            <h2 className="mt-3 max-w-xl text-ds-heading-1">{why.heading}</h2>
+            <p className="mt-4 max-w-xl text-ds-body-lg text-zinc-700 dark:text-zinc-300">
+              {why.intro}
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {why.features.map((feature) => (
+              <FeatureCard key={feature.title} accent={accent} {...feature} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Split feature sections */}
+      {sections.map((section, index) => (
+        <SplitSection
+          key={section.heading}
+          accent={accent}
+          section={section}
+          alt={index % 2 === 0}
+        />
+      ))}
+
+      {interlude}
+
+      {/* Testimonials */}
+      {testimonials ? (
+        <section className="border-b border-zinc-200 bg-zinc-50 py-16 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className={SHELL}>
+            <div className="max-w-3xl">
+              <SectionKicker accent={accent} {...testimonials.kicker} />
+              <h2 className="mt-3 text-ds-heading-1">{testimonials.heading}</h2>
+              <p className="mt-4 text-ds-body-lg text-zinc-700 dark:text-zinc-300">
+                {testimonials.body}
+              </p>
+            </div>
+          </div>
+          <div className="mt-8">
+            <LibraryTestimonials testimonials={testimonials.items} />
+          </div>
+        </section>
+      ) : null}
+
+      {/* Open source ecosystem */}
+      <section className="bg-white py-16 dark:bg-zinc-950">
+        <div className={SHELL}>
+          <div className="max-w-3xl">
+            <SectionKicker
+              accent={accent}
+              icon={
+                ecosystem.kicker?.icon ?? <GithubIcon className="h-4 w-4" />
+              }
+              text={ecosystem.kicker?.text ?? 'Open source ecosystem'}
+            />
+            <h2 className="mt-3 text-ds-heading-1">{ecosystem.heading}</h2>
+            <p className="mt-4 text-ds-body-lg text-zinc-700 dark:text-zinc-300">
+              {ecosystem.body}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-10 flex flex-col gap-14">
+          <LandingCommunitySection libraryId={libraryId} />
+          {ecosystem.extra}
+          <SponsorSection
+            title="GitHub Sponsors"
+            aspectRatio="1/1"
+            packMaxWidth="900px"
+            showCTA
+          />
+        </div>
+      </section>
+
+      <LandingPageGad />
+      <BottomCTA
+        linkProps={{
+          to: '/$libraryId/$version/docs',
+          params: { libraryId: library.id, version: resolvedVersion },
+        }}
+        label="Get started"
+        className={accent.cta}
+      />
+      <Footer />
+    </div>
+  )
+}
+
+function SplitSection({
+  accent,
+  alt,
+  section,
+}: {
+  accent: LandingAccent
+  alt: boolean
+  section: LibrarySplitSection
+}) {
+  const panelLeft = section.side === 'left'
+  const cols = panelLeft
+    ? 'lg:grid-cols-[1.08fr_0.92fr]'
+    : 'lg:grid-cols-[0.82fr_1.18fr]'
+  const text = (
+    <div className="max-w-xl">
+      <SectionKicker accent={accent} {...section.kicker} />
+      <h2 className="mt-3 text-ds-heading-1">{section.heading}</h2>
+      <p className="mt-4 text-ds-body-lg text-zinc-700 dark:text-zinc-300">
+        {section.body}
+      </p>
+      {section.belowBody}
+    </div>
+  )
+
+  return (
+    <section
+      className={`border-b border-zinc-200 dark:border-zinc-800 ${
+        alt ? 'bg-white dark:bg-zinc-950' : 'bg-zinc-50 dark:bg-zinc-900'
+      }`}
+    >
+      <div className={`${GRID} ${cols} lg:items-center`}>
+        {panelLeft ? (
+          <>
+            {section.panel}
+            {text}
+          </>
+        ) : (
+          <>
+            {text}
+            {section.panel}
+          </>
+        )}
+      </div>
+    </section>
+  )
+}
+
+// Thin adapter over the DS <Eyebrow>: maps the template's {icon, text} + brand
+// accent onto the shared component so every library page renders the same
+// on-system eyebrow. Brand color rides in via className until the color pass
+// moves accents onto DS tokens.
+function SectionKicker({
+  accent,
+  icon,
+  text,
+}: {
+  accent: LandingAccent
+  icon: React.ReactNode
+  text: React.ReactNode
+}) {
+  return (
+    <Eyebrow icon={icon} className={accent.kicker}>
+      {text}
+    </Eyebrow>
+  )
+}
+
+function FeatureCard({
+  accent,
+  body,
+  icon,
+  title,
+}: LibraryFeature & { accent: LandingAccent }) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
+      <span
+        className={`flex h-9 w-9 items-center justify-center rounded-lg ${accent.chip}`}
+      >
+        {icon}
+      </span>
+      <h3 className="mt-4 text-ds-heading-4">{title}</h3>
+      <p className="mt-3 text-ds-body-sm text-zinc-700 dark:text-zinc-300">
+        {body}
+      </p>
+    </div>
+  )
+}
+
+function ProofPill({
+  accent,
+  label,
+  value,
+}: {
+  accent: LandingAccent
+  label: string
+  value: string
+}) {
+  return (
+    <div className={`border-l-2 pl-3 ${accent.pill}`}>
+      <p className="text-ds-label-md text-zinc-950 dark:text-white">{label}</p>
+      <p className="mt-1 text-ds-body-sm text-zinc-600 dark:text-zinc-400">
+        {value}
+      </p>
+    </div>
+  )
+}
+
+function PrimaryLink({
+  icon,
+  label,
+  params,
+  to,
+}: {
+  icon: React.ReactNode
+  label: string
+  params: Record<string, string>
+  to: string
+}) {
+  return (
+    <Link
+      to={to}
+      params={params}
+      className="inline-flex w-full max-w-full items-center justify-center gap-2 rounded-lg border border-zinc-950 bg-zinc-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200 sm:w-auto"
+    >
+      {icon}
+      {label}
+      <ArrowRight size={15} aria-hidden="true" />
+    </Link>
+  )
+}

--- a/src/components/landing/QueryLanding.tsx
+++ b/src/components/landing/QueryLanding.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
-import { Link, useParams } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   Pulse,
-  ArrowRight,
-  BookOpen,
   Database,
   Eye,
   Flame,
@@ -17,45 +14,160 @@ import {
   Sparkle,
 } from '@phosphor-icons/react'
 
-import { BottomCTA } from '~/components/BottomCTA'
-import { Footer } from '~/components/Footer'
-import { GithubIcon } from '~/components/icons/GithubIcon'
-import { LandingCommunitySection } from '~/components/LandingCommunitySection'
-import { SponsorSection } from '~/components/SponsorSection'
-import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
-import { LibraryTestimonials } from '~/components/LibraryTestimonials'
-import { LibraryWordmark } from '~/components/LibraryWordmark'
-import LandingPageGad from '~/components/LandingPageGad'
 import { QueryGGBanner } from '~/components/QueryGGBanner'
-import { getLibrary } from '~/libraries'
-import { queryProject } from '~/libraries/query'
+import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
 import { LandingCodeExampleCard } from '~/components/landing/LandingCodeExampleCard'
 import { queryCodeExample } from '~/components/landing/codeExamples'
+import {
+  LibraryLanding,
+  type LandingAccent,
+  type LibraryLandingConfig,
+} from '~/components/landing/LibraryLanding'
+import { queryProject } from '~/libraries/query'
 import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 
-import { LandingEcosystemProof } from '~/components/landing/LandingEcosystemProof'
-import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
-const library = getLibrary('query')
+const queryAccent: LandingAccent = {
+  kicker: 'text-red-700 dark:text-red-300',
+  chip: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200',
+  pill: 'border-red-500',
+  cta: 'border-red-500 bg-red-500 text-white hover:bg-red-600',
+}
+
 const queryAgentPrompt = [
   'Build a TanStack Query server-state layer for a TypeScript app.',
   'Use query keys that model the product domain, colocated query functions, mutations with optimistic updates where useful, and targeted invalidation after writes.',
   'Include loading, error, empty, background-refetch, and stale data states. Prefer framework adapters from TanStack Query and avoid storing server data in global client state.',
 ].join(' ')
 
-const heroProof = [
-  {
-    label: 'Server-state cache',
-    value: 'freshness, retries, gc, dedupe',
-  },
-  {
-    label: 'Mutation workflow',
-    value: 'optimistic UI, rollback, invalidate',
-  },
-  {
-    label: 'Framework adapters',
-    value: 'React, Vue, Solid, Svelte, Angular, Lit',
-  },
+const frameworkAdapters = [
+  'React',
+  'Vue',
+  'Solid',
+  'Svelte',
+  'Angular',
+  'Preact',
+  'Lit',
 ]
+
+export default function QueryLanding() {
+  const config: LibraryLandingConfig = {
+    libraryId: 'query',
+    accent: queryAccent,
+    hero: {
+      kicker: { icon: <Database size={14} />, text: 'Server-state manager' },
+      tagline: 'Stop syncing server data by hand.',
+      description:
+        'Query gives async data a cache, a lifecycle, and a set of declarative APIs for fetching, sharing, refetching, mutating, and observing server state across TypeScript applications.',
+      prompt: queryAgentPrompt,
+      promptLabel: 'Copy Query Prompt',
+      proof: [
+        {
+          label: 'Server-state cache',
+          value: 'freshness, retries, gc, dedupe',
+        },
+        {
+          label: 'Mutation workflow',
+          value: 'optimistic UI, rollback, invalidate',
+        },
+        {
+          label: 'Framework adapters',
+          value: 'React, Vue, Solid, Svelte, Angular, Lit',
+        },
+      ],
+      panel: <QueryCachePanel />,
+      belowProof: <LandingEcosystemProof />,
+    },
+    why: {
+      kicker: { icon: <Pulse size={14} />, text: 'Why Query' },
+      heading: 'Server state is not the same problem as client state.',
+      intro:
+        'Server data is remote, shared, cached, refetched, invalidated, and sometimes stale on purpose. Query handles that lifecycle directly instead of making you recreate it with reducers, effects, and synchronized stores.',
+      features: [
+        {
+          title: 'Important defaults do the boring work.',
+          body: 'Caching, request dedupe, retries, background refetching, window-focus updates, and garbage collection are already wired for the shape of real apps.',
+          icon: <Sparkle size={18} />,
+        },
+        {
+          title: 'Query keys become the cache contract.',
+          body: 'Keys describe the resource, inputs, filters, and scope so reads, writes, invalidation, prefetching, and devtools all speak the same language.',
+          icon: <GitBranch size={18} />,
+        },
+        {
+          title: 'Mutations have a real lifecycle.',
+          body: 'Handle pending UI, optimistic writes, invalidation, rollback, and follow-up refetches without inventing an ad hoc client-state machine.',
+          icon: <ArrowsCounterClockwise size={18} />,
+        },
+        {
+          title: 'Devtools make the cache visible.',
+          body: 'See query keys, observers, freshness, retries, errors, mutations, and cache contents while the app is actually running.',
+          icon: <Eye size={18} />,
+        },
+      ],
+    },
+    sections: [
+      {
+        kicker: {
+          icon: <ArrowCounterClockwise size={14} />,
+          text: 'Cache lifecycle',
+        },
+        heading: 'Keep data useful while the network catches up.',
+        body: 'Query lets stale data remain valuable. Screens can render instantly from cache, refetch in the background, keep previous results during pagination, and recover when the user comes back online.',
+        panel: <CacheLifecyclePanel />,
+        side: 'left',
+      },
+      {
+        kicker: { icon: <Network size={14} />, text: 'Mutations' },
+        heading: 'Writes update the world, then the cache.',
+        body: 'Query keeps mutation work explicit: optimistic updates, pending states, error recovery, invalidation, and background reconciliation are first-class instead of scattered through components.',
+        panel: <MutationPanel />,
+      },
+      {
+        kicker: {
+          icon: <InfinityIcon size={14} />,
+          text: 'Framework adapters',
+        },
+        heading: 'One server-state model, every UI runtime.',
+        body: 'The core cache model travels across frameworks. Teams can keep the same query keys, invalidation strategy, mutation semantics, and mental model whether the UI is React, Vue, Solid, Svelte, Angular, Preact, or Lit.',
+        belowBody: (
+          <div className="mt-5 flex flex-wrap gap-2">
+            {frameworkAdapters.map((framework) => (
+              <span
+                key={framework}
+                className="rounded-md border border-zinc-200 bg-zinc-100 px-3 py-1.5 text-sm font-bold text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300"
+              >
+                {framework}
+              </span>
+            ))}
+          </div>
+        ),
+        panel: (
+          <div className="min-w-0 max-w-full overflow-hidden">
+            <LandingCodeExampleCard example={queryCodeExample} />
+          </div>
+        ),
+      },
+    ],
+    testimonials: {
+      kicker: { icon: <Flame size={14} />, text: 'Field notes' },
+      heading: 'Query is the default answer for async server state.',
+      body: 'Query saves code by deleting whole categories of hand-written fetching, loading, retry, cache, and mutation logic.',
+      items: queryProject.testimonials,
+    },
+    ecosystem: {
+      heading:
+        'Maintainers, education, sponsors, and partners keep Query moving.',
+      body: 'Query is built in public and taught in public. The maintainers, partner integrations, Query.gg, and GitHub sponsors all stay close to the product story.',
+      extra: (
+        <div className="mx-auto w-full max-w-[80rem] px-4 xl:max-w-[92rem]">
+          <QueryGGBanner />
+        </div>
+      ),
+    },
+  }
+
+  return <LibraryLanding config={config} />
+}
 
 type QueryHeroIssue = {
   id: string
@@ -127,29 +239,6 @@ const lifecycleSteps = [
   },
 ]
 
-const featureCards = [
-  {
-    title: 'Important defaults do the boring work.',
-    body: 'Caching, request dedupe, retries, background refetching, window-focus updates, and garbage collection are already wired for the shape of real apps.',
-    icon: <Sparkle size={18} />,
-  },
-  {
-    title: 'Query keys become the cache contract.',
-    body: 'Keys describe the resource, inputs, filters, and scope so reads, writes, invalidation, prefetching, and devtools all speak the same language.',
-    icon: <GitBranch size={18} />,
-  },
-  {
-    title: 'Mutations have a real lifecycle.',
-    body: 'Handle pending UI, optimistic writes, invalidation, rollback, and follow-up refetches without inventing an ad hoc client-state machine.',
-    icon: <ArrowsCounterClockwise size={18} />,
-  },
-  {
-    title: 'Devtools make the cache visible.',
-    body: 'See query keys, observers, freshness, retries, errors, mutations, and cache contents while the app is actually running.',
-    icon: <Eye size={18} />,
-  },
-]
-
 const mutationSteps = [
   {
     label: 'optimistic write',
@@ -168,247 +257,6 @@ const mutationSteps = [
     code: 'onError: restoreSnapshot',
   },
 ]
-
-const frameworkAdapters = [
-  'React',
-  'Vue',
-  'Solid',
-  'Svelte',
-  'Angular',
-  'Preact',
-  'Lit',
-]
-
-export default function QueryLanding() {
-  const { version } = useParams({ strict: false })
-  const resolvedVersion = version ?? library.latestVersion
-
-  return (
-    <div className="w-full min-w-0 overflow-x-hidden bg-[#fff8f3] text-zinc-950 dark:bg-zinc-950 dark:text-white">
-      <section className="max-w-full overflow-hidden border-b border-red-950/10 bg-[#fff3ec] dark:border-red-300/10 dark:bg-[#130806]">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-10 lg:max-w-[80rem] lg:grid-cols-[0.86fr_1.14fr] lg:items-start lg:py-12 xl:max-w-[92rem]">
-          <div className="min-w-0 max-w-full sm:max-w-3xl">
-            <SectionKicker icon={<Database size={14} />}>
-              Server-state manager
-            </SectionKicker>
-
-            <h1 className="mt-4 text-5xl font-black leading-[0.95] sm:text-6xl lg:text-7xl">
-              <LibraryWordmark library={library} />
-            </h1>
-
-            <p className="mt-5 max-w-2xl text-lg font-bold leading-8 text-zinc-900 dark:text-zinc-100 sm:text-xl">
-              Stop syncing server data by hand.
-            </p>
-
-            <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-700 dark:text-zinc-300 sm:text-lg">
-              Query gives async data a cache, a lifecycle, and a set of
-              declarative APIs for fetching, sharing, refetching, mutating, and
-              observing server state across TypeScript applications.
-            </p>
-
-            <LibraryDownloadsMicro
-              animateIncreaseTrend
-              library={library}
-              className="mt-5"
-              label="weekly downloads"
-              period="weekly"
-              showTotals
-            />
-
-            <p className="mt-4 max-w-xl border-l-2 border-red-500 pl-3 text-sm font-black text-red-800 dark:text-red-200">
-              The server-state standard for modern frontend apps.
-            </p>
-
-            <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-              <QueryLink
-                to="/$libraryId/$version/docs"
-                params={{ libraryId: library.id, version: resolvedVersion }}
-                label="Read the docs"
-                icon={<BookOpen size={16} aria-hidden="true" />}
-              />
-              <LandingCopyPromptButton
-                prompt={queryAgentPrompt}
-                label="Copy Query Prompt"
-              />
-            </div>
-
-            <div className="mt-8 grid gap-3 sm:grid-cols-3">
-              {heroProof.map((proof) => (
-                <ProofPill key={proof.label} {...proof} />
-              ))}
-            </div>
-            <LandingEcosystemProof />
-          </div>
-
-          <QueryCachePanel />
-        </div>
-      </section>
-
-      <section className="border-b border-red-950/10 bg-[#fff7ed] dark:border-red-300/10 dark:bg-[#170b07]">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[0.74fr_1.26fr] xl:max-w-[92rem]">
-          <div>
-            <SectionKicker icon={<Pulse size={14} />}>Why Query</SectionKicker>
-            <h2 className="mt-3 max-w-xl text-3xl font-black leading-tight sm:text-4xl">
-              Server state is not the same problem as client state.
-            </h2>
-            <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Server data is remote, shared, cached, refetched, invalidated, and
-              sometimes stale on purpose. Query handles that lifecycle directly
-              instead of making you recreate it with reducers, effects, and
-              synchronized stores.
-            </p>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {featureCards.map((feature) => (
-              <FeatureCard key={feature.title} {...feature} />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[1.08fr_0.92fr] lg:items-center xl:max-w-[92rem]">
-          <CacheLifecyclePanel />
-          <div>
-            <SectionKicker icon={<ArrowCounterClockwise size={14} />}>
-              Cache lifecycle
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Keep data useful while the network catches up.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Query lets stale data remain valuable. Screens can render
-              instantly from cache, refetch in the background, keep previous
-              results during pagination, and recover when the user comes back
-              online.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-[#fbfaf6] dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[0.82fr_1.18fr] lg:items-start xl:max-w-[92rem]">
-          <div>
-            <SectionKicker icon={<Network size={14} />}>
-              Mutations
-            </SectionKicker>
-            <h2 className="mt-3 max-w-xl text-3xl font-black leading-tight sm:text-4xl">
-              Writes update the world, then the cache.
-            </h2>
-            <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Query keeps mutation work explicit: optimistic updates, pending
-              states, error recovery, invalidation, and background
-              reconciliation are first-class instead of scattered through
-              components.
-            </p>
-          </div>
-
-          <MutationPanel />
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[0.72fr_1.28fr] lg:items-start xl:max-w-[92rem]">
-          <div className="max-w-xl">
-            <SectionKicker icon={<InfinityIcon size={14} />}>
-              Framework adapters
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              One server-state model, every UI runtime.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              The core cache model travels across frameworks. Teams can keep the
-              same query keys, invalidation strategy, mutation semantics, and
-              mental model whether the UI is React, Vue, Solid, Svelte, Angular,
-              Preact, or Lit.
-            </p>
-            <div className="mt-5 flex flex-wrap gap-2">
-              {frameworkAdapters.map((framework) => (
-                <span
-                  key={framework}
-                  className="rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-bold text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200"
-                >
-                  {framework}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <div className="min-w-0 max-w-full overflow-hidden">
-            <LandingCodeExampleCard example={queryCodeExample} />
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-[#fff8f3] py-12 dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="mx-auto w-full max-w-[80rem] px-4 xl:max-w-[92rem]">
-          <div className="max-w-3xl">
-            <SectionKicker icon={<Flame size={14} />}>
-              Field notes
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Query is the default answer for async server state.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              The original copy was right: Query saves code by deleting whole
-              categories of hand-written fetching, loading, retry, cache, and
-              mutation logic.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-8">
-          <LibraryTestimonials testimonials={queryProject.testimonials} />
-        </div>
-      </section>
-
-      <section className="bg-white py-12 dark:bg-zinc-950">
-        <div className="mx-auto w-full max-w-[80rem] px-4 xl:max-w-[92rem]">
-          <div className="max-w-3xl">
-            <SectionKicker icon={<GithubIcon className="h-4 w-4" />}>
-              Open source ecosystem
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Maintainers, education, sponsors, and partners keep Query moving.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Query is built in public and taught in public. The maintainers,
-              partner integrations, Query.gg, and GitHub sponsors all stay close
-              to the product story.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-10 flex flex-col gap-14">
-          <LandingCommunitySection libraryId="query" />
-
-          <div className="mx-auto w-full max-w-[80rem] px-4 xl:max-w-[92rem]">
-            <QueryGGBanner />
-          </div>
-
-          <SponsorSection
-            title="GitHub Sponsors"
-            aspectRatio="1/1"
-            packMaxWidth="900px"
-            showCTA
-          />
-        </div>
-      </section>
-
-      <LandingPageGad />
-      <BottomCTA
-        linkProps={{
-          to: '/$libraryId/$version/docs',
-          params: { libraryId: library.id, version: resolvedVersion },
-        }}
-        label="Get Started!"
-        className="border-red-500 bg-red-500 text-white hover:bg-red-600"
-      />
-      <Footer />
-    </div>
-  )
-}
 
 function QueryCachePanel() {
   const prefersReducedMotion = usePrefersReducedMotion()
@@ -718,79 +566,5 @@ function MutationPanel() {
         and the cache knows exactly what changed.
       </div>
     </div>
-  )
-}
-
-function FeatureCard({
-  body,
-  icon,
-  title,
-}: {
-  body: string
-  icon: React.ReactNode
-  title: string
-}) {
-  return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
-      <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200">
-        {icon}
-      </span>
-      <h3 className="mt-4 text-xl font-black leading-tight">{title}</h3>
-      <p className="mt-3 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
-        {body}
-      </p>
-    </div>
-  )
-}
-
-function SectionKicker({
-  children,
-  icon,
-}: {
-  children: React.ReactNode
-  icon: React.ReactNode
-}) {
-  return (
-    <p className="inline-flex items-center gap-2 text-sm font-black uppercase text-red-700 dark:text-red-300">
-      {icon}
-      {children}
-    </p>
-  )
-}
-
-function ProofPill({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="border-l-2 border-red-500 pl-3">
-      <p className="text-sm font-black text-zinc-950 dark:text-white">
-        {label}
-      </p>
-      <p className="mt-1 text-sm leading-5 text-zinc-600 dark:text-zinc-400">
-        {value}
-      </p>
-    </div>
-  )
-}
-
-function QueryLink({
-  icon,
-  label,
-  params,
-  to,
-}: {
-  icon: React.ReactNode
-  label: string
-  params: Record<string, string>
-  to: string
-}) {
-  return (
-    <Link
-      to={to}
-      params={params}
-      className="inline-flex w-full max-w-full items-center justify-center gap-2 rounded-lg border border-zinc-950 bg-zinc-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200 sm:w-auto"
-    >
-      {icon}
-      {label}
-      <ArrowRight size={15} aria-hidden="true" />
-    </Link>
   )
 }

--- a/src/components/landing/RangerLanding.tsx
+++ b/src/components/landing/RangerLanding.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
-import { Link, useParams } from '@tanstack/react-router'
+import { useParams } from '@tanstack/react-router'
 import {
-  ArrowRight,
-  BookOpen,
   Gauge,
   GitBranch,
   ArrowsHorizontal,
@@ -11,63 +9,21 @@ import {
   Sparkle,
 } from '@phosphor-icons/react'
 
-import { BottomCTA } from '~/components/BottomCTA'
-import { Footer } from '~/components/Footer'
-import { GithubIcon } from '~/components/icons/GithubIcon'
-import LandingPageGad from '~/components/LandingPageGad'
-import { LandingCommunitySection } from '~/components/LandingCommunitySection'
-import { SponsorSection } from '~/components/SponsorSection'
-import { LibraryDownloadsMicro } from '~/components/LibraryDownloadsMicro'
-import { LibraryWordmark } from '~/components/LibraryWordmark'
 import { StackBlitzSection } from '~/components/StackBlitzSection'
 import { getBranch, getLibrary } from '~/libraries'
 import { rangerProject } from '~/libraries/ranger'
+import {
+  LibraryLanding,
+  type LibraryLandingConfig,
+} from '~/components/landing/LibraryLanding'
 
-import { LandingCopyPromptButton } from '~/components/landing/LandingCopyPromptButton'
 const library = getLibrary('ranger')
+
 const rangerAgentPrompt = [
   'Build a custom range or multi-range slider with TanStack Ranger.',
   'Keep the slider headless: own the markup, track, ticks, labels, thumbs, formatting, and accessibility while using Ranger for range math and thumb interaction state.',
   'Show min/max, steps, multiple thumbs, constrained movement, and product-specific styling.',
 ].join(' ')
-
-const heroProof = [
-  {
-    label: 'Headless track',
-    value: 'bring your own UI and semantics',
-  },
-  {
-    label: 'Multi-thumb',
-    value: 'ranges, bounds, steps, constraints',
-  },
-  {
-    label: 'React hooks',
-    value: 'range math without a slider skin',
-  },
-]
-
-const featureCards = [
-  {
-    title: 'The slider is yours.',
-    body: 'Ranger gives interaction state and range math without rendering the track, thumbs, labels, or layout for you.',
-    icon: <SlidersHorizontal size={18} />,
-  },
-  {
-    title: 'Multi-range without bespoke math.',
-    body: 'Build price filters, timelines, editors, split ranges, or multi-thumb controls with bounds and steps handled predictably.',
-    icon: <ArrowsHorizontal size={18} />,
-  },
-  {
-    title: 'Ticks and labels can be product-specific.',
-    body: 'Display percentages, dates, currency, logarithmic labels, marks, or custom annotations from the same headless primitives.',
-    icon: <Ruler size={18} />,
-  },
-  {
-    title: 'Small utility, high inversion of control.',
-    body: 'Ranger is useful precisely because it does not become your design system. It stays under the component you actually need.',
-    icon: <Gauge size={18} />,
-  },
-]
 
 const rangeSteps = [
   {
@@ -93,168 +49,77 @@ export default function RangerLanding() {
   const resolvedVersion = version ?? library.latestVersion
   const branch = getBranch(rangerProject, resolvedVersion)
 
-  return (
-    <div className="w-full min-w-0 overflow-x-hidden bg-zinc-100 text-zinc-950 dark:bg-zinc-950 dark:text-white">
-      <section className="max-w-full overflow-hidden border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-10 lg:max-w-[80rem] lg:grid-cols-[0.84fr_1.16fr] lg:items-start lg:py-12 xl:max-w-[92rem]">
-          <div className="min-w-0 max-w-full sm:max-w-3xl">
-            <SectionKicker icon={<ArrowsHorizontal size={14} />}>
-              Headless range controls
-            </SectionKicker>
-
-            <h1 className="mt-4 text-5xl font-black leading-[0.95] sm:text-6xl lg:text-7xl">
-              <LibraryWordmark library={library} />
-            </h1>
-
-            <p className="mt-5 max-w-2xl text-lg font-bold leading-8 text-zinc-900 dark:text-zinc-100 sm:text-xl">
-              Build the slider your product actually needs.
-            </p>
-
-            <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-700 dark:text-zinc-300 sm:text-lg">
-              Ranger provides headless primitives for range and multi-range
-              sliders, leaving the track, thumbs, labels, ticks, and product UI
-              completely under your control.
-            </p>
-
-            <LibraryDownloadsMicro
-              animateIncreaseTrend
-              library={library}
-              className="mt-5"
-              label="weekly downloads"
-              period="weekly"
-              showTotals
-            />
-
-            <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-              <RangerLink
-                to="/$libraryId/$version/docs"
-                params={{ libraryId: library.id, version: resolvedVersion }}
-                label="Read the docs"
-                icon={<BookOpen size={16} aria-hidden="true" />}
-              />
-              <LandingCopyPromptButton
-                prompt={rangerAgentPrompt}
-                label="Copy Ranger Prompt"
-              />
-            </div>
-
-            <div className="mt-8 grid gap-3 sm:grid-cols-3">
-              {heroProof.map((proof) => (
-                <ProofPill key={proof.label} {...proof} />
-              ))}
-            </div>
-          </div>
-
-          <RangerLabPanel />
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[0.74fr_1.26fr] xl:max-w-[92rem]">
-          <div>
-            <SectionKicker icon={<Sparkle size={14} />}>
-              Why Ranger
-            </SectionKicker>
-            <h2 className="mt-3 max-w-xl text-3xl font-black leading-tight sm:text-4xl">
-              Range controls are small until the product gets specific.
-            </h2>
-            <p className="mt-4 max-w-xl text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Once a slider needs multiple thumbs, custom labels, controlled
-              values, meaningful ticks, and a design system skin, a prebuilt UI
-              becomes the wrong abstraction. Ranger keeps the hard math below
-              your component.
-            </p>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {featureCards.map((feature) => (
-              <FeatureCard key={feature.title} {...feature} />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[1.05fr_0.95fr] lg:items-center xl:max-w-[92rem]">
-          <StepPanel />
-          <div>
-            <SectionKicker icon={<GitBranch size={14} />}>
-              Slider lifecycle
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Values in, product-specific control out.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Ranger helps translate values into interactive geometry. Your app
-              decides what those values mean and how the user should see them.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="mx-auto grid w-full min-w-0 max-w-full gap-8 px-4 py-12 lg:max-w-[80rem] lg:grid-cols-[0.72fr_1.28fr] lg:items-start xl:max-w-[92rem]">
-          <div className="max-w-xl">
-            <SectionKicker icon={<SlidersHorizontal size={14} />}>
-              Example
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Take the range math for a spin.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              The example stays simple on purpose: hooks provide the behavior,
-              and the component owns the rendered slider.
-            </p>
-          </div>
-        </div>
-      </section>
-
+  const config: LibraryLandingConfig = {
+    libraryId: 'ranger',
+    hero: {
+      kicker: {
+        icon: <ArrowsHorizontal size={14} />,
+        text: 'Headless range controls',
+      },
+      tagline: 'Build the slider your product actually needs.',
+      description:
+        'Ranger provides headless primitives for range and multi-range sliders, leaving the track, thumbs, labels, ticks, and product UI completely under your control.',
+      prompt: rangerAgentPrompt,
+      promptLabel: 'Copy Ranger Prompt',
+      proof: [
+        { label: 'Headless track', value: 'bring your own UI and semantics' },
+        { label: 'Multi-thumb', value: 'ranges, bounds, steps, constraints' },
+        { label: 'React hooks', value: 'range math without a slider skin' },
+      ],
+      panel: <RangerLabPanel />,
+    },
+    why: {
+      kicker: { icon: <Sparkle size={14} />, text: 'Why Ranger' },
+      heading: 'Range controls are small until the product gets specific.',
+      intro:
+        'Once a slider needs multiple thumbs, custom labels, controlled values, meaningful ticks, and a design system skin, a prebuilt UI becomes the wrong abstraction. Ranger keeps the hard math below your component.',
+      features: [
+        {
+          title: 'The slider is yours.',
+          body: 'Ranger gives interaction state and range math without rendering the track, thumbs, labels, or layout for you.',
+          icon: <SlidersHorizontal size={18} />,
+        },
+        {
+          title: 'Multi-range without bespoke math.',
+          body: 'Build price filters, timelines, editors, split ranges, or multi-thumb controls with bounds and steps handled predictably.',
+          icon: <ArrowsHorizontal size={18} />,
+        },
+        {
+          title: 'Ticks and labels can be product-specific.',
+          body: 'Display percentages, dates, currency, logarithmic labels, marks, or custom annotations from the same headless primitives.',
+          icon: <Ruler size={18} />,
+        },
+        {
+          title: 'Small utility, high inversion of control.',
+          body: 'Ranger is useful precisely because it does not become your design system. It stays under the component you actually need.',
+          icon: <Gauge size={18} />,
+        },
+      ],
+    },
+    sections: [
+      {
+        kicker: { icon: <GitBranch size={14} />, text: 'Slider lifecycle' },
+        heading: 'Values in, product-specific control out.',
+        body: 'Ranger helps translate values into interactive geometry. Your app decides what those values mean and how the user should see them.',
+        panel: <StepPanel />,
+        side: 'left',
+      },
+    ],
+    interlude: (
       <StackBlitzSection
         project={rangerProject}
         branch={branch}
         examplePath="examples/${framework}/basic"
         title="tannerlinsley/react-ranger: basic"
       />
+    ),
+    ecosystem: {
+      heading: 'Ranger stays small so your component can be specific.',
+      body: 'Maintainers, examples, partners, and GitHub sponsors keep the headless range primitive useful without turning it into a UI kit.',
+    },
+  }
 
-      <section className="bg-white py-12 dark:bg-zinc-950">
-        <div className="mx-auto w-full max-w-[80rem] px-4 xl:max-w-[92rem]">
-          <div className="max-w-3xl">
-            <SectionKicker icon={<GithubIcon className="h-4 w-4" />}>
-              Open source ecosystem
-            </SectionKicker>
-            <h2 className="mt-3 text-3xl font-black leading-tight sm:text-4xl">
-              Ranger stays small so your component can be specific.
-            </h2>
-            <p className="mt-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
-              Maintainers, examples, partners, and GitHub sponsors keep the
-              headless range primitive useful without turning it into a UI kit.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-10 flex flex-col gap-14">
-          <LandingCommunitySection libraryId="ranger" />
-          <SponsorSection
-            title="GitHub Sponsors"
-            aspectRatio="1/1"
-            packMaxWidth="900px"
-            showCTA
-          />
-        </div>
-      </section>
-
-      <LandingPageGad />
-      <BottomCTA
-        linkProps={{
-          to: '/$libraryId/$version/docs',
-          params: { libraryId: library.id, version: resolvedVersion },
-        }}
-        label="Get Started!"
-        className="border-zinc-950 bg-zinc-950 text-white hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200"
-      />
-      <Footer />
-    </div>
-  )
+  return <LibraryLanding config={config} />
 }
 
 function RangerLabPanel() {
@@ -373,79 +238,5 @@ function StepPanel() {
         </div>
       ))}
     </div>
-  )
-}
-
-function FeatureCard({
-  body,
-  icon,
-  title,
-}: {
-  body: string
-  icon: React.ReactNode
-  title: string
-}) {
-  return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
-      <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-zinc-950 text-white dark:bg-white dark:text-zinc-950">
-        {icon}
-      </span>
-      <h3 className="mt-4 text-xl font-black leading-tight">{title}</h3>
-      <p className="mt-3 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
-        {body}
-      </p>
-    </div>
-  )
-}
-
-function SectionKicker({
-  children,
-  icon,
-}: {
-  children: React.ReactNode
-  icon: React.ReactNode
-}) {
-  return (
-    <p className="inline-flex items-center gap-2 text-sm font-black uppercase text-zinc-700 dark:text-zinc-300">
-      {icon}
-      {children}
-    </p>
-  )
-}
-
-function ProofPill({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="border-l-2 border-zinc-950 pl-3 dark:border-white">
-      <p className="text-sm font-black text-zinc-950 dark:text-white">
-        {label}
-      </p>
-      <p className="mt-1 text-sm leading-5 text-zinc-600 dark:text-zinc-400">
-        {value}
-      </p>
-    </div>
-  )
-}
-
-function RangerLink({
-  icon,
-  label,
-  params,
-  to,
-}: {
-  icon: React.ReactNode
-  label: string
-  params: Record<string, string>
-  to: string
-}) {
-  return (
-    <Link
-      to={to}
-      params={params}
-      className="inline-flex w-full max-w-full items-center justify-center gap-2 rounded-lg border border-zinc-950 bg-zinc-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-zinc-800 dark:border-white dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200 sm:w-auto"
-    >
-      {icon}
-      {label}
-      <ArrowRight size={15} aria-hidden="true" />
-    </Link>
   )
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -70,9 +70,11 @@ import { Route as DsShadowsRouteImport } from './routes/ds.shadows'
 import { Route as DsSemanticRouteImport } from './routes/ds.semantic'
 import { Route as DsPaletteRouteImport } from './routes/ds.palette'
 import { Route as DsNavbarRouteImport } from './routes/ds.navbar'
+import { Route as DsLogosRouteImport } from './routes/ds.logos'
 import { Route as DsInputsRouteImport } from './routes/ds.inputs'
 import { Route as DsIconographyRouteImport } from './routes/ds.iconography'
 import { Route as DsIconMigrationRouteImport } from './routes/ds.icon-migration'
+import { Route as DsEyebrowRouteImport } from './routes/ds.eyebrow'
 import { Route as DsEffectsRouteImport } from './routes/ds.effects'
 import { Route as DsDropdownRouteImport } from './routes/ds.dropdown'
 import { Route as DsColorsRouteImport } from './routes/ds.colors'
@@ -487,6 +489,11 @@ const DsNavbarRoute = DsNavbarRouteImport.update({
   path: '/navbar',
   getParentRoute: () => DsRoute,
 } as any)
+const DsLogosRoute = DsLogosRouteImport.update({
+  id: '/logos',
+  path: '/logos',
+  getParentRoute: () => DsRoute,
+} as any)
 const DsInputsRoute = DsInputsRouteImport.update({
   id: '/inputs',
   path: '/inputs',
@@ -500,6 +507,11 @@ const DsIconographyRoute = DsIconographyRouteImport.update({
 const DsIconMigrationRoute = DsIconMigrationRouteImport.update({
   id: '/icon-migration',
   path: '/icon-migration',
+  getParentRoute: () => DsRoute,
+} as any)
+const DsEyebrowRoute = DsEyebrowRouteImport.update({
+  id: '/eyebrow',
+  path: '/eyebrow',
   getParentRoute: () => DsRoute,
 } as any)
 const DsEffectsRoute = DsEffectsRouteImport.update({
@@ -1154,9 +1166,11 @@ export interface FileRoutesByFullPath {
   '/ds/colors': typeof DsColorsRoute
   '/ds/dropdown': typeof DsDropdownRoute
   '/ds/effects': typeof DsEffectsRoute
+  '/ds/eyebrow': typeof DsEyebrowRoute
   '/ds/icon-migration': typeof DsIconMigrationRoute
   '/ds/iconography': typeof DsIconographyRoute
   '/ds/inputs': typeof DsInputsRoute
+  '/ds/logos': typeof DsLogosRoute
   '/ds/navbar': typeof DsNavbarRoute
   '/ds/palette': typeof DsPaletteRoute
   '/ds/semantic': typeof DsSemanticRoute
@@ -1320,9 +1334,11 @@ export interface FileRoutesByTo {
   '/ds/colors': typeof DsColorsRoute
   '/ds/dropdown': typeof DsDropdownRoute
   '/ds/effects': typeof DsEffectsRoute
+  '/ds/eyebrow': typeof DsEyebrowRoute
   '/ds/icon-migration': typeof DsIconMigrationRoute
   '/ds/iconography': typeof DsIconographyRoute
   '/ds/inputs': typeof DsInputsRoute
+  '/ds/logos': typeof DsLogosRoute
   '/ds/navbar': typeof DsNavbarRoute
   '/ds/palette': typeof DsPaletteRoute
   '/ds/semantic': typeof DsSemanticRoute
@@ -1493,9 +1509,11 @@ export interface FileRoutesById {
   '/ds/colors': typeof DsColorsRoute
   '/ds/dropdown': typeof DsDropdownRoute
   '/ds/effects': typeof DsEffectsRoute
+  '/ds/eyebrow': typeof DsEyebrowRoute
   '/ds/icon-migration': typeof DsIconMigrationRoute
   '/ds/iconography': typeof DsIconographyRoute
   '/ds/inputs': typeof DsInputsRoute
+  '/ds/logos': typeof DsLogosRoute
   '/ds/navbar': typeof DsNavbarRoute
   '/ds/palette': typeof DsPaletteRoute
   '/ds/semantic': typeof DsSemanticRoute
@@ -1669,9 +1687,11 @@ export interface FileRouteTypes {
     | '/ds/colors'
     | '/ds/dropdown'
     | '/ds/effects'
+    | '/ds/eyebrow'
     | '/ds/icon-migration'
     | '/ds/iconography'
     | '/ds/inputs'
+    | '/ds/logos'
     | '/ds/navbar'
     | '/ds/palette'
     | '/ds/semantic'
@@ -1835,9 +1855,11 @@ export interface FileRouteTypes {
     | '/ds/colors'
     | '/ds/dropdown'
     | '/ds/effects'
+    | '/ds/eyebrow'
     | '/ds/icon-migration'
     | '/ds/iconography'
     | '/ds/inputs'
+    | '/ds/logos'
     | '/ds/navbar'
     | '/ds/palette'
     | '/ds/semantic'
@@ -2007,9 +2029,11 @@ export interface FileRouteTypes {
     | '/ds/colors'
     | '/ds/dropdown'
     | '/ds/effects'
+    | '/ds/eyebrow'
     | '/ds/icon-migration'
     | '/ds/iconography'
     | '/ds/inputs'
+    | '/ds/logos'
     | '/ds/navbar'
     | '/ds/palette'
     | '/ds/semantic'
@@ -2631,6 +2655,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DsNavbarRouteImport
       parentRoute: typeof DsRoute
     }
+    '/ds/logos': {
+      id: '/ds/logos'
+      path: '/logos'
+      fullPath: '/ds/logos'
+      preLoaderRoute: typeof DsLogosRouteImport
+      parentRoute: typeof DsRoute
+    }
     '/ds/inputs': {
       id: '/ds/inputs'
       path: '/inputs'
@@ -2650,6 +2681,13 @@ declare module '@tanstack/react-router' {
       path: '/icon-migration'
       fullPath: '/ds/icon-migration'
       preLoaderRoute: typeof DsIconMigrationRouteImport
+      parentRoute: typeof DsRoute
+    }
+    '/ds/eyebrow': {
+      id: '/ds/eyebrow'
+      path: '/eyebrow'
+      fullPath: '/ds/eyebrow'
+      preLoaderRoute: typeof DsEyebrowRouteImport
       parentRoute: typeof DsRoute
     }
     '/ds/effects': {
@@ -3654,9 +3692,11 @@ interface DsRouteChildren {
   DsColorsRoute: typeof DsColorsRoute
   DsDropdownRoute: typeof DsDropdownRoute
   DsEffectsRoute: typeof DsEffectsRoute
+  DsEyebrowRoute: typeof DsEyebrowRoute
   DsIconMigrationRoute: typeof DsIconMigrationRoute
   DsIconographyRoute: typeof DsIconographyRoute
   DsInputsRoute: typeof DsInputsRoute
+  DsLogosRoute: typeof DsLogosRoute
   DsNavbarRoute: typeof DsNavbarRoute
   DsPaletteRoute: typeof DsPaletteRoute
   DsSemanticRoute: typeof DsSemanticRoute
@@ -3676,9 +3716,11 @@ const DsRouteChildren: DsRouteChildren = {
   DsColorsRoute: DsColorsRoute,
   DsDropdownRoute: DsDropdownRoute,
   DsEffectsRoute: DsEffectsRoute,
+  DsEyebrowRoute: DsEyebrowRoute,
   DsIconMigrationRoute: DsIconMigrationRoute,
   DsIconographyRoute: DsIconographyRoute,
   DsInputsRoute: DsInputsRoute,
+  DsLogosRoute: DsLogosRoute,
   DsNavbarRoute: DsNavbarRoute,
   DsPaletteRoute: DsPaletteRoute,
   DsSemanticRoute: DsSemanticRoute,

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -79,7 +79,10 @@ export function LibraryNavbarTitle({
 }) {
   const library = getLibrary(libraryId)
   const libraryName = library.name.replace('TanStack ', '')
-  const gradientText = `inline-block text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
+  // DS type role for the navbar wordmark: heading-4 (20px / 700) in the display
+  // font. `text-transparent` sets color only, so it coexists with the size/
+  // weight from `text-ds-heading-4` (no conflict) and keeps the gradient clip.
+  const gradientText = `inline-block font-ds-display text-ds-heading-4 text-transparent bg-clip-text bg-linear-to-r ${library.colorFrom} ${library.colorTo}`
 
   return (
     <Link

--- a/src/routes/ds.eyebrow.tsx
+++ b/src/routes/ds.eyebrow.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { Sparkle, GitBranch, Database } from '@phosphor-icons/react'
+import { seo } from '~/utils/seo'
+import { Eyebrow } from '~/components/ds/ui'
+import { ComponentPreview, DsPage, DsSection } from '~/components/ds/DsKit'
+import type { LibraryId } from '~/libraries/ids'
+
+// Libraries that ship a --color-lib-* brand token (the rest fall back to neutral).
+const BRAND_LIBRARIES: Array<LibraryId> = [
+  'start',
+  'router',
+  'query',
+  'table',
+  'db',
+  'ai',
+  'form',
+  'virtual',
+  'pacer',
+  'hotkeys',
+  'store',
+  'devtools',
+  'cli',
+  'intent',
+]
+
+function EyebrowPlayground() {
+  const [library, setLibrary] = React.useState<LibraryId>('query')
+  const [branded, setBranded] = React.useState(true)
+
+  return (
+    <div className="rounded-xl border border-border-default bg-background-surface p-6">
+      <div className="flex flex-wrap items-center gap-5">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={branded}
+            onChange={(e) => setBranded(e.target.checked)}
+            className="h-4 w-4 accent-ds-blue-400"
+          />
+          Branded by category
+        </label>
+        <label className="flex items-center gap-2 text-sm text-text-secondary">
+          Category
+          <select
+            value={library}
+            disabled={!branded}
+            onChange={(e) => setLibrary(e.target.value as LibraryId)}
+            className="rounded-lg border border-border-default bg-background-default px-3 py-1.5 text-sm text-text-primary transition disabled:opacity-40"
+          >
+            {BRAND_LIBRARIES.map((id) => (
+              <option key={id} value={id}>
+                {id[0].toUpperCase() + id.slice(1)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="mt-6 border-t border-border-subtle pt-6">
+        <Eyebrow
+          icon={<Sparkle size={14} />}
+          library={branded ? library : undefined}
+        >
+          {branded ? `${library} · section kicker` : 'section kicker'}
+        </Eyebrow>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/ds/eyebrow')({
+  component: EyebrowPage,
+  head: () => ({
+    meta: seo({
+      title: 'Eyebrow | TanStack Design System',
+      description:
+        'The Eyebrow component — the small uppercase kicker above a section heading.',
+    }),
+  }),
+})
+
+const TONES = ['secondary', 'muted', 'accent'] as const
+
+function EyebrowPage() {
+  return (
+    <DsPage
+      title="Eyebrow"
+      description="The small uppercase label that sits above a section heading. Locks in the DS mono-caps role (IBM Plex Mono · 12px · +1.5px tracking) and the inline icon layout, so every kicker across library pages stays on-system. Source: src/components/ds/ui/index.tsx."
+    >
+      <DsSection
+        title="Context"
+        description="Toggle branding and select the library/category the eyebrow is nested within. When branded, the eyebrow takes that library's --color-lib-* token; when off, it falls back to a neutral tone."
+      >
+        <EyebrowPlayground />
+      </DsSection>
+
+      <DsSection
+        title="Tones"
+        description="Neutral, accessible colors by default. Secondary is the standard choice."
+      >
+        <ComponentPreview
+          code={`<Eyebrow tone="secondary">Server-state manager</Eyebrow>
+<Eyebrow tone="muted">Server-state manager</Eyebrow>
+<Eyebrow tone="accent">Server-state manager</Eyebrow>`}
+        >
+          {TONES.map((tone) => (
+            <Eyebrow key={tone} tone={tone}>
+              Server-state manager
+            </Eyebrow>
+          ))}
+        </ComponentPreview>
+      </DsSection>
+
+      <DsSection
+        title="With icon"
+        description="An optional leading icon — use Phosphor icons at 14px."
+      >
+        <ComponentPreview
+          code={`<Eyebrow icon={<Sparkle size={14} />}>Why Query</Eyebrow>
+<Eyebrow icon={<GitBranch size={14} />}>Cache lifecycle</Eyebrow>`}
+        >
+          <Eyebrow icon={<Sparkle size={14} />}>Why Query</Eyebrow>
+          <Eyebrow icon={<GitBranch size={14} />}>Cache lifecycle</Eyebrow>
+        </ComponentPreview>
+      </DsSection>
+
+      <DsSection
+        title="Brand accent"
+        description="Library pages pass a brand color via className. The label-sm type role stays locked — only the color changes. (Pick a shade that clears text contrast; the lightest library brand tokens are not legible as small text on light surfaces.)"
+      >
+        <ComponentPreview
+          code={`<Eyebrow icon={<Database size={14} />} className="text-lib-cli">
+  Server-state manager
+</Eyebrow>`}
+        >
+          <Eyebrow icon={<Database size={14} />} className="text-lib-cli">
+            Server-state manager
+          </Eyebrow>
+        </ComponentPreview>
+      </DsSection>
+    </DsPage>
+  )
+}

--- a/src/routes/ds.logos.tsx
+++ b/src/routes/ds.logos.tsx
@@ -1,0 +1,129 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { DownloadSimple } from '@phosphor-icons/react'
+import { seo } from '~/utils/seo'
+import { DsPage, DsSection } from '~/components/ds/DsKit'
+
+export const Route = createFileRoute('/ds/logos')({
+  component: LogosPage,
+  head: () => ({
+    meta: seo({
+      title: 'Logos | TanStack Design System',
+      description:
+        'Download the TanStack logo lockups — stacked and landscape, in every brand color.',
+    }),
+  }),
+})
+
+type LogoTone = 'black' | 'charcoal' | 'cream' | 'white'
+
+interface LogoAsset {
+  tone: LogoTone
+  file: string
+  // Light marks (cream/white) need a dark backdrop to stay visible.
+  onDark: boolean
+}
+
+const TONE_LABEL: Record<LogoTone, string> = {
+  black: 'Black',
+  charcoal: 'Charcoal',
+  cream: 'Cream',
+  white: 'White',
+}
+
+const STACKED: Array<LogoAsset> = [
+  { tone: 'black', file: 'tanstack-stacked-black.svg', onDark: false },
+  { tone: 'charcoal', file: 'tanstack-stacked-charcoal.svg', onDark: false },
+  { tone: 'cream', file: 'tanstack-stacked-cream.svg', onDark: true },
+  { tone: 'white', file: 'tanstack-stacked-white.svg', onDark: true },
+]
+
+const LANDSCAPE: Array<LogoAsset> = [
+  { tone: 'black', file: 'tanstack-landscape-black.svg', onDark: false },
+  { tone: 'charcoal', file: 'tanstack-landscape-charcoal.svg', onDark: false },
+  { tone: 'white', file: 'tanstack-landscape-white.svg', onDark: true },
+]
+
+function LogoCard({
+  asset,
+  lockup,
+  imgClass,
+}: {
+  asset: LogoAsset
+  lockup: string
+  imgClass: string
+}) {
+  const src = `/images/brand/${asset.file}`
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border-default bg-background-surface">
+      {/* Fixed backdrops — a mark's color is fixed, so its preview surface must
+          not flip with the page theme. Light marks on neutral-500, dark marks on
+          neutral-100. */}
+      <div
+        className={`flex items-center justify-center px-8 py-12 ${
+          asset.onDark ? 'bg-ds-neutral-500' : 'bg-ds-neutral-100'
+        }`}
+      >
+        <img
+          src={src}
+          alt={`TanStack ${lockup} logo — ${TONE_LABEL[asset.tone]}`}
+          className={`w-auto max-w-full ${imgClass}`}
+        />
+      </div>
+      <div className="flex items-center justify-between gap-3 border-t border-border-default px-4 py-3">
+        <span className="font-ds-mono text-xs text-text-secondary">
+          {TONE_LABEL[asset.tone]}
+        </span>
+        <a
+          href={src}
+          download
+          className="inline-flex items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-background-subtle hover:text-text-primary"
+        >
+          <DownloadSimple size={14} />
+          SVG
+        </a>
+      </div>
+    </div>
+  )
+}
+
+function LogosPage() {
+  return (
+    <DsPage
+      title="Logos"
+      description="The TanStack brand marks. Use the stacked lockup where vertical room allows and the landscape lockup for navbars and wide, short spaces. Pick the color that keeps the mark legible on its background — dark marks on light surfaces, light marks on dark. Every mark is an SVG; download the one you need below."
+    >
+      <DsSection
+        title="Stacked"
+        description="Emblem over the wordmark — the primary lockup."
+      >
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {STACKED.map((asset) => (
+            <LogoCard
+              key={asset.file}
+              asset={asset}
+              lockup="stacked"
+              imgClass="h-20"
+            />
+          ))}
+        </div>
+      </DsSection>
+
+      <DsSection
+        title="Landscape"
+        description="Emblem beside the wordmark — for headers and horizontal space."
+      >
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {LANDSCAPE.map((asset) => (
+            <LogoCard
+              key={asset.file}
+              asset={asset}
+              lockup="landscape"
+              imgClass="h-10"
+            />
+          ))}
+        </div>
+      </DsSection>
+    </DsPage>
+  )
+}

--- a/src/routes/ds.typography.tsx
+++ b/src/routes/ds.typography.tsx
@@ -77,9 +77,9 @@ const GROUPS: Array<TypeGroup> = [
     font: 'font-sans',
     sample: 'Headless, type-safe tools for building modern web apps.',
     items: [
-      { name: 'body/xl', cls: 'text-ds-body-xl', spec: '20 / 32 · Regular' },
-      { name: 'body/lg', cls: 'text-ds-body-lg', spec: '18 / 28 · Regular' },
-      { name: 'body/md', cls: 'text-ds-body-md', spec: '16 / 24 · Regular' },
+      { name: 'body/xl', cls: 'text-ds-body-xl', spec: '20 / 32 · Light' },
+      { name: 'body/lg', cls: 'text-ds-body-lg', spec: '18 / 28 · Light' },
+      { name: 'body/md', cls: 'text-ds-body-md', spec: '16 / 24 · Light' },
       { name: 'body/sm', cls: 'text-ds-body-sm', spec: '14 / 20 · Regular' },
       { name: 'body/xs', cls: 'text-ds-body-xs', spec: '12 / 17 · Regular' },
     ],

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -292,13 +292,13 @@ html.theme-switching *::after {
 
   --text-ds-body-xl: 20px;
   --text-ds-body-xl--line-height: 32px;
-  --text-ds-body-xl--font-weight: 400;
+  --text-ds-body-xl--font-weight: 300;
   --text-ds-body-lg: 18px;
   --text-ds-body-lg--line-height: 28px;
-  --text-ds-body-lg--font-weight: 400;
+  --text-ds-body-lg--font-weight: 300;
   --text-ds-body-md: 16px;
   --text-ds-body-md--line-height: 24px;
-  --text-ds-body-md--font-weight: 400;
+  --text-ds-body-md--font-weight: 300;
   --text-ds-body-sm: 14px;
   --text-ds-body-sm--line-height: 20px;
   --text-ds-body-sm--font-weight: 400;


### PR DESCRIPTION
Targets **`ds-rebrand-phosphor-icons`** (not `main`) — this is the DS/rebrand work meant to land on that branch before it merges up.

Merge is **conflict-free** against the current `ds-rebrand-phosphor-icons` tip (verified with `git merge-tree`).

## Landing
- Shared, config-driven `LibraryLanding` template replacing the copy-pasted per-library pages; **Query** (rich) and **Ranger** (lean) converted as the first POC pages
- De-noise: one exclamation-free CTA, dropped superlative taglines, small TanStack mark stacked over a large product wordmark
- Typography repackaged onto DS `text-ds-*` roles (no more `font-black`)
- ~30% more section padding, gutters, and column gap

## Design system
- **Eyebrow** component — `mono-caps` role, brand-by-category via `--color-lib-*` tokens — with a `/ds/eyebrow` style book (incl. an interactive brand selector)
- **Logos** brand page (`/ds/logos`) with per-variant SVG downloads; new **Brand** entry merged into a **Brand & Styles** nav section
- **Button**: added polymorphic `as` prop so it can render as a `Link`/anchor (unblocks a future site-wide button migration; no live buttons changed)
- Lightened body type tokens (`body xl/lg/md` → weight 300) + updated style-book labels
- Navbar library wordmark → DS `heading-4` in the display font (all libraries)

## Verification
`pnpm test` green — tsc clean, oxlint 0/0, unit tests 23 passed / 1 skipped / 0 failed. POC pages verified in the browser preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
