### PR TITLE
Bump @tanstack/markdown to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@tanstack/ai-openai": "^0.9.5",
     "@tanstack/create": "^0.68.4",
     "@tanstack/highlight": "^0.0.3",
-    "@tanstack/markdown": "^0.0.7",
+    "@tanstack/markdown": "^0.0.9",
     "@tanstack/pacer": "^0.21.1",
     "@tanstack/react-hotkeys": "^0.10.0",
     "@tanstack/react-pacer": "^0.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3
       '@tanstack/markdown':
-        specifier: ^0.0.7
-        version: 0.0.7(react@19.2.3)
+        specifier: ^0.0.9
+        version: 0.0.9(react@19.2.3)
       '@tanstack/pacer':
         specifier: ^0.21.1
         version: 0.21.1
@@ -3334,11 +3334,14 @@ packages:
     resolution: {integrity: sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==}
     engines: {node: '>=18'}
 
-  '@tanstack/markdown@0.0.7':
-    resolution: {integrity: sha512-yznMna6T79pKv2lcW4ll0KmyE70kKsVFPBfgaAiL5w1MigkqqXgslgjUZ+JT0xbwfnhBOZ6X48x2NO8ajYUPkg==}
+  '@tanstack/markdown@0.0.9':
+    resolution: {integrity: sha512-vUqLs9YmmU3W/EHssxvCg2OQmeEkpvBfY2adpgQ0I5lfRdoEVRn+3+ZuLuMEgsypVECwotHndYpk+qIqtcfi1w==}
     peerDependencies:
+      octane: '>=0.1.12'
       react: '>=18'
     peerDependenciesMeta:
+      octane:
+        optional: true
       react:
         optional: true
 
@@ -9645,7 +9648,7 @@ snapshots:
     dependencies:
       '@tanstack/store': 0.11.0
 
-  '@tanstack/markdown@0.0.7(react@19.2.3)':
+  '@tanstack/markdown@0.0.9(react@19.2.3)':
     optionalDependencies:
       react: 19.2.3
 


### PR DESCRIPTION
## What changed

Upgrade `@tanstack/markdown` from `0.0.7` to `0.0.9`.

Version `0.0.9` recognizes CommonMark link reference definitions with optional titles, so internal docs markers such as `[//]: # 'ExampleUI1'` are omitted instead of rendered as paragraphs.

## Validation

- `pnpm test`
  - TypeScript passed
  - lint passed with zero warnings/errors
  - 24 unit tests passed; 1 optional smoke test skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering dependency to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->