### PR TITLE
Remove principle card numbers

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -568,7 +568,7 @@ function WhyTanStackSection() {
         </div>
 
         <ol className="grid gap-3 sm:grid-cols-2">
-          {whyTanStackPrinciples.map((principle, index) => (
+          {whyTanStackPrinciples.map((principle) => (
             <li
               key={principle.title}
               className="group relative flex min-h-[19rem] flex-col overflow-hidden border border-gray-200 bg-white/70 p-5 shadow-sm transition-colors hover:bg-white dark:border-gray-800 dark:bg-gray-950/50 dark:hover:bg-gray-950 sm:p-6"
@@ -605,12 +605,6 @@ function WhyTanStackSection() {
                 proof={principle.proof}
                 accentClassName={principle.accentClassName}
               />
-              <span
-                aria-hidden="true"
-                className="absolute bottom-3 right-5 font-mono text-5xl font-black leading-none text-gray-100 transition-colors group-hover:text-gray-200 dark:text-white/[0.04] dark:group-hover:text-white/[0.07]"
-              >
-                {String(index + 1).padStart(2, '0')}
-              </span>
             </li>
           ))}
         </ol>


### PR DESCRIPTION
## What changed

  - Removed the decorative `01`–`04` numbers from the “Why TanStack?” principle cards.
  - Removed the now-unused array index parameter.

  ## Why

  The numbers overlapped other card content and did not provide useful information.

  ## Validation

  - Verified locally in the browser
  - TypeScript passed
  - Lint passed
  - Unit tests passed: 24 passed, 1 skipped
  
Before: 
<img width="1425" height="865" alt="before_warya_wayne_tanstack_remove_principal_numbers" src="https://github.com/user-attachments/assets/7a45f4ce-de50-49c9-9c9e-7fcb02c7173d" />


After: 
<img width="1425" height="865" alt="after_warya_wayne_tanstack_remove_principal_numbers" src="https://github.com/user-attachments/assets/7bfca8d9-b333-4ae6-9963-8be5b26980fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed numbered badges from the “Why TanStack?” principles cards.
  * Principle cards now display only their content and supporting proof elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->