### PR TITLE
Fix hydration recovery crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@tanstack/devtools-vite": "^0.7.0",
     "@tanstack/react-devtools": "^0.10.5",
     "@tanstack/react-query-devtools": "^5.100.11",
-    "@tanstack/redact": "^0.0.18",
+    "@tanstack/redact": "^0.0.19",
     "@types/hast": "^3.0.4",
     "@types/node": "^25.5.0",
     "@types/pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ importers:
         specifier: ^5.100.11
         version: 5.100.11(@tanstack/react-query@5.100.11(react@19.2.3))(react@19.2.3)
       '@tanstack/redact':
-        specifier: ^0.0.18
-        version: 0.0.18(vite@8.0.13(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: ^0.0.19
+        version: 0.0.19(vite@8.0.13(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -3490,8 +3490,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/redact@0.0.18':
-    resolution: {integrity: sha512-8HV0qg2fCQRb5Avqy+wG6dMgKKojyLdNo42h3E9FQqwj+VYnEkdkGFS7FO1Ig9T9zkNc8SlwRoDEEkdFhIAvlg==}
+  '@tanstack/redact@0.0.19':
+    resolution: {integrity: sha512-fsEaG6sCooTQawyXff83FnLaZjhGoKoAWLPPTkEib/lqxATeloZc7Rq3TDRn9nQE1HAkQfuMjjCsYNRW3swRnQ==}
     peerDependencies:
       vite: '>=5'
     peerDependenciesMeta:
@@ -9821,7 +9821,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/redact@0.0.18(vite@8.0.13(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/redact@0.0.19(vite@8.0.13(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     optionalDependencies:
       vite: 8.0.13(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -145,7 +145,7 @@ export const useTheme = () => {
 // Reads from DOM on client (matches what head script set), empty on server
 const getHtmlClass = createIsomorphicFn()
   .server(() => '')
-  .client(() => document.documentElement.className)
+  .client(() => document.documentElement?.className ?? '')
 
 export function useHtmlClass(): string {
   return getHtmlClass()


### PR DESCRIPTION
## What changed

- update `@tanstack/redact` from `0.0.18` to `0.0.19`
- keep the root theme class read safe during document recovery

## Why

Browser extensions such as Dark Reader can mutate styles before hydration. Redact 0.0.19 tolerates those mutations and repairs document-shell mismatches in place instead of temporarily removing `document.documentElement`.

## Validation

- `pnpm test` — 24 passed, 1 skipped
- commit hook reran formatting, TypeScript, lint, and unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme class handling to prevent errors when the page document is unavailable.
  * Ensured consistent HTML class behavior across client-side and server-side rendering environments.

* **Chores**
  * Updated an internal development tool to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->