### PR TITLE
fix(intent): decode legacy `__` scoped-package slugs (500 on indexed registry URLs)

### DIFF
--- a/src/utils/route-encoding.ts
+++ b/src/utils/route-encoding.ts
@@ -11,12 +11,20 @@ export function decodePackageNameSlug(slug: string) {
     try {
       const decoded = decodeURIComponent(next)
       if (decoded === next) {
-        return decoded
+        break
       }
       next = decoded
     } catch {
       return slug
     }
+  }
+
+  // Back-compat: legacy links encoded the scope separator as `__`
+  // (`@scope/name` -> `@scope__name`). Those URLs are still indexed, so
+  // restore the separator instead of failing package-name validation.
+  // Matches the stats route (`src/routes/stats/npm/-utils.ts`).
+  if (next.startsWith('@') && next.includes('__') && !next.includes('/')) {
+    return next.replace('__', '/')
   }
 
   return next

--- a/tests/route-encoding.test.ts
+++ b/tests/route-encoding.test.ts
@@ -28,6 +28,34 @@ assert.equal(
   'double-encoded package route slugs decode for router/browser compatibility',
 )
 
+// Legacy `__` scope-separator slugs (still indexed by search engines) must
+// resolve to the real scoped name instead of failing package-name validation.
+assert.equal(
+  decodePackageNameSlug('@firfi__quint-connect'),
+  '@firfi/quint-connect',
+  'legacy __ scoped slug decodes to the scoped package name',
+)
+
+assert.equal(
+  decodePackageNameSlug('%40apollo__client'),
+  '@apollo/client',
+  'legacy __ scoped slug decodes from the percent-encoded form',
+)
+
+// Only the scope separator is restored; a `__` inside the package name stays.
+assert.equal(
+  decodePackageNameSlug('@depup__trpc__server'),
+  '@depup/trpc__server',
+  'only the leading scope-separator __ is restored',
+)
+
+// Unscoped names that contain `__` are not legacy scoped slugs.
+assert.equal(
+  decodePackageNameSlug('tanstack__intent'),
+  'tanstack__intent',
+  'unscoped __ names are left intact',
+)
+
 assert.equal(
   getRowFieldId('moderation-note', '@scope/pkg', 'note'),
   'moderation-note-scope-pkg-note',


### PR DESCRIPTION
## Problem
Legacy registry links encoded the scope separator as `__` (`@scope/name` → `@scope__name`) and those URLs are still indexed by search engines. Commit 0f55472 switched the slug codec to `encodeURIComponent`/`decodeURIComponent` and dropped the old `__`→`/` decode. Landing on a legacy `__` URL now runs the package lookup with the literal `@scope__name`, which fails the npm package-name regex → the query errors → **HTTP 500**.

Reproduces for every scoped package via its legacy URL, e.g.:

```
curl -so /dev/null -w "%{http_code}\n" https://tanstack.com/intent/registry/%40apollo__client         # 500
curl -so /dev/null -w "%{http_code}\n" https://tanstack.com/intent/registry/%2540apollo%252Fclient     # 200 (canonical)
```

## Fix
Restore the `__`→`/` scope-separator back-compat in `decodePackageNameSlug`, mirroring the still-present logic in `src/routes/stats/npm/-utils.ts` (`decodePackageName`). The guard is narrow — `startsWith('@') && includes('__') && !includes('/')` — so:

- legacy `@firfi__quint-connect` → `@firfi/quint-connect`
- `@depup__trpc__server` → `@depup/trpc__server` (only the scope separator is restored)
- unscoped `tanstack__intent` → unchanged
- canonical `%2F` / double-encoded slugs → unchanged

## Tests
Added legacy-slug cases to `tests/route-encoding.test.ts`.

Local gate (all green): `pnpm test` (`tsc` + `oxlint --type-aware` + `tsx --test`) and `pnpm build`.

## Not included (open to feedback)
A 301 redirect from the legacy `__` slug to the canonical `encodeURIComponent` URL would additionally consolidate SEO. Left out here because the router's double-encoding makes a redirect loop-prone; this decoder fix alone stops the 500s. Happy to add the redirect if preferred.

Closes #1050


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of package route links, including legacy links for scoped packages.
  * Restored compatibility with older links that use encoded scope separators.
  * Prevented unnecessary repeated decoding and preserved double underscores within package names.
  * Ensured unscoped package names containing double underscores continue to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->