### PR TITLE
Audit and harden partner experience

### DIFF
--- a/.agents/analytics.md
+++ b/.agents/analytics.md
@@ -101,9 +101,9 @@ User changed the filter state on the partners directory.
 
 User clicked a "get in touch", "let's chat", or "become a partner" CTA.
 
-| Prop        | Type | Notes                                                      |
-| ----------- | ---- | ---------------------------------------------------------- |
-| `placement` | enum | `partners_index_cta`, `library_callout`, `docs_right_rail` |
+| Prop        | Type | Notes                        |
+| ----------- | ---- | ---------------------------- |
+| `placement` | enum | See `PartnerPlacement` below |
 
 ---
 
@@ -191,6 +191,7 @@ User took an action on the generated result. Single event with `action` prop cov
 | `ecosystem_game`     | 3D ecosystem game islands                                                                                                         |
 | `partners_index_cta` | "Get in touch" mailto on `/partners`                                                                                              |
 | `library_callout`    | "Let's chat" callout per library                                                                                                  |
+| `navbar`             | "Partnership Inquiry" mailto in the Support menu                                                                                  |
 
 ### `BuilderAction`
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@tanstack/ai-anthropic": "^0.10.1",
     "@tanstack/ai-client": "^0.11.3",
     "@tanstack/ai-openai": "^0.9.5",
-    "@tanstack/create": "^0.68.4",
+    "@tanstack/create": "^0.69.0",
     "@tanstack/highlight": "^0.0.3",
     "@tanstack/markdown": "^0.0.11",
     "@tanstack/pacer": "^0.21.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^0.9.5
         version: 0.9.5(@tanstack/ai-client@0.11.3(@opentelemetry/api@1.9.1))(@tanstack/ai@0.20.1(@opentelemetry/api@1.9.1))(ws@8.21.0)(zod@4.3.6)
       '@tanstack/create':
-        specifier: ^0.68.4
-        version: 0.68.4(tslib@2.8.1)
+        specifier: ^0.69.0
+        version: 0.69.0(tslib@2.8.1)
       '@tanstack/highlight':
         specifier: ^0.0.3
         version: 0.0.3
@@ -3286,8 +3286,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@tanstack/create@0.68.4':
-    resolution: {integrity: sha512-LJ4eGQQPxyh88rEfod21P2HSAnlNFLVxlCw5GphhTBgzQTTw1FUA86N1VnIrI8h7LofDY4LfP0X84KVavXZKxQ==}
+  '@tanstack/create@0.69.0':
+    resolution: {integrity: sha512-LVbzkTWiCK+JCKa/1Qwax0JddfJt4rxwekrDyHzhDWsSeNodJrTwbUg4eqqbQsxEWcrk0kHEJSfiTVzMnmI+kQ==}
     engines: {node: '>=20'}
 
   '@tanstack/devtools-client@0.0.6':
@@ -9573,7 +9573,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@tanstack/create@0.68.4(tslib@2.8.1)':
+  '@tanstack/create@0.69.0(tslib@2.8.1)':
     dependencies:
       ejs: 3.1.10
       execa: 9.6.1

--- a/src/blog/netlify-partnership.md
+++ b/src/blog/netlify-partnership.md
@@ -1,47 +1,32 @@
 ---
 title: TanStack + Netlify Partnership
 published: 2025-03-18
-excerpt: Netlify is now the official deployment partner for TanStack Start. Their focus on speed, simplicity, and flexibility aligns perfectly with our vision for full-stack development.
+excerpt: Netlify is an official hosting partner for TanStack Start, with a Vite integration for deploying full-stack apps and an official starter template.
 authors:
   - Tanner Linsley
 ---
 
 ![Netlify Header](/blog-assets/netlify-partnership/header.jpg)
 
-We’re excited to announce that **Netlify** is now the **Official Deployment Partner** for **TanStack Start**! Together, we’re making it easier than ever for developers to build and deploy modern, type-safe, and user-focused web applications.
+**Netlify is an official hosting partner for TanStack Start.** The practical result is a supported deployment path through [`@netlify/vite-plugin-tanstack-start`](https://www.npmjs.com/package/@netlify/vite-plugin-tanstack-start), including SSR, Server Routes, Server Functions, middleware, and local Netlify platform emulation.
 
-Netlify has earned its reputation as the ultimate deployment platform for modern web developers. Its focus on speed, simplicity, modularity, and flexibility aligns perfectly with TanStack Start’s vision for full-stack development. Here’s why Netlify stands out:
+## TanStack Start on Netlify
 
-- **No-config simplicity** – Deploy your TanStack Start apps in seconds, with zero setup hassle.
-- **Serverless power** – Netlify Functions enable dynamic, real-time features effortlessly.
-- **Global performance** – Fast, reliable apps served from Netlify’s global edge network.
-- **Developer-first tools** – Instant previews, automated workflows, and seamless integrations make building a joy.
+Netlify’s Vite integration configures TanStack Start for its full-stack runtime while keeping the usual Vite development loop. Git-based continuous deployment creates Deploy Previews for pull and merge requests. Teams can also enable branch deploys for selected or all non-production branches.
 
-## Why Netlify?
+Netlify also maintains a [full-stack TanStack Start chat template](https://github.com/netlify-templates/tanstack-template) built with TanStack Router, TanStack Store, Claude, and optional Sentry and Convex integrations. You can deploy that template directly, or create a new Netlify-ready project with the TanStack CLI:
 
-Netlify is more than just a deployment provider. They’ve worked closely with us to ensure that deploying TanStack Start applications is not just fast, but optimized for the best possible developer experience. Whether you’re building interactive UIs, data-heavy dashboards, real-time tools, or AI-powered applications, Netlify’s platform makes the process seamless.
-
-As part of this partnership, Netlify has also launched a **full-stack AI chatbot starter template** that showcases TanStack Start’s powerful data management capabilities alongside Netlify Functions. This template provides:
-
-- **Real-time data handling** with TanStack Query
-- **Efficient routing** with TanStack Router
-- **Seamless server function integration** with Netlify
-- **A production-ready deployment configuration**
-
-To get started with the template, simply run:
-
-```
-npx create-tsrouter-app@latest <name> --template file-router --add-ons tanchat
+```bash
+npx @tanstack/cli create my-app --deployment netlify
 ```
 
-This template is a great way to explore how TanStack Start and Netlify work together to simplify modern web development.
+The CLI installs and configures the Netlify deployment target, so the generated project is ready for the Netlify CLI or a Git-connected deployment.
 
-## What’s Next?
+## Deploy a TanStack Start app
 
-We’re just getting started. Expect more updates, new features, and deeper collaboration between TanStack Start and Netlify. Stay tuned for success stories, guides, and real-world examples showcasing what’s possible with this powerful combination.
+For a new project, use the command above and follow the generated setup. For an existing app, add the Netlify Vite plugin and deploy with `npx netlify deploy`.
 
-Additionally, join us March 31 for a **special TanStack Start episode on [Netlify’s Remote Desk series](https://www.netlify.com/webinars/netlify-remote-desk/)**. We’ll dive into live demos, developer tips, and an exclusive Q&A to show how to unlock the full potential of TanStack Start on Netlify.
+- [TanStack Start hosting guide](https://tanstack.com/start/latest/docs/framework/react/guide/hosting#netlify--official-partner)
+- [Netlify’s TanStack Start template](https://github.com/netlify-templates/tanstack-template)
 
-**Ready to dive in?** Check out the [TanStack Start docs](/start/latest/docs/framework/react/overview), explore the deployment guides, and start building with Netlify today.
-
-A huge thank you to Netlify for supporting and empowering developers. Let’s build something incredible together! 🚀
+Netlify’s support helps fund TanStack’s open-source work while giving Start users a deployment path maintained by both teams.

--- a/src/blog/openrouter-partnership.md
+++ b/src/blog/openrouter-partnership.md
@@ -1,20 +1,20 @@
 ---
 title: TanStack + OpenRouter Partnership
 published: 2026-03-09
-excerpt: OpenRouter is now an official TanStack sponsor. The most concrete result is already shipped — a first-class TanStack AI adapter giving you access to 300+ models from 60+ providers through a single API.
+excerpt: OpenRouter is an official TanStack sponsor, with a first-class TanStack AI adapter for accessing hundreds of models through one API.
 authors:
   - Tanner Linsley
 ---
 
 ![TanStack + OpenRouter](/blog-assets/openrouter-partnership/header.png)
 
-**OpenRouter is now an official TanStack sponsor.** And the most concrete expression of that is already shipped: [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter) — a first-class TanStack AI adapter that gives you access to 300+ models from 60+ providers through a single, unified API.
+**OpenRouter is now an official TanStack sponsor.** The most concrete expression of that is already shipped: [`@tanstack/ai-openrouter`](https://tanstack.com/ai/latest/docs/adapters/openrouter), a first-class TanStack AI adapter that gives you access to hundreds of models through one API.
 
 ## Why OpenRouter
 
 When we started building TanStack AI, one of our core beliefs was that you shouldn't have to bet your integration on a single provider. The AI model landscape is moving faster than anyone can predict. The model that wins this quarter might not be the one you want next quarter, and rewriting your AI layer every time a new frontier model drops is exactly the kind of undifferentiated toil we want to help you avoid.
 
-OpenRouter solves this cleanly. One API key. One integration. GPT-5, Claude, Gemini, Llama, Mistral, DeepSeek — and whatever ships next month. When you want to try a different model, you change a string. When a provider goes down, OpenRouter routes around it automatically. That's the kind of leverage I want TanStack developers to have.
+OpenRouter solves this cleanly. One API key and one integration for GPT, Claude, Gemini, Llama, Mistral, DeepSeek, and whatever ships next. When you want to try a different model, you change a string. When a provider goes down, OpenRouter can route around it. That's the kind of leverage I want TanStack developers to have.
 
 ## The Adapter
 
@@ -32,7 +32,7 @@ const stream = chat({
 })
 ```
 
-Swap the model string for any of the [300+ models on OpenRouter](https://openrouter.ai/models?utm_source=tanstack). Everything else stays the same.
+Swap the model string for any model in the [OpenRouter catalog](https://openrouter.ai/models?utm_source=tanstack). Everything else stays the same.
 
 One feature I particularly love is the auto-router with fallbacks. It's dead simple to set up and gives your app real production resilience without any retry logic of your own:
 
@@ -40,18 +40,17 @@ One feature I particularly love is the auto-router with fallbacks. It's dead sim
 const stream = chat({
   adapter: openRouterText('openrouter/auto'),
   messages,
-  providerOptions: {
+  modelOptions: {
     models: [
-      'openai/gpt-5',
+      'openai/gpt-5.5',
       'anthropic/claude-sonnet-4.5',
-      'google/gemini-3-pro-preview',
+      'google/gemini-3.1-pro-preview',
     ],
-    route: 'fallback',
   },
 })
 ```
 
-If the primary model fails or gets rate-limited, OpenRouter falls through to the next one. No outage pages, no extra infrastructure.
+If the primary model is unavailable, OpenRouter falls through the configured list. The fallback order stays in the request instead of becoming hand-written retry logic.
 
 ## Jack's Image Generation Demo
 
@@ -69,7 +68,7 @@ Our own Jack Herrington put together a demo showing off TanStack AI with the Ope
 
 ## What This Means Going Forward
 
-OpenRouter's sponsorship of TanStack means the adapter is actively maintained, tested, and will stay in sync with both libraries as they evolve. More importantly, both teams are genuinely aligned on the same goal: give developers the most flexible AI integration possible without locking them into anything.
+The sponsorship supports ongoing maintenance and testing as TanStack AI and OpenRouter evolve. More importantly, both teams are aligned on the same goal: give developers a flexible AI integration without locking them into a single model provider.
 
 If you're building AI features with TanStack, the OpenRouter adapter is the one I'd reach for first.
 

--- a/src/builder/api/create-worker.ts
+++ b/src/builder/api/create-worker.ts
@@ -21,6 +21,7 @@ type GeneratedTemplateContext = WorkerTemplateContext & {
   projectName: unknown
   typescript: unknown
   tailwind: unknown
+  blank: unknown
   js: unknown
   jsx: unknown
   fileRouter: unknown
@@ -62,6 +63,7 @@ type WorkerAddOnPhase = WorkerAddOnManifest['phase']
 type WorkerAddOnCategory = NonNullable<WorkerAddOnManifest['category']>
 type WorkerAddOnExclusive = NonNullable<WorkerAddOnManifest['exclusive']>[number]
 type WorkerAddOnEnvVar = NonNullable<WorkerAddOnManifest['envVars']>[number]
+type WorkerAddOnPartner = NonNullable<WorkerAddOnManifest['partner']>
 type WorkerAddOnOptions = NonNullable<WorkerAddOnManifest['options']>
 type WorkerAddOnOption = WorkerAddOnOptions[string]
 type WorkerAddOnPackageAdditions = NonNullable<
@@ -71,6 +73,10 @@ type GeneratedStringRecord = Record<string, string | undefined>
 type GeneratedAddOnPackageAdditions = {
   dependencies?: GeneratedStringRecord
   devDependencies?: GeneratedStringRecord
+  engines?: GeneratedStringRecord
+  pnpm?: {
+    onlyBuiltDependencies?: Array<string>
+  }
   scripts?: GeneratedStringRecord
 }
 type GeneratedAddOnEnvVar = Omit<WorkerAddOnEnvVar, 'file'> & {
@@ -78,6 +84,9 @@ type GeneratedAddOnEnvVar = Omit<WorkerAddOnEnvVar, 'file'> & {
 }
 type GeneratedAddOnOption = Omit<WorkerAddOnOption, 'type'> & {
   type: string
+}
+type GeneratedAddOnPartner = Omit<WorkerAddOnPartner, 'tier'> & {
+  tier: string
 }
 type GeneratedAddOnOptions = Record<string, GeneratedAddOnOption | undefined>
 type GeneratedAddOnFields = {
@@ -87,6 +96,7 @@ type GeneratedAddOnFields = {
   exclusive?: Array<string>
   envVars?: Array<GeneratedAddOnEnvVar>
   options?: GeneratedAddOnOptions
+  partner?: GeneratedAddOnPartner
 }
 type GeneratedAddOnManifest = Omit<
   WorkerAddOnManifest,
@@ -96,6 +106,7 @@ type GeneratedAddOnManifest = Omit<
   | 'exclusive'
   | 'envVars'
   | 'options'
+  | 'partner'
   | 'packageAdditions'
 > &
   GeneratedAddOnFields & {
@@ -109,6 +120,7 @@ type GeneratedAddOnMetadata = Omit<
   | 'exclusive'
   | 'envVars'
   | 'options'
+  | 'partner'
   | 'packageAdditions'
 > &
   GeneratedAddOnFields & {
@@ -136,6 +148,7 @@ function getGeneratedTemplateContext(
     projectName: context.projectName,
     typescript: context.typescript,
     tailwind: context.tailwind,
+    blank: context.blank,
     js: context.js,
     jsx: context.jsx,
     fileRouter: context.fileRouter,
@@ -238,6 +251,28 @@ function getAddOnExclusive(exclusive: string): WorkerAddOnExclusive {
   }
 }
 
+function getAddOnPartnerTier(tier: string): WorkerAddOnPartner['tier'] {
+  switch (tier) {
+    case 'gold':
+    case 'silver':
+    case 'bronze':
+      return tier
+    default:
+      throw new Error(`Unsupported partner tier: ${tier}`)
+  }
+}
+
+function getAddOnPartner(
+  partner: GeneratedAddOnPartner | undefined,
+): WorkerAddOnManifest['partner'] {
+  if (!partner) return undefined
+
+  return {
+    ...partner,
+    tier: getAddOnPartnerTier(partner.tier),
+  }
+}
+
 function getAddOnEnvFile(file: string | undefined): WorkerAddOnEnvVar['file'] {
   switch (file) {
     case undefined:
@@ -310,6 +345,8 @@ function getPackageAdditions(
   const normalizedPackageAdditions: WorkerAddOnPackageAdditions = {
     dependencies: getStringRecord(packageAdditions.dependencies),
     devDependencies: getStringRecord(packageAdditions.devDependencies),
+    engines: getStringRecord(packageAdditions.engines),
+    pnpm: packageAdditions.pnpm,
     scripts: getStringRecord(packageAdditions.scripts),
   }
 
@@ -327,6 +364,7 @@ function getAddOnMetadata(
     exclusive: addOn.exclusive?.map(getAddOnExclusive),
     envVars: getAddOnEnvVars(addOn.envVars),
     options: getAddOnOptions(addOn.options),
+    partner: getAddOnPartner(addOn.partner),
     packageAdditions: getPackageAdditions(addOn.packageAdditions),
   }
 }
@@ -340,6 +378,7 @@ function getAddOnManifest(addOn: GeneratedAddOnManifest): WorkerAddOnManifest {
     exclusive: addOn.exclusive?.map(getAddOnExclusive),
     envVars: getAddOnEnvVars(addOn.envVars),
     options: getAddOnOptions(addOn.options),
+    partner: getAddOnPartner(addOn.partner),
     packageAdditions: getPackageAdditions(addOn.packageAdditions),
   }
 }
@@ -376,6 +415,12 @@ function loadAddOn(
   }
 }
 
+function defineAddOnLoaders(
+  loaders: Record<string, () => Promise<WorkerAddOnManifestModule>>,
+) {
+  return loaders
+}
+
 const frameworkLoaders: Record<
   string,
   () => Promise<WorkerFrameworkManifestModule>
@@ -388,7 +433,7 @@ const frameworkLoaders: Record<
   ),
 }
 
-const reactAddOnLoaders = {
+const reactAddOnLoaders = defineAddOnLoaders({
   ai: loadAddOn(() =>
     import('@tanstack/create/worker-manifest/frameworks/react/add-ons/ai'),
   ),
@@ -512,9 +557,9 @@ const reactAddOnLoaders = {
   workos: loadAddOn(() =>
     import('@tanstack/create/worker-manifest/frameworks/react/add-ons/workos'),
   ),
-} satisfies Record<string, () => Promise<WorkerAddOnManifestModule>>
+})
 
-const solidAddOnLoaders = {
+const solidAddOnLoaders = defineAddOnLoaders({
   'better-auth': loadAddOn(() =>
     import(
       '@tanstack/create/worker-manifest/frameworks/solid/add-ons/better-auth'
@@ -571,7 +616,7 @@ const solidAddOnLoaders = {
       '@tanstack/create/worker-manifest/frameworks/solid/add-ons/tanstack-query'
     ),
   ),
-} satisfies Record<string, () => Promise<WorkerAddOnManifestModule>>
+})
 
 const addOnLoaders: Record<
   string,

--- a/src/builder/templates.ts
+++ b/src/builder/templates.ts
@@ -46,18 +46,10 @@ export const TEMPLATES: Array<Template> = [
   {
     id: 'saas',
     name: 'SaaS Starter',
-    description: 'Auth, database, monitoring',
+    description: 'Auth, database, and UI',
     icon: Rocket,
     color: '#F97316', // orange
-    features: [
-      'cloudflare',
-      'better-auth',
-      'neon',
-      'drizzle',
-      'sentry',
-      'shadcn',
-      'form',
-    ],
+    features: ['cloudflare', 'better-auth', 'prisma', 'shadcn', 'form'],
   },
   {
     id: 'ai-chat',
@@ -81,7 +73,7 @@ export const TEMPLATES: Array<Template> = [
     description: 'Content-driven site',
     icon: FileText,
     color: '#EC4899', // pink
-    features: ['cloudflare', 'strapi', 'tanstack-query'],
+    features: ['cloudflare', 'tanstack-query'],
   },
   {
     id: 'api-first',
@@ -97,7 +89,7 @@ export const TEMPLATES: Array<Template> = [
     description: 'Live, collaborative features',
     icon: Radio,
     color: '#EF4444', // red
-    features: ['cloudflare', 'convex', 'tanstack-query'],
+    features: ['cloudflare', 'db', 'tanstack-query'],
   },
   {
     id: 'i18n',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,10 +14,6 @@ const footerLinks = [
     to: 'https://youtube.com/@tan_stack',
   },
   {
-    label: 'Nozzle.io - Keyword Rank Tracker',
-    to: 'https://nozzle.io',
-  },
-  {
     label: 'Ethos',
     to: '/ethos',
   },

--- a/src/components/LandingCommunitySection.tsx
+++ b/src/components/LandingCommunitySection.tsx
@@ -41,7 +41,7 @@ export function LandingCommunitySection({
     >
       <div className="flex flex-col gap-20 md:gap-24">
         <MaintainersSection libraryId={libraryId} />
-        <PartnersSection libraryId={libraryId} />
+        <PartnersSection />
       </div>
     </Hydrate>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,6 +63,11 @@ import { groupToSlug } from '~/components/stack/stack-categories'
 import { getProducts } from '~/utils/shop.functions'
 import { formatMoney, shopifyImageUrl } from '~/utils/shopify-format'
 import type { ProductListItem } from '~/utils/shopify-queries'
+import type { PartnerPlacement } from '~/utils/analytics'
+import {
+  PARTNER_INQUIRY_HREF,
+  trackPartnerInquiry,
+} from '~/utils/partner-inquiry'
 
 type LogoProps = {
   title?: React.ComponentType | null
@@ -112,6 +117,7 @@ type NavMenuKey =
   | 'support'
 
 type NavMenuItem = {
+  analyticsPlacement?: PartnerPlacement
   label: string
   to: string
   hash?: string
@@ -344,8 +350,9 @@ const NAV_GROUPS = [
       title: 'Work with TanStack',
       description: 'Sponsorships, placements, and partner pages.',
       item: {
+        analyticsPlacement: 'navbar',
         label: 'Partnership Inquiry',
-        to: 'mailto:partners@tanstack.com?subject=TanStack Partnership Inquiry',
+        to: PARTNER_INQUIRY_HREF,
         icon: Mail,
       },
     },
@@ -1414,7 +1421,12 @@ function MenuItemLink({
         target={item.to.startsWith('mailto:') ? undefined : '_blank'}
         rel={item.to.startsWith('mailto:') ? undefined : 'noopener noreferrer'}
         className={className}
-        onClick={onNavigate}
+        onClick={() => {
+          onNavigate()
+          if (item.analyticsPlacement) {
+            trackPartnerInquiry(item.analyticsPlacement)
+          }
+        }}
       >
         {content}
       </a>

--- a/src/components/PartnerStatusFilter.tsx
+++ b/src/components/PartnerStatusFilter.tsx
@@ -1,0 +1,54 @@
+import type { PartnerDirectoryStatus } from '~/utils/partner-directory'
+
+const partnerStatusOptions: Array<{
+  label: string
+  status: PartnerDirectoryStatus
+}> = [
+  { label: 'Current', status: 'active' },
+  { label: 'Previous', status: 'inactive' },
+]
+
+export function PartnerStatusFilter({
+  selectedStatus,
+  onStatusChange,
+}: {
+  selectedStatus: PartnerDirectoryStatus
+  onStatusChange: (status: PartnerDirectoryStatus) => void
+}) {
+  return (
+    <fieldset className="mb-6">
+      <legend className="mb-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+        Partner status
+      </legend>
+      <div className="inline-flex rounded-lg border border-gray-200 bg-white p-1 dark:border-gray-700 dark:bg-gray-800">
+        {partnerStatusOptions.map(({ status, label }) => {
+          const isSelected = selectedStatus === status
+
+          return (
+            <label key={status} className="cursor-pointer">
+              <input
+                type="radio"
+                name="partner-status"
+                value={status}
+                checked={isSelected}
+                onChange={() => onStatusChange(status)}
+                className="peer sr-only"
+              />
+              <span
+                className={`block rounded-md px-3 py-2 text-sm font-medium transition-colors peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-blue-500 ${
+                  isSelected
+                    ? status === 'active'
+                      ? 'bg-green-700 text-white'
+                      : 'bg-orange-700 text-white'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700'
+                }`}
+              >
+                {label}
+              </span>
+            </label>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}

--- a/src/components/PartnersSection.tsx
+++ b/src/components/PartnersSection.tsx
@@ -1,44 +1,29 @@
 import * as React from 'react'
-import { Link } from '@tanstack/react-router'
 import { PartnersGrid } from './PartnersGrid'
 import { PartnershipCallout } from './PartnershipCallout'
-import { LibraryId } from '~/libraries'
 import { Button } from '~/ui'
+import { Link } from '@tanstack/react-router'
 
 type PartnersSectionProps = {
-  libraryId?: LibraryId
   title?: string
   showPreviousLink?: boolean
 }
 
 export function PartnersSection({
-  libraryId,
   title = 'Partners',
   showPreviousLink = true,
 }: PartnersSectionProps) {
-  if (!libraryId) {
-    throw new Error('Library ID is required')
-  }
-
   return (
     <div className="px-4 lg:max-w-(--breakpoint-lg) md:mx-auto mx-auto max-w-full">
       <div className="space-y-8">
         <h3 className="text-3xl font-bold">{title}</h3>
         <PartnersGrid analyticsPlacement="library_grid" />
-        <PartnershipCallout libraryId={libraryId} />
+        <PartnershipCallout />
         {showPreviousLink ? (
           <div className="flex justify-center mt-6">
-            <Button
-              as={Link}
-              to="/partners"
-              search={
-                (libraryId
-                  ? { libraries: [libraryId], status: 'inactive' }
-                  : { status: 'inactive' }) as any
-              }
-            >
-              View Previous Partners
-            </Button>
+            <Link to="/partners" search={{ status: 'inactive' }}>
+              <Button as="span">View Previous Partners</Button>
+            </Link>
           </div>
         ) : null}
       </div>

--- a/src/components/PartnershipCallout.tsx
+++ b/src/components/PartnershipCallout.tsx
@@ -1,6 +1,9 @@
 import { HeartHandshake } from 'lucide-react'
 import { Card } from './Card'
-import { trackEvent } from '~/utils/analytics'
+import {
+  PARTNER_INQUIRY_HREF,
+  trackPartnerInquiry,
+} from '~/utils/partner-inquiry'
 
 export function PartnershipCallout() {
   return (
@@ -18,13 +21,9 @@ export function PartnershipCallout() {
           and build useful integrations for the ecosystem.
         </div>
         <a
-          href="mailto:partners@tanstack.com?subject=TanStack Partnership"
+          href={PARTNER_INQUIRY_HREF}
           className="text-blue-500 uppercase font-black text-sm"
-          onClick={() => {
-            trackEvent('partner_inquiry_started', {
-              placement: 'library_callout',
-            })
-          }}
+          onClick={() => trackPartnerInquiry('library_callout')}
         >
           Let's chat
         </a>

--- a/src/components/PartnershipCallout.tsx
+++ b/src/components/PartnershipCallout.tsx
@@ -1,15 +1,8 @@
-import { getLibrary, LibraryId } from '~/libraries'
 import { HeartHandshake } from 'lucide-react'
 import { Card } from './Card'
 import { trackEvent } from '~/utils/analytics'
 
-interface PartnershipCalloutProps {
-  libraryId: LibraryId
-}
-
-export function PartnershipCallout({ libraryId }: PartnershipCalloutProps) {
-  const library = getLibrary(libraryId)
-
+export function PartnershipCallout() {
   return (
     <Card
       className="relative flex-1 flex flex-col items-center text-sm text-center
@@ -17,16 +10,15 @@ export function PartnershipCallout({ libraryId }: PartnershipCalloutProps) {
                     w-[500px] max-w-full mx-auto"
     >
       <span className="flex items-center gap-2 p-8 text-3xl text-rose-500 font-black uppercase">
-        {library.name.replace('TanStack ', '')} <HeartHandshake /> You?
+        TanStack <HeartHandshake /> You?
       </span>
       <div className="flex flex-col p-4 gap-3 text-sm">
         <div>
-          We're looking for {library.name} Partners to join our mission! Partner
-          with us to push the boundaries of {library.name} and build amazing
-          things together.
+          We're looking for TanStack partners to support our open-source mission
+          and build useful integrations for the ecosystem.
         </div>
         <a
-          href={`mailto:partners@tanstack.com?subject=TanStack ${library.name} Partnership`}
+          href="mailto:partners@tanstack.com?subject=TanStack Partnership"
           className="text-blue-500 uppercase font-black text-sm"
           onClick={() => {
             trackEvent('partner_inquiry_started', {

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -19,6 +19,10 @@ import {
   useTrackedImpression,
   type PartnerPlacement,
 } from '~/utils/analytics'
+import {
+  PARTNER_INQUIRY_HREF,
+  trackPartnerInquiry,
+} from '~/utils/partner-inquiry'
 
 type RailPartner = {
   category: Partner['category']
@@ -148,15 +152,9 @@ export function PartnersRail({
           {title}
         </Link>
         <a
-          href="https://docs.google.com/document/d/1Hg2MzY2TU6U3hFEZ3MLe2oEOM3JS4-eByti3kdJU3I8"
-          target="_blank"
-          rel="noopener noreferrer"
+          href={PARTNER_INQUIRY_HREF}
           className="font-medium opacity-60 hover:opacity-100 text-xs hover:underline"
-          onClick={() => {
-            trackEvent('partner_inquiry_started', {
-              placement: analyticsPlacement,
-            })
-          }}
+          onClick={() => trackPartnerInquiry(analyticsPlacement)}
         >
           Become a Partner
         </a>

--- a/src/routes/api/data/partners.ts
+++ b/src/routes/api/data/partners.ts
@@ -24,8 +24,19 @@ export const Route = createFileRoute('/api/data/partners')({
             description: p.llmDescription,
             category: p.category,
             categoryLabel: partnerCategoryLabels[p.category],
-            libraries: p.libraries || [],
+            partnershipScope: 'tanstack',
+            relatedProducts: p.relatedProducts || [],
+            tier: p.tier,
+            lastReviewedAt: p.lastReviewedAt,
             url: p.href,
+            websiteUrl: p.canonicalHref ?? p.href,
+            partnerPageUrl: `https://tanstack.com/partners/${p.id}`,
+            resources: (p.resources ?? []).map((resource) => ({
+              ...resource,
+              href: resource.href.startsWith('/')
+                ? `https://tanstack.com${resource.href}`
+                : resource.href,
+            })),
           }))
 
         return new Response(

--- a/src/routes/partners.$partner.tsx
+++ b/src/routes/partners.$partner.tsx
@@ -1,20 +1,37 @@
 import * as React from 'react'
 import { Link, createFileRoute, notFound } from '@tanstack/react-router'
-import { ArrowUpRight, CheckCircle2, CircleDashed } from 'lucide-react'
+import {
+  ArrowRight,
+  ArrowUpRight,
+  CheckCircle2,
+  CircleDashed,
+} from 'lucide-react'
 import { Footer } from '~/components/Footer'
 import { Card } from '~/components/Card'
 import { Button } from '~/ui'
 import { seo } from '~/utils/seo'
-import { PartnerImage, partnerCategoryLabels } from '~/utils/partners'
+import {
+  PartnerImage,
+  partnerCategoryLabels,
+  partnerTierFlares,
+  partnerTierLabels,
+  type PartnerResourceKind,
+} from '~/utils/partners'
 import { trackEvent } from '~/utils/analytics'
 import {
   findPartnerForPage,
   getPartnerJsonLd,
-  getPartnerLibraryLabels,
   getPartnerPageCopy,
   getPartnerPageDescription,
   getPartnerPageTitle,
 } from '~/utils/partner-pages'
+import { getPartnerWindowLabel } from '~/utils/partner-lifecycle'
+
+const partnerResourceKindLabels: Record<PartnerResourceKind, string> = {
+  announcement: 'Announcement',
+  documentation: 'Documentation',
+  example: 'Example',
+}
 
 export const Route = createFileRoute('/partners/$partner')({
   loader: ({ params }) => {
@@ -60,15 +77,19 @@ function PartnerDetailPage() {
   }
 
   const copy = getPartnerPageCopy(partner)
-  const libraries = getPartnerLibraryLabels(partner)
+  const partnerWindow = getPartnerWindowLabel(partner)
   const isActive = partner.status === 'active'
+  const resources = partner.resources ?? []
+  const tier = isActive ? partner.tier : undefined
+  const tierFlare = tier ? partnerTierFlares[tier] : undefined
 
   React.useEffect(() => {
     trackEvent('partner_viewed', {
       partner_id: partner.id,
       placement: 'detail',
+      partner_tier: tier,
     })
-  }, [partner])
+  }, [partner, tier])
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -108,6 +129,16 @@ function PartnerDetailPage() {
                   <span className="inline-flex rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:bg-blue-950/40 dark:text-blue-300">
                     {partnerCategoryLabels[partner.category]}
                   </span>
+                  {tier && tierFlare ? (
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${tierFlare.labelColor}`}
+                    >
+                      <span className={tierFlare.iconColor}>
+                        {tierFlare.icon}
+                      </span>
+                      {partnerTierLabels[tier]} Partner
+                    </span>
+                  ) : null}
                 </div>
 
                 <div>
@@ -148,6 +179,7 @@ function PartnerDetailPage() {
                         placement: 'detail',
                         destination: 'external',
                         destination_host: destinationHost,
+                        partner_tier: tier,
                       })
                     }}
                   >
@@ -167,6 +199,78 @@ function PartnerDetailPage() {
               </div>
             </div>
           </Card>
+
+          {resources.length > 0 ? (
+            <Card>
+              <div className="p-6 md:p-8">
+                <h2 className="text-2xl font-black text-gray-950 dark:text-white">
+                  Resources
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                  Resources for using {partner.name} with TanStack.
+                </p>
+                <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                  {resources.map((resource) => {
+                    const isExternal = resource.href.startsWith('http')
+                    const className =
+                      'group flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-gray-50 p-4 transition-colors hover:border-blue-500/50 hover:bg-blue-50/50 dark:border-gray-800 dark:bg-gray-950/40 dark:hover:border-blue-400/50 dark:hover:bg-blue-950/20'
+                    const onClick = () => {
+                      trackEvent('partner_clicked', {
+                        partner_id: partner.id,
+                        placement: 'detail',
+                        destination: isExternal
+                          ? 'external'
+                          : 'internal_resource',
+                        destination_host: isExternal
+                          ? new URL(resource.href).host
+                          : undefined,
+                        partner_tier: tier,
+                      })
+                    }
+                    const content = (
+                      <>
+                        <span>
+                          <span className="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                            {partnerResourceKindLabels[resource.kind]}
+                          </span>
+                          <span className="mt-1 block font-semibold text-gray-900 group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-300">
+                            {resource.label}
+                          </span>
+                        </span>
+                        {isExternal ? (
+                          <ArrowUpRight className="h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-blue-500" />
+                        ) : (
+                          <ArrowRight className="h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-blue-500" />
+                        )}
+                      </>
+                    )
+
+                    return isExternal ? (
+                      <a
+                        key={`${resource.kind}:${resource.href}`}
+                        href={resource.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={className}
+                        onClick={onClick}
+                      >
+                        {content}
+                      </a>
+                    ) : (
+                      <Link
+                        key={`${resource.kind}:${resource.href}`}
+                        to={resource.href}
+                        className={className}
+                        onClick={onClick}
+                      >
+                        {content}
+                      </Link>
+                    )
+                  })}
+                </div>
+              </div>
+            </Card>
+          ) : null}
 
           <div className="grid gap-6 md:grid-cols-2">
             <Card>
@@ -192,43 +296,21 @@ function PartnerDetailPage() {
             </Card>
           </div>
 
-          {(libraries.length > 0 || partner.startDate) && (
+          {partnerWindow && (
             <Card>
               <div className="p-6 md:p-8">
                 <h2 className="text-2xl font-black text-gray-950 dark:text-white">
                   Quick Fit
                 </h2>
-                <div className="mt-5 grid gap-6 md:grid-cols-2">
-                  {libraries.length > 0 ? (
-                    <div>
-                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                        Relevant Libraries
-                      </h3>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {libraries.map((library) => (
-                          <span
-                            key={library}
-                            className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300"
-                          >
-                            {library}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  ) : null}
-
-                  {partner.startDate ? (
-                    <div>
-                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                        Partner Window
-                      </h3>
-                      <p className="mt-3 text-base leading-7 text-gray-700 dark:text-gray-300">
-                        {partner.endDate
-                          ? `${partner.startDate} - ${partner.endDate}`
-                          : `${partner.startDate} - Present`}
-                      </p>
-                    </div>
-                  ) : null}
+                <div className="mt-5">
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Partner Window
+                    </h3>
+                    <p className="mt-3 text-base leading-7 text-gray-700 dark:text-gray-300">
+                      {partnerWindow}
+                    </p>
+                  </div>
                 </div>
               </div>
             </Card>

--- a/src/routes/partners.$partner.tsx
+++ b/src/routes/partners.$partner.tsx
@@ -300,12 +300,12 @@ function PartnerDetailPage() {
             <Card>
               <div className="p-6 md:p-8">
                 <h2 className="text-2xl font-black text-gray-950 dark:text-white">
-                  Quick Fit
+                  Partnership History
                 </h2>
                 <div className="mt-5">
                   <div>
                     <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                      Partner Window
+                      Dates
                     </h3>
                     <p className="mt-3 text-base leading-7 text-gray-700 dark:text-gray-300">
                       {partnerWindow}

--- a/src/routes/partners.index.tsx
+++ b/src/routes/partners.index.tsx
@@ -1,6 +1,7 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
 import { Footer } from '~/components/Footer'
 import { Card } from '~/components/Card'
+import { PartnerStatusFilter } from '~/components/PartnerStatusFilter'
 import {
   partners,
   PartnerImage,
@@ -16,181 +17,54 @@ import {
 } from '~/utils/partner-placement'
 import { usePartnerPlacementContext } from '~/utils/usePartnerPlacementContext'
 import { seo } from '~/utils/seo'
-import { useState } from 'react'
 import * as React from 'react'
-import { ListFilter } from 'lucide-react'
 import { Button } from '~/ui'
 import { trackEvent, useTrackedImpression } from '~/utils/analytics'
 import { getPartnerWindowLabel } from '~/utils/partner-lifecycle'
-import * as v from 'valibot'
+import {
+  getPartnerDirectoryMetadata,
+  getPartnerDirectorySearch,
+  normalizePartnerDirectorySearch,
+  partnerDirectorySearchSchema,
+  type PartnerDirectoryStatus,
+} from '~/utils/partner-directory'
+import {
+  PARTNER_INQUIRY_HREF,
+  trackPartnerInquiry,
+} from '~/utils/partner-inquiry'
 
-const statusSchema = v.picklist(['active', 'inactive'])
-
-const searchSchema = v.object({
-  status: v.fallback(v.optional(statusSchema, 'active'), 'active'),
-})
-
-type PartnersSearch = v.InferOutput<typeof searchSchema>
+type NormalizedPartnersSearch = {
+  status: PartnerDirectoryStatus
+}
 type PartnersSearchUpdates = {
-  status: 'active' | 'inactive'
+  status: PartnerDirectoryStatus
 }
 
-const defaultPartnersSearch = {
+const defaultPartnersSearch: NormalizedPartnersSearch = {
   status: 'active',
-} satisfies PartnersSearch
-
-function normalizePartnersSearch(
-  search: Partial<PartnersSearch>,
-): PartnersSearch {
-  return {
-    status: search.status ?? defaultPartnersSearch.status,
-  }
 }
 
 export const Route = createFileRoute('/partners/')({
   component: PartnersIndexPage,
-  validateSearch: searchSchema,
+  validateSearch: partnerDirectorySearchSchema,
+  loaderDeps: ({ search }) => normalizePartnerDirectorySearch(search),
+  loader: ({ deps }) => deps,
   staticData: {
     includeSearchInCanonical: true,
   },
-  head: () => ({
-    meta: seo({
-      title: 'Partners',
-      description:
-        'Companies and organizations supporting TanStack and our open source mission',
-    }),
-  }),
+  head: ({ loaderData }) => {
+    const metadata = getPartnerDirectoryMetadata(
+      loaderData?.status ?? defaultPartnersSearch.status,
+    )
+
+    return {
+      meta: seo(metadata),
+    }
+  },
 })
 
-interface FilterProps {
-  selectedStatus: 'active' | 'inactive'
-  onStatusChange: (status: 'active' | 'inactive') => void
-}
-
-function PartnersFilter({ selectedStatus, onStatusChange }: FilterProps) {
-  const [isOpen, setIsOpen] = useState(false)
-  const triggerRef = React.useRef<HTMLButtonElement>(null)
-
-  const selectStatus = (status: 'active' | 'inactive') => {
-    onStatusChange(status)
-    setIsOpen(false)
-    triggerRef.current?.focus()
-  }
-
-  React.useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        event.target instanceof Element &&
-        !event.target.closest('[data-filter-dropdown]')
-      ) {
-        setIsOpen(false)
-      }
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false)
-        triggerRef.current?.focus()
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('click', handleClickOutside)
-      document.addEventListener('keydown', handleKeyDown)
-      return () => {
-        document.removeEventListener('click', handleClickOutside)
-        document.removeEventListener('keydown', handleKeyDown)
-      }
-    }
-  }, [isOpen])
-
-  const hasNonDefaultFilter = selectedStatus !== defaultPartnersSearch.status
-
-  return (
-    <div className="mb-6">
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="relative" data-filter-dropdown>
-          <button
-            ref={triggerRef}
-            type="button"
-            onClick={() => setIsOpen(!isOpen)}
-            aria-controls="partner-status-filter"
-            aria-expanded={isOpen}
-            aria-haspopup="dialog"
-            className="inline-flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <ListFilter className="w-4 h-4" />
-            Filter Partners
-            {hasNonDefaultFilter && (
-              <span className="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-0.5 rounded-full text-xs">
-                1
-              </span>
-            )}
-          </button>
-
-          {isOpen && (
-            <div
-              id="partner-status-filter"
-              role="dialog"
-              aria-label="Filter partners by status"
-              className="absolute top-full left-0 mt-2 w-[calc(100vw-2rem)] max-w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50"
-            >
-              <div className="p-4">
-                <div className="flex items-center justify-between mb-4">
-                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    Partner Status
-                  </span>
-                  {hasNonDefaultFilter && (
-                    <button
-                      type="button"
-                      onClick={() => selectStatus('active')}
-                      className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-                    >
-                      Reset
-                    </button>
-                  )}
-                </div>
-
-                <div
-                  className="flex gap-2"
-                  role="group"
-                  aria-label="Partner status"
-                >
-                  <button
-                    type="button"
-                    aria-pressed={selectedStatus === 'active'}
-                    onClick={() => selectStatus('active')}
-                    className={`px-3 py-2 rounded-md text-sm transition-colors ${
-                      selectedStatus === 'active'
-                        ? 'bg-green-700 text-white'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    Current Partners
-                  </button>
-                  <button
-                    type="button"
-                    aria-pressed={selectedStatus === 'inactive'}
-                    onClick={() => selectStatus('inactive')}
-                    className={`px-3 py-2 rounded-md text-sm transition-colors ${
-                      selectedStatus === 'inactive'
-                        ? 'bg-orange-700 text-white'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    Previous Partners
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function getFilteredPartners(search: PartnersSearch) {
-  const normalizedSearch = normalizePartnersSearch(search)
+function getFilteredPartners(search: NormalizedPartnersSearch) {
+  const normalizedSearch = normalizePartnerDirectorySearch(search)
 
   return partners.filter((partner) => {
     if (normalizedSearch.status && partner.status !== normalizedSearch.status) {
@@ -343,14 +217,15 @@ function TierSectionHeader({ tier }: { tier: PartnerTier }) {
       <div
         className={`h-px flex-1 bg-linear-to-r from-transparent ${flare.gradientStops}`}
       />
-      <div
+      <h2
+        id={`partner-tier-${tier}`}
         className={`flex items-center gap-2 px-3 py-1 rounded-full ${flare.labelColor}`}
       >
         <span className={flare.iconColor}>{flare.icon}</span>
         <span className="text-xs uppercase tracking-[0.2em] font-bold">
-          {partnerTierLabels[tier]}
+          {partnerTierLabels[tier]} Partners
         </span>
-      </div>
+      </h2>
       <div
         className={`h-px flex-1 bg-linear-to-l from-transparent ${flare.gradientStops}`}
       />
@@ -375,7 +250,10 @@ function TieredPartnerSections({
   return (
     <div className="space-y-16">
       {sections.map((section) => (
-        <section key={section.tier}>
+        <section
+          key={section.tier}
+          aria-labelledby={`partner-tier-${section.tier}`}
+        >
           <TierSectionHeader tier={section.tier} />
           <div className={tierGridCols[section.tier]}>
             {section.partners.map((partner) => {
@@ -399,11 +277,11 @@ function TieredPartnerSections({
 }
 
 function PartnersIndexPage() {
-  const search = normalizePartnersSearch(Route.useSearch())
+  const search = normalizePartnerDirectorySearch(Route.useSearch())
   const navigate = Route.useNavigate()
 
   const trackFiltersChanged = React.useCallback(
-    (nextSearch: PartnersSearch, change: 'status_changed') => {
+    (nextSearch: NormalizedPartnersSearch, change: 'status_changed') => {
       trackEvent('partner_filter_applied', {
         change,
         status_filter: nextSearch.status ?? null,
@@ -417,13 +295,13 @@ function PartnersIndexPage() {
     updates: PartnersSearchUpdates,
     change: 'status_changed',
   ) => {
-    const nextSearch = normalizePartnersSearch({
+    const nextSearch = normalizePartnerDirectorySearch({
       ...search,
       ...updates,
     })
 
     navigate({
-      search: () => nextSearch,
+      search: () => getPartnerDirectorySearch(nextSearch.status),
       replace: true,
     })
 
@@ -464,7 +342,7 @@ function PartnersIndexPage() {
           </p>
         </header>
 
-        <PartnersFilter
+        <PartnerStatusFilter
           selectedStatus={search.status}
           onStatusChange={(status) =>
             updateFilters({ status }, 'status_changed')
@@ -527,13 +405,9 @@ function PartnersIndexPage() {
             want to support open source development.
           </p>
           <a
-            href="mailto:partners@tanstack.com?subject=TanStack Partnership Inquiry"
+            href={PARTNER_INQUIRY_HREF}
             className="inline-block px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-            onClick={() => {
-              trackEvent('partner_inquiry_started', {
-                placement: 'partners_index_cta',
-              })
-            }}
+            onClick={() => trackPartnerInquiry('partners_index_cta')}
           >
             Get in Touch
           </a>

--- a/src/routes/partners.index.tsx
+++ b/src/routes/partners.index.tsx
@@ -16,53 +16,23 @@ import {
 } from '~/utils/partner-placement'
 import { usePartnerPlacementContext } from '~/utils/usePartnerPlacementContext'
 import { seo } from '~/utils/seo'
-import { Library } from '~/libraries'
 import { useState } from 'react'
 import * as React from 'react'
-import { ListFilter, X } from 'lucide-react'
+import { ListFilter } from 'lucide-react'
 import { Button } from '~/ui'
-import { startProject } from '~/libraries/start'
-import { routerProject } from '~/libraries/router'
-import { queryProject } from '~/libraries/query'
-import { tableProject } from '~/libraries/table'
-import { configProject } from '~/libraries/config'
-import { dbProject } from '~/libraries/db'
-import { aiProject } from '~/libraries/ai'
-import { formProject } from '~/libraries/form'
-import { pacerProject } from '~/libraries/pacer'
-import { rangerProject } from '~/libraries/ranger'
-import { storeProject } from '~/libraries/store'
-import { virtualProject } from '~/libraries/virtual'
-import { libraryIdSchema } from '~/utils/schemas'
 import { trackEvent, useTrackedImpression } from '~/utils/analytics'
+import { getPartnerWindowLabel } from '~/utils/partner-lifecycle'
 import * as v from 'valibot'
-
-const availableLibraries = [
-  startProject,
-  routerProject,
-  queryProject,
-  tableProject,
-  formProject,
-  virtualProject,
-  rangerProject,
-  storeProject,
-  pacerProject,
-  dbProject,
-  aiProject,
-  configProject,
-]
 
 const statusSchema = v.picklist(['active', 'inactive'])
 
 const searchSchema = v.object({
-  libraries: v.fallback(v.optional(v.array(libraryIdSchema)), undefined),
   status: v.fallback(v.optional(statusSchema, 'active'), 'active'),
 })
 
 type PartnersSearch = v.InferOutput<typeof searchSchema>
 type PartnersSearchUpdates = {
-  libraries?: Library['id'][] | undefined
-  status?: 'active' | 'inactive' | undefined
+  status: 'active' | 'inactive'
 }
 
 const defaultPartnersSearch = {
@@ -73,7 +43,6 @@ function normalizePartnersSearch(
   search: Partial<PartnersSearch>,
 ): PartnersSearch {
   return {
-    libraries: search.libraries?.length ? search.libraries : undefined,
     status: search.status ?? defaultPartnersSearch.status,
   }
 }
@@ -94,193 +63,127 @@ export const Route = createFileRoute('/partners/')({
 })
 
 interface FilterProps {
-  selectedLibraries: Library['id'][] | undefined
-  selectedStatus: 'active' | 'inactive' | undefined
-  onLibrariesChange: (libraries: Library['id'][] | undefined) => void
-  onStatusChange: (status: 'active' | 'inactive' | undefined) => void
-  onClearAll: () => void
+  selectedStatus: 'active' | 'inactive'
+  onStatusChange: (status: 'active' | 'inactive') => void
 }
 
-function PartnersFilter({
-  selectedLibraries,
-  selectedStatus,
-  onLibrariesChange,
-  onStatusChange,
-  onClearAll,
-}: FilterProps) {
+function PartnersFilter({ selectedStatus, onStatusChange }: FilterProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = React.useRef<HTMLButtonElement>(null)
 
-  const toggleLibrary = (libraryId: Library['id']) => {
-    if (!selectedLibraries) {
-      onLibrariesChange([libraryId])
-      return
-    }
-
-    if (selectedLibraries.includes(libraryId)) {
-      const newLibraries = selectedLibraries.filter((id) => id !== libraryId)
-      onLibrariesChange(newLibraries.length > 0 ? newLibraries : undefined)
-    } else {
-      onLibrariesChange([...selectedLibraries, libraryId])
-    }
-  }
-
-  const clearFilters = () => {
-    onClearAll()
+  const selectStatus = (status: 'active' | 'inactive') => {
+    onStatusChange(status)
     setIsOpen(false)
+    triggerRef.current?.focus()
   }
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Element
-      if (!target.closest('[data-filter-dropdown]')) {
+      if (
+        event.target instanceof Element &&
+        !event.target.closest('[data-filter-dropdown]')
+      ) {
         setIsOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false)
+        triggerRef.current?.focus()
       }
     }
 
     if (isOpen) {
       document.addEventListener('click', handleClickOutside)
-      return () => document.removeEventListener('click', handleClickOutside)
+      document.addEventListener('keydown', handleKeyDown)
+      return () => {
+        document.removeEventListener('click', handleClickOutside)
+        document.removeEventListener('keydown', handleKeyDown)
+      }
     }
   }, [isOpen])
 
-  const hasFilters =
-    (selectedLibraries && selectedLibraries.length > 0) || selectedStatus
-  const filterCount =
-    (selectedLibraries?.length || 0) + (selectedStatus ? 1 : 0)
+  const hasNonDefaultFilter = selectedStatus !== defaultPartnersSearch.status
 
   return (
     <div className="mb-6">
       <div className="flex items-center gap-3 flex-wrap">
         <div className="relative" data-filter-dropdown>
           <button
+            ref={triggerRef}
+            type="button"
             onClick={() => setIsOpen(!isOpen)}
+            aria-controls="partner-status-filter"
+            aria-expanded={isOpen}
+            aria-haspopup="dialog"
             className="inline-flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           >
             <ListFilter className="w-4 h-4" />
             Filter Partners
-            {hasFilters && (
+            {hasNonDefaultFilter && (
               <span className="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-0.5 rounded-full text-xs">
-                {filterCount}
+                1
               </span>
             )}
           </button>
 
           {isOpen && (
-            <div className="absolute top-full left-0 mt-2 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50">
+            <div
+              id="partner-status-filter"
+              role="dialog"
+              aria-label="Filter partners by status"
+              className="absolute top-full left-0 mt-2 w-[calc(100vw-2rem)] max-w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50"
+            >
               <div className="p-4">
                 <div className="flex items-center justify-between mb-4">
                   <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    Filter Options
+                    Partner Status
                   </span>
-                  {hasFilters && (
+                  {hasNonDefaultFilter && (
                     <button
-                      onClick={clearFilters}
+                      type="button"
+                      onClick={() => selectStatus('active')}
                       className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
                     >
-                      Clear All
+                      Reset
                     </button>
                   )}
                 </div>
 
-                <div className="mb-4">
-                  <label
-                    htmlFor="partner-status"
-                    className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2"
+                <div
+                  className="flex gap-2"
+                  role="group"
+                  aria-label="Partner status"
+                >
+                  <button
+                    type="button"
+                    aria-pressed={selectedStatus === 'active'}
+                    onClick={() => selectStatus('active')}
+                    className={`px-3 py-2 rounded-md text-sm transition-colors ${
+                      selectedStatus === 'active'
+                        ? 'bg-green-700 text-white'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
                   >
-                    Partner Status
-                  </label>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => {
-                        onStatusChange(
-                          selectedStatus === 'active' ? undefined : 'active',
-                        )
-                      }}
-                      className={`px-3 py-2 rounded-md text-sm transition-colors ${
-                        selectedStatus === 'active'
-                          ? 'bg-green-500 text-white'
-                          : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      Current Partners
-                    </button>
-                    <button
-                      onClick={() => {
-                        onStatusChange(
-                          selectedStatus === 'inactive'
-                            ? undefined
-                            : 'inactive',
-                        )
-                      }}
-                      className={`px-3 py-2 rounded-md text-sm transition-colors ${
-                        selectedStatus === 'inactive'
-                          ? 'bg-orange-500 text-white'
-                          : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      Previous Partners
-                    </button>
-                  </div>
-                </div>
-
-                <div>
-                  <label
-                    htmlFor="library-filter"
-                    className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2"
+                    Current Partners
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={selectedStatus === 'inactive'}
+                    onClick={() => selectStatus('inactive')}
+                    className={`px-3 py-2 rounded-md text-sm transition-colors ${
+                      selectedStatus === 'inactive'
+                        ? 'bg-orange-700 text-white'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
                   >
-                    Filter by Libraries
-                  </label>
-                  <div className="grid grid-cols-2 gap-2">
-                    {availableLibraries.map((library) => {
-                      const isSelected =
-                        selectedLibraries?.includes(library.id) || false
-
-                      const bgStyle = library.bgStyle ?? 'bg-gray-500'
-
-                      return (
-                        <button
-                          key={library.id}
-                          onClick={() => toggleLibrary(library.id)}
-                          className={`text-left px-3 py-2 rounded-md text-sm transition-colors ${
-                            isSelected
-                              ? `${bgStyle} text-white`
-                              : `${bgStyle}/30 text-gray-600 dark:text-gray-400 hover:${bgStyle}/40`
-                          }`}
-                        >
-                          {library.name}
-                        </button>
-                      )
-                    })}
-                  </div>
+                    Previous Partners
+                  </button>
                 </div>
               </div>
             </div>
           )}
         </div>
-
-        {hasFilters && (
-          <div className="flex flex-wrap gap-2">
-            {selectedLibraries?.map((libraryId) => {
-              const library = availableLibraries.find(
-                (lib) => lib.id === libraryId,
-              )
-              return (
-                <span
-                  key={libraryId}
-                  className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-md text-xs"
-                >
-                  {library?.name || libraryId}
-                  <button
-                    onClick={() => toggleLibrary(libraryId)}
-                    className="hover:bg-blue-200 dark:hover:bg-blue-800 rounded p-0.5 transition-colors"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              )
-            })}
-          </div>
-        )}
       </div>
     </div>
   )
@@ -292,12 +195,6 @@ function getFilteredPartners(search: PartnersSearch) {
   return partners.filter((partner) => {
     if (normalizedSearch.status && partner.status !== normalizedSearch.status) {
       return false
-    }
-
-    if (normalizedSearch.libraries && normalizedSearch.libraries.length > 0) {
-      return partner.libraries?.some((library) =>
-        normalizedSearch.libraries?.includes(library as Library['id']),
-      )
     }
 
     return true
@@ -373,10 +270,7 @@ function PartnerDirectoryCard({
     },
   })
 
-  const duration =
-    isShowingPrevious && partner.startDate && partner.endDate
-      ? `${partner.startDate} - ${partner.endDate}`
-      : null
+  const duration = isShowingPrevious ? getPartnerWindowLabel(partner) : null
 
   const layout = cardSizeLayout[size]
 
@@ -418,25 +312,11 @@ function PartnerDirectoryCard({
           {layout.showDescription && (
             <div className="text-sm flex-1">
               {isShowingPrevious ? (
-                <>
-                  {duration && (
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 text-center">
-                      {duration}
-                    </p>
-                  )}
-                  {partner.libraries && partner.libraries.length > 0 && (
-                    <div className="flex flex-wrap gap-1 justify-center">
-                      {partner.libraries.map((library) => (
-                        <span
-                          key={library}
-                          className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-700 rounded-md"
-                        >
-                          {library}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </>
+                duration && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 text-center">
+                    {duration}
+                  </p>
+                )
               ) : (
                 <p className="text-gray-700 dark:text-gray-300">
                   {partner.llmDescription}
@@ -523,16 +403,9 @@ function PartnersIndexPage() {
   const navigate = Route.useNavigate()
 
   const trackFiltersChanged = React.useCallback(
-    (
-      nextSearch: PartnersSearch,
-      change: 'libraries_changed' | 'status_changed' | 'cleared_all',
-    ) => {
+    (nextSearch: PartnersSearch, change: 'status_changed') => {
       trackEvent('partner_filter_applied', {
         change,
-        library_filters: nextSearch.libraries?.join(',') ?? '',
-        // Status defaults to 'active' even when the user hasn't touched it,
-        // so we can't distinguish "explicitly chose active" from "untouched".
-        // Pass the value as-is; doc explains this is a known limitation.
         status_filter: nextSearch.status ?? null,
         result_count: getFilteredPartners(nextSearch).length,
       })
@@ -542,7 +415,7 @@ function PartnersIndexPage() {
 
   const updateFilters = (
     updates: PartnersSearchUpdates,
-    change: 'libraries_changed' | 'status_changed',
+    change: 'status_changed',
   ) => {
     const nextSearch = normalizePartnersSearch({
       ...search,
@@ -559,8 +432,6 @@ function PartnersIndexPage() {
 
   const filteredPartners = getFilteredPartners(search)
 
-  const hasStatusFilter = search.status
-  const hasLibraryFilter = search.libraries && search.libraries.length > 0
   const hasResults = filteredPartners.length > 0
   const isShowingPrevious = search.status === 'inactive'
   const isShowingActive = search.status === 'active'
@@ -594,46 +465,21 @@ function PartnersIndexPage() {
         </header>
 
         <PartnersFilter
-          selectedLibraries={search.libraries}
           selectedStatus={search.status}
-          onLibrariesChange={(libraries) =>
-            updateFilters({ libraries }, 'libraries_changed')
-          }
           onStatusChange={(status) =>
             updateFilters({ status }, 'status_changed')
           }
-          onClearAll={() => {
-            navigate({ search: () => defaultPartnersSearch, replace: true })
-            trackFiltersChanged(defaultPartnersSearch, 'cleared_all')
-          }}
         />
 
         {hasResults ? (
           <div>
-            {(hasStatusFilter || hasLibraryFilter) && (
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6 text-center">
-                Showing {filteredPartners.length} partner
-                {filteredPartners.length === 1 ? '' : 's'}
-                {hasStatusFilter && (
-                  <span>
-                    {' '}
-                    ({search.status === 'inactive' ? 'previous' : 'current'})
-                  </span>
-                )}
-                {hasLibraryFilter && search.libraries && (
-                  <span>
-                    {' '}
-                    for{' '}
-                    {search.libraries.length === 1 ? 'library' : 'libraries'}:{' '}
-                    <span className="font-medium">
-                      {search.libraries.join(', ')}
-                    </span>
-                  </span>
-                )}
-              </p>
-            )}
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6 text-center">
+              Showing {filteredPartners.length} partner
+              {filteredPartners.length === 1 ? '' : 's'} (
+              {isShowingPrevious ? 'previous' : 'current'})
+            </p>
 
-            {isShowingActive && !hasLibraryFilter ? (
+            {isShowingActive ? (
               <TieredPartnerSections
                 partners={filteredPartners}
                 placementContext={placementContext}
@@ -654,21 +500,21 @@ function PartnersIndexPage() {
           </div>
         ) : (
           <div className="text-center text-gray-600 dark:text-gray-400">
-            {hasStatusFilter || hasLibraryFilter ? (
-              <div>
-                <p className="text-lg mb-4">
-                  No partners found for the selected filters.
-                </p>
+            <div>
+              <p className="text-lg mb-4">
+                No {isShowingPrevious ? 'previous' : 'current'} partners found.
+              </p>
+              {isShowingPrevious && (
                 <Button
                   size="sm"
-                  onClick={() => navigate({ search: {}, replace: true })}
+                  onClick={() =>
+                    updateFilters({ status: 'active' }, 'status_changed')
+                  }
                 >
-                  View All Partners
+                  View Current Partners
                 </Button>
-              </div>
-            ) : (
-              <p>No partners to display.</p>
-            )}
+              )}
+            </div>
           </div>
         )}
 

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -25,34 +25,52 @@ import {
 } from '~/components/Collapsible'
 import { CodeBlock } from '~/components/markdown/CodeBlock'
 import { seo } from '~/utils/seo'
-import { getPartnerById, PartnerImage } from '~/utils/partners'
+import {
+  PartnerImage,
+  partnerCategoryLabels,
+  partnerTierLabels,
+} from '~/utils/partners'
 import { getPartnerJsonLd } from '~/utils/partner-pages'
 import { trackEvent } from '~/utils/analytics'
+import { getRailwayPartnerPageModel } from '~/utils/railway-partner'
+import { SITE_URL } from '~/utils/site'
+import defaultOgImage from '~/images/og.png'
 
+const RAILWAY_PAGE_MODEL = getRailwayPartnerPageModel()
+const {
+  docsHash: TANSTACK_START_RAILWAY_DOCS_HASH,
+  docsResource: RAILWAY_DOCS_RESOURCE,
+  partner: RAILWAY_PARTNER,
+} = RAILWAY_PAGE_MODEL
 const RAILWAY_HREF =
   'https://railway.com/new?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
-const TANSTACK_START_RAILWAY_DOCS_PATH =
-  '/start/latest/docs/framework/react/guide/hosting'
-const TANSTACK_START_RAILWAY_DOCS_HASH = 'railway-official-partner'
-const RAILWAY_HOME_HREF =
-  'https://railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
-const RAILWAY_PRICING_HREF =
-  'https://railway.com/pricing?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
-
-const CONFIG_SNIPPET = `import { defineConfig } from 'vite'
-import { tanstackStart } from '@tanstack/react-start/plugin/vite'
-import { nitro } from 'nitro/vite'
-import viteReact from '@vitejs/plugin-react'
-
-export default defineConfig({
-  plugins: [tanstackStart(), nitro(), viteReact()],
-})
-`
-
-const DEPLOY_SNIPPET = `# From your TanStack Start app directory
-railway init
-railway up
-`
+const TANSTACK_START_RAILWAY_DOCS_PATH = RAILWAY_DOCS_RESOURCE.href
+const RAILWAY_CANONICAL_HREF =
+  RAILWAY_PARTNER.canonicalHref ?? RAILWAY_PARTNER.href
+const railwayHomeUrl = new URL(RAILWAY_CANONICAL_HREF)
+railwayHomeUrl.search = new URL(RAILWAY_PARTNER.href).search
+const RAILWAY_HOME_HREF = railwayHomeUrl.toString()
+const railwayPricingUrl = new URL('/pricing', RAILWAY_CANONICAL_HREF)
+railwayPricingUrl.search = railwayHomeUrl.search
+const RAILWAY_PRICING_HREF = railwayPricingUrl.toString()
+const RAILWAY_OG_IMAGE = new URL(defaultOgImage, SITE_URL).toString()
+const RAILWAY_TIER_LABEL = RAILWAY_PARTNER.tier
+  ? partnerTierLabels[RAILWAY_PARTNER.tier]
+  : undefined
+const RAILWAY_PARTNERSHIP_LABEL =
+  RAILWAY_PARTNER.status === 'active'
+    ? 'Current TanStack partner'
+    : 'Previous TanStack partner'
+const RAILWAY_PARTNER_TITLE_LABEL =
+  RAILWAY_PARTNER.status === 'active'
+    ? `${partnerTierLabels[RAILWAY_PARTNER.tier]} TanStack Partner`
+    : 'Previous TanStack Partner'
+const RAILWAY_PARTNER_BADGE_LABEL =
+  RAILWAY_PARTNER.status === 'active'
+    ? `${partnerTierLabels[RAILWAY_PARTNER.tier]} Partner`
+    : RAILWAY_TIER_LABEL
+      ? `Previous ${RAILWAY_TIER_LABEL} Partner`
+      : 'Previous Partner'
 
 type FeatureIcon = React.ComponentType<{ className?: string }>
 
@@ -102,18 +120,16 @@ const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
 const steps: Array<{ num: string; title: string; code: string }> = [
   {
     num: '01',
-    title: 'Create your TanStack app',
-    code: 'npx @tanstack/cli@latest create',
+    title: 'Enter your app',
+    code: 'cd my-tanstack-app',
   },
-  { num: '02', title: 'Install Nitro', code: 'npm install nitro' },
-  { num: '03', title: 'Add Nitro to Vite', code: 'nitro()' },
   {
-    num: '04',
+    num: '02',
     title: 'Install the Railway CLI',
     code: 'npm install -g @railway/cli',
   },
-  { num: '05', title: 'Authenticate', code: 'railway login' },
-  { num: '06', title: 'Deploy', code: 'railway init && railway up' },
+  { num: '03', title: 'Authenticate', code: 'railway login' },
+  { num: '04', title: 'Deploy', code: 'railway init && railway up' },
 ]
 
 const pricing: Array<{
@@ -137,7 +153,7 @@ const pricing: Array<{
   {
     plan: 'Hobby',
     price: '$5',
-    note: 'month · includes $5 of usage',
+    note: 'month, includes $5 of usage',
     features: [
       'Up to 48 vCPU / 48 GB RAM',
       'Up to 5 GB storage',
@@ -148,7 +164,7 @@ const pricing: Array<{
   {
     plan: 'Pro',
     price: '$20',
-    note: 'min/month · includes $20 credits',
+    note: 'min/month, includes $20 credits',
     features: [
       'Up to 1,000 vCPU / 1 TB RAM',
       'Up to 1 TB storage',
@@ -173,8 +189,8 @@ const pricing: Array<{
 ]
 
 const meteredPricing: Array<[string, string]> = [
-  ['Memory', '$0.00000386 / GB·sec'],
-  ['CPU', '$0.00000772 / vCPU·sec'],
+  ['Memory', '$0.00000386 / GB-sec'],
+  ['CPU', '$0.00000772 / vCPU-sec'],
   ['Egress', '$0.05 / GB'],
 ]
 
@@ -200,11 +216,11 @@ const testimonials: Array<{ quote: string; author: string; role: string }> = [
 const faqs: Array<{ q: string; a: string }> = [
   {
     q: 'Does Railway support TanStack Start SSR and streaming?',
-    a: 'Yes. TanStack Start builds a Node server for SSR, streaming, server functions, and static assets. Follow the Nitro setup in the Start hosting docs, then deploy that Node service to Railway.',
+    a: 'Yes. Create a Railway-ready TanStack Start app with the TanStack CLI, or add the Nitro setup from the Start hosting guide to an existing app.',
   },
   {
     q: 'Can I run a database alongside my TanStack app?',
-    a: "Absolutely. Railway lets you provision Postgres, MySQL, Redis, or MongoDB in the same project as your app. They communicate over Railway's private network at up to 100 Gbps — no VPC setup needed.",
+    a: "Absolutely. Railway lets you provision Postgres, MySQL, Redis, or MongoDB in the same project as your app. They communicate over Railway's private network at up to 100 Gbps, with no VPC setup needed.",
   },
   {
     q: 'How does Railway pricing actually work?',
@@ -212,7 +228,7 @@ const faqs: Array<{ q: string; a: string }> = [
   },
   {
     q: 'What makes Railway different from Vercel or Render?',
-    a: 'Railway is a full-stack cloud — not just a frontend host. You can run your TanStack app server, managed databases, background workers, cron jobs, and private networking all in one project. Configurable usage alerts and hard limits help keep resource spending under control.',
+    a: 'Railway is a full-stack cloud. You can run your TanStack app server, managed databases, background workers, cron jobs, and private networking in one project. Configurable usage alerts and hard limits help keep resource spending under control.',
   },
   {
     q: 'Does Railway have PR preview environments?',
@@ -224,7 +240,7 @@ const faqs: Array<{ q: string; a: string }> = [
   },
 ]
 
-const PAGE_TITLE = 'Deploy TanStack to Railway — Official Gold Partner'
+const PAGE_TITLE = `Deploy TanStack to ${RAILWAY_PARTNER.name} | ${RAILWAY_PARTNER_TITLE_LABEL}`
 const PAGE_DESCRIPTION =
   'Railway gives TanStack teams a single place to run app services, databases, and supporting infrastructure. Nitro-powered TanStack Start deploys, optional PR preview environments, up to 100 Gbps private networking, and hard spending limits. Resource usage is billed by the second.'
 
@@ -244,33 +260,24 @@ function getFaqJsonLd() {
 }
 
 export const Route = createFileRoute('/partners/railway')({
-  head: () => {
-    const partner = getPartnerById('railway')
-
-    return {
-      meta: seo({
-        title: PAGE_TITLE,
-        description: PAGE_DESCRIPTION,
-        keywords:
-          'deploy tanstack to railway, tanstack start railway, tanstack router railway, railway hosting, tanstack deployment, railway gold sponsor',
-        image: 'https://tanstack.com/og.png',
-      }),
-      scripts: [
-        ...(partner
-          ? [
-              {
-                type: 'application/ld+json',
-                children: JSON.stringify(getPartnerJsonLd(partner)),
-              },
-            ]
-          : []),
-        {
-          type: 'application/ld+json',
-          children: JSON.stringify(getFaqJsonLd()),
-        },
-      ],
-    }
-  },
+  head: () => ({
+    meta: seo({
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      keywords: `deploy tanstack to railway, tanstack start railway, tanstack router railway, railway hosting, tanstack deployment, railway tanstack partner`,
+      image: RAILWAY_OG_IMAGE,
+    }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getPartnerJsonLd(RAILWAY_PARTNER)),
+      },
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getFaqJsonLd()),
+      },
+    ],
+  }),
   component: RailwayPartnerPage,
 })
 
@@ -284,20 +291,20 @@ function CheckBadge() {
 
 function trackRailwayClick() {
   trackEvent('partner_clicked', {
-    partner_id: 'railway',
+    partner_id: RAILWAY_PARTNER.id,
     placement: 'detail',
     destination: 'external',
-    destination_host: 'railway.com',
-    partner_tier: 'gold',
+    destination_host: new URL(RAILWAY_CANONICAL_HREF).host,
+    partner_tier: RAILWAY_PARTNER.tier,
   })
 }
 
 function trackTanStackDocsClick() {
   trackEvent('partner_clicked', {
-    partner_id: 'railway',
+    partner_id: RAILWAY_PARTNER.id,
     placement: 'detail',
     destination: 'internal_resource',
-    partner_tier: 'gold',
+    partner_tier: RAILWAY_PARTNER.tier,
   })
 }
 
@@ -322,13 +329,11 @@ function RailwayPartnerPage() {
 
   React.useEffect(() => {
     trackEvent('partner_viewed', {
-      partner_id: 'railway',
+      partner_id: RAILWAY_PARTNER.id,
       placement: 'detail',
-      partner_tier: 'gold',
+      partner_tier: RAILWAY_PARTNER.tier,
     })
   }, [])
-
-  const partner = getPartnerById('railway')
 
   return (
     <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
@@ -341,29 +346,36 @@ function RailwayPartnerPage() {
             Partners
           </Link>
           <span>/</span>
-          <span className="text-gray-900 dark:text-white">Railway</span>
+          <span className="text-gray-900 dark:text-white">
+            {RAILWAY_PARTNER.name}
+          </span>
         </nav>
 
         {/* Hero */}
         <section className="border-b border-gray-200 pb-10 pt-10 dark:border-gray-800">
           <div className="mb-5 flex items-center gap-4">
-            {partner ? (
-              <div className="flex h-12 w-44 items-center justify-start">
-                <PartnerImage
-                  config={partner.image}
-                  alt="Railway"
-                  className="max-h-10 w-auto"
-                />
-              </div>
-            ) : null}
+            <div className="flex h-12 w-44 items-center justify-start">
+              <PartnerImage
+                config={RAILWAY_PARTNER.image}
+                alt={RAILWAY_PARTNER.name}
+                className="max-h-10 w-auto"
+              />
+            </div>
             <div>
               <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400">
-                Gold Sponsor · Deployment & Hosting
+                {RAILWAY_PARTNER_BADGE_LABEL} ·{' '}
+                {partnerCategoryLabels[RAILWAY_PARTNER.category]}
               </span>
               <div className="mt-1 flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${
+                    RAILWAY_PARTNER.status === 'active'
+                      ? 'bg-emerald-500'
+                      : 'bg-gray-400'
+                  }`}
+                />
                 <span className="text-xs text-gray-500 dark:text-gray-400">
-                  Railway V3 — faster and cheaper
+                  {RAILWAY_PARTNERSHIP_LABEL}
                 </span>
               </div>
             </div>
@@ -384,7 +396,7 @@ function RailwayPartnerPage() {
 
           <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
             "Services that took 1 week to configure elsewhere take 1 day to spin
-            up in Railway." — Daniel Lobaton, CTO at G2X
+            up in Railway." - Daniel Lobaton, CTO at G2X
           </p>
 
           <div className="mt-7 flex flex-wrap gap-3">
@@ -454,13 +466,22 @@ function RailwayPartnerPage() {
           className="border-t border-gray-200 py-10 dark:border-gray-800"
         >
           <h2 className="text-2xl font-black tracking-tight md:text-3xl">
-            Deploy from the Railway CLI in 6 steps
+            Create a Railway-ready app
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
-            Railway runs TanStack Start as a standard Node service. Add Nitro to
-            your Vite config, then deploy from GitHub or the Railway CLI.
+            The TanStack CLI adds the Railway deployment setup while it creates
+            your app.
           </p>
 
+          <div className="mt-6">
+            <RailwayCodeExample
+              code={RAILWAY_PAGE_MODEL.create.command}
+              lang="bash"
+              title="terminal"
+            />
+          </div>
+
+          <h3 className="mt-8 text-lg font-bold">Deploy the app</h3>
           <div className="mt-6 flex flex-col gap-3">
             {steps.map(({ num, title, code }) => (
               <Card
@@ -478,19 +499,6 @@ function RailwayPartnerPage() {
                 </div>
               </Card>
             ))}
-          </div>
-
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
-            <RailwayCodeExample
-              code={CONFIG_SNIPPET}
-              lang="ts"
-              title="vite.config.ts"
-            />
-            <RailwayCodeExample
-              code={DEPLOY_SNIPPET}
-              lang="bash"
-              title="terminal"
-            />
           </div>
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
@@ -517,27 +525,27 @@ function RailwayPartnerPage() {
           </div>
         </section>
 
-        {/* TanStack Start deployment path */}
+        {/* Existing TanStack Start apps */}
         <section className="border-t border-gray-200 py-10 dark:border-gray-800">
           <h2 className="text-2xl font-black tracking-tight md:text-3xl">
-            TanStack Start on Railway
+            Add Railway to an existing app
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
-            Build TanStack Start as a Nitro-powered Node server, then deploy the
-            generated server and static assets as a Railway service. SSR,
-            streaming, and server functions run in the same Node process.
+            Follow the TanStack Start hosting guide to install Nitro, configure
+            Vite, and add the Node start command Railway needs.
           </p>
 
-          <Button
-            as={Link}
-            to={TANSTACK_START_RAILWAY_DOCS_PATH}
-            hash={TANSTACK_START_RAILWAY_DOCS_HASH}
-            onClick={trackTanStackDocsClick}
-            variant="ghost"
-            className="mt-5"
-          >
-            Read the deployment guide
-          </Button>
+          <div className="mt-5">
+            <Button
+              as={Link}
+              to={TANSTACK_START_RAILWAY_DOCS_PATH}
+              hash={TANSTACK_START_RAILWAY_DOCS_HASH}
+              onClick={trackTanStackDocsClick}
+              variant="ghost"
+            >
+              Open the Railway hosting guide
+            </Button>
+          </div>
         </section>
 
         {/* Pricing */}
@@ -667,7 +675,7 @@ function RailwayPartnerPage() {
             </Button>
             <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
               <DollarSign className="h-3.5 w-3.5" />
-              Per-second billing · no credit card required
+              Per-second billing, no credit card required
             </span>
           </div>
         </section>
@@ -716,7 +724,7 @@ function RailwayPartnerPage() {
         {/* CTA */}
         <section className="mt-6 rounded-2xl bg-gray-950 px-6 py-10 text-center md:px-10 md:py-12 dark:bg-gray-900">
           <div className="inline-block rounded-full bg-white/5 px-3 py-1 text-[11px] text-gray-400">
-            Railway V3 — now faster and cheaper
+            Railway V3 is faster and cheaper
           </div>
           <h2 className="mt-4 text-2xl font-black tracking-tight text-white md:text-3xl">
             Ready to ship TanStack peacefully?
@@ -756,7 +764,9 @@ function RailwayPartnerPage() {
         </section>
 
         <p className="mt-6 text-center text-xs text-gray-500 dark:text-gray-400">
-          Railway is a Gold-tier TanStack sponsor.{' '}
+          {RAILWAY_PARTNER.status === 'active'
+            ? `${RAILWAY_PARTNER.name} is a ${RAILWAY_TIER_LABEL} TanStack partner. `
+            : `${RAILWAY_PARTNER.name} is a previous TanStack partner. `}
           <Link
             to="/partners"
             className="underline decoration-dotted underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"

--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -31,8 +31,9 @@ import { trackEvent } from '~/utils/analytics'
 
 const RAILWAY_HREF =
   'https://railway.com/new?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
-const RAILWAY_DOCS_HREF =
-  'https://docs.railway.com/guides/tanstack-start?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
+const TANSTACK_START_RAILWAY_DOCS_PATH =
+  '/start/latest/docs/framework/react/guide/hosting'
+const TANSTACK_START_RAILWAY_DOCS_HASH = 'railway-official-partner'
 const RAILWAY_HOME_HREF =
   'https://railway.com/?utm_medium=sponsor&utm_source=tanstack&utm_campaign=partner-page'
 const RAILWAY_PRICING_HREF =
@@ -64,27 +65,27 @@ const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
   {
     Icon: GitPullRequest,
     title: 'Live PR previews',
-    desc: 'Every pull request spins up its own environment. Test routing, data, and server logic before merging.',
+    desc: 'Enable PR Environments on a GitHub-connected project to spin up isolated previews for eligible pull requests.',
   },
   {
     Icon: LineChart,
     title: 'Logs, metrics, and alerts',
-    desc: 'Observability is built in. Pipe custom alerts to Slack, Discord, or email without a third-party agent.',
+    desc: 'Logs and metrics are built in. Pro workspaces can configure Monitors that notify Slack, Discord, or email.',
   },
   {
     Icon: Network,
-    title: '100 Gbps private networking',
-    desc: 'Services in a project talk over private IPs at 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled for you.',
+    title: 'Up to 100 Gbps private networking',
+    desc: 'Services in a project talk over private IPs at up to 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled for you.',
   },
   {
     Icon: Undo2,
-    title: 'One-click rollbacks',
-    desc: 'Every deploy is versioned. Roll back to a previous deployment instantly when something breaks.',
+    title: 'Retained deployment versions',
+    desc: 'Redeploy an earlier version while its image is retained. Retention ranges from 24 hours to 360 hours by plan.',
   },
   {
     Icon: ShieldCheck,
     title: 'Hard spending limits',
-    desc: 'Set a hard cap on what a project can spend. Billing is per-second, so you only pay for actual compute.',
+    desc: 'Set a hard limit for workspace compute usage. Railway sends alerts as you approach it and stops workloads at the limit.',
   },
   {
     Icon: Globe,
@@ -106,7 +107,13 @@ const steps: Array<{ num: string; title: string; code: string }> = [
   },
   { num: '02', title: 'Install Nitro', code: 'npm install nitro' },
   { num: '03', title: 'Add Nitro to Vite', code: 'nitro()' },
-  { num: '04', title: 'Deploy', code: 'railway init && railway up' },
+  {
+    num: '04',
+    title: 'Install the Railway CLI',
+    code: 'npm install -g @railway/cli',
+  },
+  { num: '05', title: 'Authenticate', code: 'railway login' },
+  { num: '06', title: 'Deploy', code: 'railway init && railway up' },
 ]
 
 const pricing: Array<{
@@ -119,7 +126,7 @@ const pricing: Array<{
   {
     plan: 'Free',
     price: '$0',
-    note: '30-day trial with $5 credits',
+    note: '30-day trial, then $1 monthly credit',
     features: [
       'Up to 1 vCPU / 0.5 GB RAM',
       '0.5 GB volume storage',
@@ -130,7 +137,7 @@ const pricing: Array<{
   {
     plan: 'Hobby',
     price: '$5',
-    note: 'min/month · includes $5 credits',
+    note: 'month · includes $5 of usage',
     features: [
       'Up to 48 vCPU / 48 GB RAM',
       'Up to 5 GB storage',
@@ -166,8 +173,8 @@ const pricing: Array<{
 ]
 
 const meteredPricing: Array<[string, string]> = [
-  ['Memory', '$0.000004 / GB·sec'],
-  ['CPU', '$0.000008 / vCPU·sec'],
+  ['Memory', '$0.00000386 / GB·sec'],
+  ['CPU', '$0.00000772 / vCPU·sec'],
   ['Egress', '$0.05 / GB'],
 ]
 
@@ -179,7 +186,7 @@ const testimonials: Array<{ quote: string; author: string; role: string }> = [
   },
   {
     quote:
-      "I've moved $4.5k/month from AWS and $1k/month from Heroku. My Railway bill is about $300/month.",
+      "I've moved $4.5k per month from AWS and $1k per month from Heroku […] and my railway bill is like $300 per month.",
     author: 'John Nunemaker',
     role: 'Founder at BoxOutSports',
   },
@@ -190,40 +197,6 @@ const testimonials: Array<{ quote: string; author: string; role: string }> = [
   },
 ]
 
-const libraries = [
-  'Start',
-  'Router',
-  'Query',
-  'Table',
-  'Form',
-  'DB',
-  'AI',
-  'Virtual',
-  'Pacer',
-  'Store',
-  'Devtools',
-  'CLI',
-]
-
-const libDetails: Array<{ label: string; desc: string }> = [
-  {
-    label: 'TanStack Start',
-    desc: 'Full SSR, streaming, and server functions run on Railway as a standard Node service built through Nitro.',
-  },
-  {
-    label: 'TanStack Router',
-    desc: 'File-based routing apps deploy in SSR and SPA modes. PR previews mean every route change gets a live test environment.',
-  },
-  {
-    label: 'TanStack Query',
-    desc: "Pair with Railway-managed Postgres or Redis. Private networking keeps your server queries inside Railway's infrastructure.",
-  },
-  {
-    label: 'TanStack DB',
-    desc: "Railway's managed databases integrate with TanStack DB's sync engine via 100 Gbps private networking.",
-  },
-]
-
 const faqs: Array<{ q: string; a: string }> = [
   {
     q: 'Does Railway support TanStack Start SSR and streaming?',
@@ -231,19 +204,19 @@ const faqs: Array<{ q: string; a: string }> = [
   },
   {
     q: 'Can I run a database alongside my TanStack app?',
-    a: "Absolutely. Railway lets you provision Postgres, MySQL, Redis, or MongoDB in the same project as your app. They communicate over Railway's 100 Gbps private network — no VPC setup needed.",
+    a: "Absolutely. Railway lets you provision Postgres, MySQL, Redis, or MongoDB in the same project as your app. They communicate over Railway's private network at up to 100 Gbps — no VPC setup needed.",
   },
   {
     q: 'How does Railway pricing actually work?',
-    a: 'Railway charges by the second based on actual CPU and memory usage — not provisioned box sizes. The Hobby plan starts at $5/month (which includes $5 of credits). Most hobby TanStack projects run for free or under $5/month.',
+    a: 'Railway bills resource usage by the second. After the 30-day trial, the Free plan costs $0 and includes $1 of monthly resource credit. Hobby costs $5/month and includes $5 of monthly usage; you pay the difference if usage exceeds $5.',
   },
   {
     q: 'What makes Railway different from Vercel or Render?',
-    a: 'Railway is a full-stack cloud — not just a frontend host. You can run your TanStack app server, managed databases, background workers, cron jobs, and private networking all in one project. Railway also has hard spending limits, which no other major cloud provider offers.',
+    a: 'Railway is a full-stack cloud — not just a frontend host. You can run your TanStack app server, managed databases, background workers, cron jobs, and private networking all in one project. Configurable usage alerts and hard limits help keep resource spending under control.',
   },
   {
     q: 'Does Railway have PR preview environments?',
-    a: 'Yes — every pull request automatically gets its own live preview environment. For TanStack teams, this means you can test routing changes, data fetching behavior, and server logic before merging.',
+    a: 'Yes. Connect the project to GitHub and enable PR Environments in project settings. Railway then creates an isolated preview for eligible pull requests and removes it after the pull request is merged or closed.',
   },
   {
     q: 'Can I migrate an existing TanStack app to Railway?',
@@ -253,7 +226,7 @@ const faqs: Array<{ q: string; a: string }> = [
 
 const PAGE_TITLE = 'Deploy TanStack to Railway — Official Gold Partner'
 const PAGE_DESCRIPTION =
-  'Railway gives TanStack teams a single place to run app services, databases, and supporting infrastructure. Nitro-powered TanStack Start deploys, live PR previews, 100 Gbps private networking, and hard spending limits. Pay per second for the compute you actually use.'
+  'Railway gives TanStack teams a single place to run app services, databases, and supporting infrastructure. Nitro-powered TanStack Start deploys, optional PR preview environments, up to 100 Gbps private networking, and hard spending limits. Resource usage is billed by the second.'
 
 function getFaqJsonLd() {
   return {
@@ -315,6 +288,16 @@ function trackRailwayClick() {
     placement: 'detail',
     destination: 'external',
     destination_host: 'railway.com',
+    partner_tier: 'gold',
+  })
+}
+
+function trackTanStackDocsClick() {
+  trackEvent('partner_clicked', {
+    partner_id: 'railway',
+    placement: 'detail',
+    destination: 'internal_resource',
+    partner_tier: 'gold',
   })
 }
 
@@ -341,6 +324,7 @@ function RailwayPartnerPage() {
     trackEvent('partner_viewed', {
       partner_id: 'railway',
       placement: 'detail',
+      partner_tier: 'gold',
     })
   }, [])
 
@@ -394,8 +378,8 @@ function RailwayPartnerPage() {
           <p className="mt-5 max-w-xl text-base leading-relaxed text-gray-600 dark:text-gray-300 md:text-lg">
             Railway gives TanStack teams a single place to run app services,
             databases, and supporting infrastructure. Deploy a TanStack Start
-            app from GitHub or the CLI — and only pay per-second for the compute
-            you actually use.
+            app from GitHub or the CLI, with resource usage billed by the
+            second.
           </p>
 
           <p className="mt-3 max-w-xl text-sm italic leading-relaxed text-gray-500 dark:text-gray-400">
@@ -413,7 +397,7 @@ function RailwayPartnerPage() {
               size="lg"
               className="bg-gray-950 text-white border-gray-950 hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:border-white dark:hover:bg-gray-200"
             >
-              Deploy free in 2 minutes
+              Start free on Railway
               <ArrowUpRight className="h-4 w-4" />
             </Button>
             <Button as="a" href="#how-it-works" variant="ghost" size="lg">
@@ -429,8 +413,8 @@ function RailwayPartnerPage() {
         <section className="grid grid-cols-2 gap-x-8 gap-y-5 border-b border-gray-200 py-7 sm:flex sm:flex-wrap sm:gap-10 dark:border-gray-800">
           {[
             ['2M+', 'Developers on Railway'],
-            ['< 2 min', 'Time to first deploy'],
-            ['100 Gbps', 'Private networking'],
+            ['Per-second', 'Resource billing'],
+            ['100 Gbps', 'Private network maximum'],
             ['$0', 'To get started'],
           ].map(([value, label]) => (
             <div key={label}>
@@ -470,7 +454,7 @@ function RailwayPartnerPage() {
           className="border-t border-gray-200 py-10 dark:border-gray-800"
         >
           <h2 className="text-2xl font-black tracking-tight md:text-3xl">
-            From zero to deployed in 4 steps
+            Deploy from the Railway CLI in 6 steps
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
             Railway runs TanStack Start as a standard Node service. Add Nitro to
@@ -522,11 +506,10 @@ function RailwayPartnerPage() {
               <ArrowUpRight className="h-4 w-4" />
             </Button>
             <Button
-              as="a"
-              href={RAILWAY_DOCS_HREF}
-              target="_blank"
-              rel="noreferrer"
-              onClick={trackRailwayClick}
+              as={Link}
+              to={TANSTACK_START_RAILWAY_DOCS_PATH}
+              hash={TANSTACK_START_RAILWAY_DOCS_HASH}
+              onClick={trackTanStackDocsClick}
               variant="ghost"
             >
               Read the deployment guide
@@ -534,40 +517,27 @@ function RailwayPartnerPage() {
           </div>
         </section>
 
-        {/* Library fit */}
+        {/* TanStack Start deployment path */}
         <section className="border-t border-gray-200 py-10 dark:border-gray-800">
           <h2 className="text-2xl font-black tracking-tight md:text-3xl">
-            Works with every TanStack library
+            TanStack Start on Railway
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
-            From full-stack apps with TanStack Start to lightweight React apps
-            using Router and Query — Railway deploys them all.
+            Build TanStack Start as a Nitro-powered Node server, then deploy the
+            generated server and static assets as a Railway service. SSR,
+            streaming, and server functions run in the same Node process.
           </p>
 
-          <div className="mt-5 flex flex-wrap gap-2">
-            {libraries.map((lib) => (
-              <span
-                key={lib}
-                className="rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium dark:border-gray-800 dark:bg-gray-900"
-              >
-                {lib}
-              </span>
-            ))}
-          </div>
-
-          <div className="mt-6 grid gap-3 sm:grid-cols-2">
-            {libDetails.map(({ label, desc }) => (
-              <Card key={label} className="p-4 shadow-none">
-                <div className="flex items-start gap-2">
-                  <CheckBadge />
-                  <span className="text-sm font-semibold">{label}</span>
-                </div>
-                <p className="mt-2 text-xs leading-relaxed text-gray-600 dark:text-gray-400">
-                  {desc}
-                </p>
-              </Card>
-            ))}
-          </div>
+          <Button
+            as={Link}
+            to={TANSTACK_START_RAILWAY_DOCS_PATH}
+            hash={TANSTACK_START_RAILWAY_DOCS_HASH}
+            onClick={trackTanStackDocsClick}
+            variant="ghost"
+            className="mt-5"
+          >
+            Read the deployment guide
+          </Button>
         </section>
 
         {/* Pricing */}
@@ -576,9 +546,9 @@ function RailwayPartnerPage() {
             Pricing that scales with you
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-relaxed text-gray-600 dark:text-gray-300 md:text-base">
-            Railway charges by the second based on actual usage — not
-            provisioned box sizes. Most TanStack hobby projects run free or
-            under $5/month.
+            Railway bills resource usage by the second. After the trial, Free
+            includes $1 of monthly resource credit. Hobby costs $5/month and
+            includes $5 of monthly usage.
           </p>
 
           <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -752,8 +722,8 @@ function RailwayPartnerPage() {
             Ready to ship TanStack peacefully?
           </h2>
           <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-gray-400">
-            No credit card required. No surprise bills. Pay only for what you
-            use.
+            No credit card required to start. Set a hard usage limit to keep
+            resource spending under control.
           </p>
           <p className="mt-1 text-xs text-gray-500">
             Most customers save ~40% by switching to Railway.
@@ -773,11 +743,10 @@ function RailwayPartnerPage() {
               <ArrowUpRight className="h-4 w-4" />
             </Button>
             <Button
-              as="a"
-              href={RAILWAY_DOCS_HREF}
-              target="_blank"
-              rel="noreferrer"
-              onClick={trackRailwayClick}
+              as={Link}
+              to={TANSTACK_START_RAILWAY_DOCS_PATH}
+              hash={TANSTACK_START_RAILWAY_DOCS_HASH}
+              onClick={trackTanStackDocsClick}
               size="lg"
               className="bg-transparent text-white border-gray-700 hover:bg-white/5"
             >

--- a/src/utils/analytics/events.ts
+++ b/src/utils/analytics/events.ts
@@ -26,6 +26,7 @@ export type PartnerPlacement =
   | 'ecosystem_game'
   | 'partners_index_cta'
   | 'library_callout'
+  | 'navbar'
 
 export type PartnerClickDestination =
   | 'external'

--- a/src/utils/analytics/events.ts
+++ b/src/utils/analytics/events.ts
@@ -27,14 +27,14 @@ export type PartnerPlacement =
   | 'partners_index_cta'
   | 'library_callout'
 
-export type PartnerClickDestination = 'external' | 'internal_detail'
+export type PartnerClickDestination =
+  | 'external'
+  | 'internal_detail'
+  | 'internal_resource'
 
 export type PartnerTierValue = 'gold' | 'silver' | 'bronze'
 
-export type PartnerFilterChange =
-  | 'libraries_changed'
-  | 'status_changed'
-  | 'cleared_all'
+export type PartnerFilterChange = 'status_changed'
 
 export type BuilderMode = 'lucky' | 'confident' | 'none'
 
@@ -106,7 +106,6 @@ export type AnalyticsEvent =
       name: 'partner_filter_applied'
       props: {
         change: PartnerFilterChange
-        library_filters: string
         status_filter: string | null
         result_count: number
       }

--- a/src/utils/application-starter.ts
+++ b/src/utils/application-starter.ts
@@ -238,7 +238,7 @@ const sharedHomeAndBuilderPrompts: Array<ContextSuggestion> = [
   {
     label: 'SaaS dashboard',
     input:
-      'Build a SaaS dashboard app with auth, billing-ready structure, Postgres, nested routes, data tables, filters, forms, monitoring, and charts-ready data fetching.',
+      'Build a SaaS dashboard app with auth, billing-ready structure, Postgres, nested routes, data tables, filters, forms, and charts-ready data fetching.',
   },
   {
     label: 'Build a shop',
@@ -276,12 +276,12 @@ const quickPrompts: Record<
     {
       label: 'Full-stack app',
       input:
-        'Build a full-stack TanStack Start app with auth, database access, forms, and monitoring.',
+        'Build a full-stack TanStack Start app with auth, database access, and forms.',
     },
     {
       label: 'Auth + database',
       input:
-        'Build a product app with authentication, Postgres, forms, and Sentry. Use pnpm.',
+        'Build a product app with authentication, Postgres, and forms. Use pnpm.',
     },
     {
       label: 'Migrate from Next.js',
@@ -650,7 +650,7 @@ function buildRecipe(
     case 'migration': {
       recipe.target = routerOnly ? 'router' : 'start'
       recipe.template = 'saas'
-      addStarterFeatures(recipe, 'better-auth', 'neon', 'drizzle', 'sentry')
+      addStarterFeatures(recipe, 'better-auth', 'prisma')
       break
     }
     case 'saas': {
@@ -658,10 +658,8 @@ function buildRecipe(
       addStarterFeatures(
         recipe,
         'better-auth',
-        'neon',
-        'drizzle',
+        'prisma',
         'form',
-        'sentry',
         'shadcn',
         'tanstack-query',
       )
@@ -674,7 +672,7 @@ function buildRecipe(
     }
     case 'content': {
       recipe.template = 'blog'
-      addStarterFeatures(recipe, 'strapi', 'tanstack-query')
+      addStarterFeatures(recipe, 'tanstack-query')
       break
     }
     case 'api': {
@@ -689,7 +687,7 @@ function buildRecipe(
     }
     case 'realtime': {
       recipe.template = 'realtime'
-      addStarterFeatures(recipe, 'convex', 'tanstack-query')
+      addStarterFeatures(recipe, 'db', 'tanstack-query')
       break
     }
     case 'ecommerce': {
@@ -727,10 +725,10 @@ function buildRecipe(
     ),
   )
 
-  applyPartnerOverrides(recipe, {
-    partnerIds: [...selectedPartnerIds, ...inferredPartnerIds],
-  })
-  applyInputOverrides(input, recipe)
+  const partnerIds = [...selectedPartnerIds, ...inferredPartnerIds]
+
+  applyPartnerOverrides(recipe, { partnerIds })
+  applyInputOverrides(input, recipe, { partnerIds })
   normalizeRecipe(recipe)
 
   return recipe
@@ -780,14 +778,41 @@ function applyPartnerOverrides(
 
   if (partnerIds.has('prisma')) {
     replaceExclusive(recipe, ['convex', 'drizzle', 'prisma'], 'prisma')
-    addStarterFeatures(recipe, 'neon')
   }
 }
 
 function hasHostedDatabaseConstraint(input: string) {
-  return /\b(do not use|don't use|avoid|without)\s+(?:a\s+)?hosted database\b/i.test(
+  return /\b(do not use|don't use|avoid|without|no)\s+(?:a\s+|any\s+)?hosted database\b/i.test(
     input,
   )
+}
+
+function hasDatabaseConstraint(input: string) {
+  return /\b(do not use|don't use|avoid|without|no)\s+(?:a\s+|any\s+)?(?:database|db)\b/i.test(
+    input,
+  )
+}
+
+function hasTanStackDbConstraint(input: string) {
+  return /\b(do not use|don't use|avoid|without|no)\s+(?:the\s+)?tanstack db\b/i.test(
+    input,
+  )
+}
+
+function removeNegativeDatabaseMentions(input: string) {
+  return input
+    .replace(
+      /\b(?:do not use|don't use|avoid|without|no)\s+(?:a\s+|any\s+)?hosted database\b/gi,
+      '',
+    )
+    .replace(
+      /\b(?:do not use|don't use|avoid|without|no)\s+(?:the\s+)?tanstack db\b/gi,
+      '',
+    )
+    .replace(
+      /\b(?:do not use|don't use|avoid|without|no)\s+(?:a\s+|any\s+)?(?:database|db)\b/gi,
+      '',
+    )
 }
 
 function hasAuthOverlapConstraint(input: string) {
@@ -803,45 +828,126 @@ function hasNegativeFeatureConstraint(input: string, feature: string) {
   ).test(input)
 }
 
-function applyInputOverrides(input: string, recipe: ApplicationStarterRecipe) {
+function applyInputOverrides(
+  input: string,
+  recipe: ApplicationStarterRecipe,
+  options: { partnerIds: Array<string> },
+) {
+  const userBrief = getApplicationStarterUserBrief(input)
+  const databaseBrief = removeNegativeDatabaseMentions(userBrief)
+  const requestedPartnerIds = new Set(options.partnerIds)
+  const hasRequestedAuthPartner =
+    requestedPartnerIds.has('clerk') || requestedPartnerIds.has('workos')
+
   if (hasNegativeFeatureConstraint(input, 'clerk')) {
     recipe.features = recipe.features.filter((feature) => feature !== 'clerk')
-  } else if (/\bclerk\b/i.test(input)) {
-    replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'clerk')
-  } else if (
-    /\b(sso|saml|scim|directory sync|enterprise auth|enterprise identity|b2b auth)\b/i.test(
-      input,
-    )
-  ) {
-    replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'workos')
-  } else if (/\bworkos\b/i.test(input)) {
-    replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'workos')
-  } else if (
-    !hasAuthOverlapConstraint(input) &&
-    /\b(authentication|auth|login|sign ?in|sign ?up|oauth|sessions?)\b/i.test(
-      input,
-    )
-  ) {
-    replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'better-auth')
+  } else if (!hasRequestedAuthPartner) {
+    if (/\bclerk\b/i.test(input)) {
+      replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'clerk')
+    } else if (/\b(workos|authkit)\b/i.test(input)) {
+      replaceExclusive(recipe, ['better-auth', 'clerk', 'workos'], 'workos')
+    } else if (
+      !hasAuthOverlapConstraint(input) &&
+      /\b(authentication|auth|login|sign ?in|sign ?up|oauth|sessions?)\b/i.test(
+        input,
+      )
+    ) {
+      replaceExclusive(
+        recipe,
+        ['better-auth', 'clerk', 'workos'],
+        'better-auth',
+      )
+    }
   }
 
-  if (hasHostedDatabaseConstraint(input)) {
+  const excludesAllDatabases = hasDatabaseConstraint(input)
+  const excludesHostedDatabase = hasHostedDatabaseConstraint(input)
+  const excludesDrizzle = hasNegativeFeatureConstraint(input, 'drizzle')
+  const excludesPrisma = hasNegativeFeatureConstraint(input, 'prisma')
+  const excludesTanStackDb = hasTanStackDbConstraint(input)
+  const hadDefaultPrisma = recipe.features.includes('prisma')
+
+  if (excludesAllDatabases) {
     recipe.features = recipe.features.filter(
-      (feature) => feature !== 'convex' && feature !== 'neon',
+      (feature) =>
+        feature !== 'convex' &&
+        feature !== 'db' &&
+        feature !== 'drizzle' &&
+        feature !== 'neon' &&
+        feature !== 'prisma',
     )
-  } else if (/\bconvex\b/i.test(input)) {
-    replaceExclusive(recipe, ['convex', 'drizzle', 'neon', 'prisma'], 'convex')
-  } else if (/\bprisma\b/i.test(input)) {
-    replaceExclusive(recipe, ['convex', 'drizzle', 'prisma'], 'prisma')
-    addStarterFeatures(recipe, 'neon')
-  } else if (/\bdrizzle\b/i.test(input)) {
-    replaceExclusive(recipe, ['convex', 'drizzle', 'prisma'], 'drizzle')
-    addStarterFeatures(recipe, 'neon')
-  } else if (
-    /\bpostgres\b|\bpostgre?s\b|\bdatabase\b|\bdb\b|\bneon\b/i.test(input)
-  ) {
-    replaceExclusive(recipe, ['convex'], 'neon')
-    replaceExclusive(recipe, ['drizzle', 'prisma'], 'drizzle')
+    delete recipe.featureOptions.prisma
+    delete recipe.featureOptions.drizzle
+  } else {
+    if (/\bconvex\b/i.test(databaseBrief) && !excludesHostedDatabase) {
+      replaceExclusive(
+        recipe,
+        ['convex', 'drizzle', 'neon', 'prisma'],
+        'convex',
+      )
+    } else if (/\bneon\b/i.test(databaseBrief) && !excludesHostedDatabase) {
+      replaceExclusive(recipe, ['convex'], 'neon')
+      replaceExclusive(recipe, ['drizzle', 'prisma'], 'drizzle')
+    } else if (/\bprisma\b/i.test(databaseBrief) && !excludesPrisma) {
+      replaceExclusive(recipe, ['convex', 'drizzle', 'prisma'], 'prisma')
+    } else if (/\bdrizzle\b/i.test(databaseBrief) && !excludesDrizzle) {
+      replaceExclusive(recipe, ['convex', 'drizzle', 'prisma'], 'drizzle')
+    } else if (
+      /\bpostgres\b|\bpostgre?s\b|\bdatabase\b|\bdb\b/i.test(databaseBrief)
+    ) {
+      if (!excludesPrisma || !excludesDrizzle) {
+        replaceExclusive(
+          recipe,
+          ['convex', 'drizzle', 'prisma'],
+          excludesPrisma ? 'drizzle' : 'prisma',
+        )
+      }
+    }
+
+    if (excludesPrisma) {
+      recipe.features = recipe.features.filter(
+        (feature) => feature !== 'prisma',
+      )
+      delete recipe.featureOptions.prisma
+
+      if (
+        hadDefaultPrisma &&
+        !excludesDrizzle &&
+        !recipe.features.some((feature) =>
+          ['convex', 'drizzle', 'neon'].includes(feature),
+        )
+      ) {
+        addStarterFeatures(recipe, 'drizzle')
+      }
+    }
+
+    if (excludesDrizzle) {
+      recipe.features = recipe.features.filter(
+        (feature) => feature !== 'drizzle',
+      )
+      delete recipe.featureOptions.drizzle
+    }
+
+    if (excludesHostedDatabase) {
+      recipe.features = recipe.features.filter(
+        (feature) => feature !== 'convex' && feature !== 'neon',
+      )
+
+      if (recipe.features.includes('prisma')) {
+        recipe.featureOptions.prisma = { database: 'sqlite' }
+      }
+      if (recipe.features.includes('drizzle')) {
+        recipe.featureOptions.drizzle = { database: 'sqlite' }
+      }
+    }
+
+    if (excludesTanStackDb) {
+      recipe.features = recipe.features.filter((feature) => feature !== 'db')
+    }
+  }
+
+  if (/\bstrapi\b/i.test(userBrief)) {
+    addStarterFeatures(recipe, 'strapi')
   }
 
   if (/\bquery\b|\bloaders?\b|\bdata fetching\b/i.test(input)) {
@@ -860,7 +966,10 @@ function applyInputOverrides(input: string, recipe: ApplicationStarterRecipe) {
     addStarterFeatures(recipe, 'posthog')
   }
 
-  if (/\bsentry\b|\bmonitoring\b|\berrors?\b/i.test(input)) {
+  if (
+    !hasNegativeFeatureConstraint(input, 'sentry') &&
+    /\bsentry\b/i.test(input)
+  ) {
     addStarterFeatures(recipe, 'sentry')
   }
 
@@ -894,12 +1003,21 @@ function applyInputOverrides(input: string, recipe: ApplicationStarterRecipe) {
     addStarterFeatures(recipe, 'ai', 'store')
   }
 
-  if (/\brealtime\b|\bcollaborat(?:e|ive|ion)\b|\blive\b/i.test(input)) {
+  if (
+    /\brealtime\b|\bcollaborat(?:e|ive|ion)\b|\blive\b/i.test(input) &&
+    !excludesAllDatabases &&
+    !excludesTanStackDb &&
+    !/\b(convex|drizzle|neon|prisma)\b/i.test(userBrief) &&
+    !requestedPartnerIds.has('prisma')
+  ) {
     recipe.features = recipe.features.filter(
       (feature) =>
-        feature !== 'neon' && feature !== 'drizzle' && feature !== 'prisma',
+        feature !== 'convex' &&
+        feature !== 'neon' &&
+        feature !== 'drizzle' &&
+        feature !== 'prisma',
     )
-    addStarterFeatures(recipe, 'convex', 'tanstack-query')
+    addStarterFeatures(recipe, 'db', 'tanstack-query')
   }
 }
 
@@ -1231,6 +1349,8 @@ export function buildAdvancedBuilderUrl(recipe: ApplicationStarterRecipe) {
     params.set('features', featureIds.join(','))
   }
 
+  appendFeatureOptionParams(params, recipe.featureOptions)
+
   return `/builder?${params.toString()}`
 }
 
@@ -1252,6 +1372,23 @@ function buildAddOnConfigArg(
   )
   if (entries.length === 0) return null
   return shellQuoteSingle(JSON.stringify(Object.fromEntries(entries)))
+}
+
+function appendFeatureOptionParams(
+  params: URLSearchParams,
+  featureOptions: ApplicationStarterRecipe['featureOptions'],
+) {
+  for (const [featureId, options] of Object.entries(featureOptions)) {
+    for (const [optionKey, value] of Object.entries(options)) {
+      if (
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+      ) {
+        params.set(`${featureId}.${optionKey}`, String(value))
+      }
+    }
+  }
 }
 
 export function buildCliCommand(recipe: ApplicationStarterRecipe) {
@@ -1310,6 +1447,8 @@ export function buildDownloadUrl(recipe: ApplicationStarterRecipe) {
   if (featureIds.length > 0) {
     params.set('features', featureIds.join(','))
   }
+
+  appendFeatureOptionParams(params, recipe.featureOptions)
 
   return `/api/builder/download?${params.toString()}`
 }

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -1,9 +1,5 @@
 import { setResponseHeader } from '@tanstack/react-start/server'
-import {
-  libraries,
-  librariesByGroup,
-  librariesGroupNamesMap,
-} from '~/libraries/libraries'
+import { librariesByGroup, librariesGroupNamesMap } from '~/libraries/libraries'
 import type { Framework, LibrarySlim } from '~/libraries/types'
 import type { ConfigSchema } from '~/utils/config'
 import { partners, partnerCategoryLabels, type Partner } from '~/utils/partners'
@@ -165,26 +161,17 @@ function formatPackages(library: LibrarySlim) {
 }
 
 function formatPartnerLink(partner: Partner) {
-  return `- [${partner.name}](${partner.href}): ${partnerCategoryLabels[partner.category]}. Works with ${formatPartnerLibraries(partner)}. ${partner.llmDescription}`
-}
+  const resources = (partner.resources ?? [])
+    .map((resource) => {
+      const href = resource.href.startsWith('/')
+        ? `${siteOrigin}${resource.href}`
+        : resource.href
+      return `[${resource.label}](${href})`
+    })
+    .join(', ')
+  const resourceSummary = resources ? ` Resources: ${resources}.` : ''
 
-function formatPartnerLibraries(partner: Partner) {
-  const libraryIds = partner.libraries ?? []
-
-  if (libraryIds.length === 0) {
-    return 'the general TanStack ecosystem'
-  }
-
-  const libraryNames = libraryIds
-    .map((libraryId) => libraries.find((library) => library.id === libraryId))
-    .map((library) => library?.name)
-    .filter(isPresent)
-
-  if (libraryNames.length === 0) {
-    return 'the general TanStack ecosystem'
-  }
-
-  return libraryNames.join(', ')
+  return `- [${partner.name}](${siteOrigin}/partners/${partner.id}): ${partnerCategoryLabels[partner.category]}. ${partner.llmDescription}${resourceSummary}`
 }
 
 function isPresent<T>(value: T | undefined): value is T {

--- a/src/utils/partner-directory.ts
+++ b/src/utils/partner-directory.ts
@@ -1,0 +1,44 @@
+import * as v from 'valibot'
+
+export type PartnerDirectoryStatus = 'active' | 'inactive'
+
+const partnerDirectoryStatusSchema = v.picklist(['active', 'inactive'])
+
+export const partnerDirectorySearchSchema = v.object({
+  status: v.pipe(
+    v.fallback(v.optional(partnerDirectoryStatusSchema, 'active'), 'active'),
+    v.transform((status) => (status === 'active' ? undefined : status)),
+  ),
+})
+
+export function normalizePartnerDirectorySearch(search: {
+  status?: PartnerDirectoryStatus
+}): {
+  status: PartnerDirectoryStatus
+} {
+  return {
+    status: search.status ?? 'active',
+  }
+}
+
+export function getPartnerDirectorySearch(status: PartnerDirectoryStatus): {
+  status: 'inactive' | undefined
+} {
+  return {
+    status: status === 'inactive' ? 'inactive' : undefined,
+  }
+}
+
+export function getPartnerDirectoryMetadata(status: PartnerDirectoryStatus) {
+  return status === 'inactive'
+    ? {
+        title: 'Previous TanStack Partners',
+        description:
+          'Companies and organizations that previously supported TanStack and its open source projects.',
+      }
+    : {
+        title: 'TanStack Partners',
+        description:
+          'Companies and organizations supporting TanStack and its open source projects.',
+      }
+}

--- a/src/utils/partner-inquiry.ts
+++ b/src/utils/partner-inquiry.ts
@@ -1,0 +1,8 @@
+import { trackEvent, type PartnerPlacement } from '~/utils/analytics'
+
+export const PARTNER_INQUIRY_HREF =
+  'mailto:partners@tanstack.com?subject=TanStack%20Partnership%20Inquiry'
+
+export function trackPartnerInquiry(placement: PartnerPlacement) {
+  trackEvent('partner_inquiry_started', { placement })
+}

--- a/src/utils/partner-lifecycle.ts
+++ b/src/utils/partner-lifecycle.ts
@@ -1,10 +1,6 @@
 import type { Partner } from '~/utils/partners'
 
-export type PartnerLifecycle = {
-  endDate?: Partner['endDate']
-  startDate?: Partner['startDate']
-  status?: Partner['status']
-}
+export type PartnerLifecycle = Pick<Partner, 'endDate' | 'startDate' | 'status'>
 
 export function getPartnerWindowLabel(partner: PartnerLifecycle) {
   if (partner.startDate && partner.endDate) {
@@ -14,8 +10,12 @@ export function getPartnerWindowLabel(partner: PartnerLifecycle) {
   if (partner.startDate) {
     return partner.status === 'active'
       ? `${partner.startDate} - Present`
-      : `Started ${partner.startDate}`
+      : `${partner.startDate} - End date unknown`
   }
 
-  return partner.endDate ? `Ended ${partner.endDate}` : undefined
+  if (partner.endDate) {
+    return `Start date unknown - ${partner.endDate}`
+  }
+
+  return partner.status === 'inactive' ? 'Dates unavailable' : undefined
 }

--- a/src/utils/partner-lifecycle.ts
+++ b/src/utils/partner-lifecycle.ts
@@ -1,0 +1,21 @@
+import type { Partner } from '~/utils/partners'
+
+export type PartnerLifecycle = {
+  endDate?: Partner['endDate']
+  startDate?: Partner['startDate']
+  status?: Partner['status']
+}
+
+export function getPartnerWindowLabel(partner: PartnerLifecycle) {
+  if (partner.startDate && partner.endDate) {
+    return `${partner.startDate} - ${partner.endDate}`
+  }
+
+  if (partner.startDate) {
+    return partner.status === 'active'
+      ? `${partner.startDate} - Present`
+      : `Started ${partner.startDate}`
+  }
+
+  return partner.endDate ? `Ended ${partner.endDate}` : undefined
+}

--- a/src/utils/partner-pages.ts
+++ b/src/utils/partner-pages.ts
@@ -1,8 +1,43 @@
 import {
   getPartnerById,
   partnerCategoryLabels,
+  partners,
   type Partner,
 } from '~/utils/partners'
+
+function asLastModified(value: string) {
+  return new Date(`${value}T12:00:00.000Z`).toISOString()
+}
+
+export function getPartnerSitemapEntries() {
+  const mostRecentReview = partners
+    .flatMap((partner) =>
+      partner.lastReviewedAt ? [partner.lastReviewedAt] : [],
+    )
+    .sort()
+    .at(-1)
+
+  return [
+    {
+      path: '/partners',
+      lastModified: mostRecentReview
+        ? asLastModified(mostRecentReview)
+        : undefined,
+    },
+    {
+      path: '/partners?status=inactive',
+      lastModified: mostRecentReview
+        ? asLastModified(mostRecentReview)
+        : undefined,
+    },
+    ...partners.map((partner) => ({
+      path: `/partners/${partner.id}`,
+      lastModified: partner.lastReviewedAt
+        ? asLastModified(partner.lastReviewedAt)
+        : undefined,
+    })),
+  ]
+}
 
 const partnerGuidance: Record<
   string,

--- a/src/utils/partner-pages.ts
+++ b/src/utils/partner-pages.ts
@@ -1,15 +1,8 @@
-import { libraries } from '~/libraries'
 import {
   getPartnerById,
   partnerCategoryLabels,
   type Partner,
 } from '~/utils/partners'
-
-const libraryLabelMap = new Map(
-  libraries
-    .filter((library) => library.name)
-    .map((library) => [library.id, library.name!.replace('TanStack ', '')]),
-)
 
 const partnerGuidance: Record<
   string,
@@ -153,42 +146,32 @@ export function findPartnerForPage(partnerId: string) {
   return getPartnerById(partnerId)
 }
 
-export function getPartnerLibraryLabels(partner: Partner) {
-  return (partner.libraries ?? []).map(
-    (libraryId) => libraryLabelMap.get(libraryId) ?? libraryId,
-  )
-}
-
 export function getPartnerPageTitle(partner: Partner) {
-  return `${partner.name} for TanStack`
+  return partner.status === 'active'
+    ? `${partner.name} — TanStack Partner`
+    : `${partner.name} — Previous TanStack Partner`
 }
 
 export function getPartnerPageDescription(partner: Partner) {
-  const libraries = getPartnerLibraryLabels(partner)
-  const librariesSuffix = libraries.length
-    ? ` Best fit for ${libraries.join(', ')} teams.`
-    : ''
+  const relationship = partner.status === 'active' ? 'is' : 'was'
+  const category = partnerCategoryLabels[partner.category].toLowerCase()
 
-  return `${partner.name} is a ${partnerCategoryLabels[partner.category].toLowerCase()} partner in the TanStack ecosystem. ${partner.llmDescription}${librariesSuffix}`
+  return `${partner.name} ${relationship} a TanStack partner for ${category}. ${partner.llmDescription}`
 }
 
 export function getPartnerPageCopy(partner: Partner) {
-  const libraryLabels = getPartnerLibraryLabels(partner)
   const guidance = partnerGuidance[partner.id] ?? {
     whyGreat: `${partner.name} offers a clearly defined product in the ${partnerCategoryLabels[partner.category].toLowerCase()} space.`,
     whyTanStack:
       'It can be a strong fit alongside TanStack depending on your stack and product needs.',
   }
-  const libraryLine = libraryLabels.length
-    ? ` It is especially relevant for teams building with ${libraryLabels.join(', ')}.`
-    : ''
   const statusLine =
     partner.status === 'active'
       ? `${partner.name} is a current TanStack partner, and we think they are a strong option for teams building in this part of the stack.`
       : `${partner.name} has supported TanStack previously, and we still think they are worth knowing about if their strengths match your stack.`
 
   return {
-    description: `${partner.llmDescription}${libraryLine}`,
+    description: partner.llmDescription,
     status: statusLine,
     whyGreat: guidance.whyGreat,
     whyTanStack: guidance.whyTanStack,
@@ -202,7 +185,7 @@ export function getPartnerJsonLd(partner: Partner) {
     about: {
       '@type': 'Organization',
       name: partner.name,
-      sameAs: partner.href,
+      sameAs: partner.canonicalHref ?? partner.href,
     },
     description: getPartnerPageDescription(partner),
     name: getPartnerPageTitle(partner),

--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -1,5 +1,6 @@
 import agGridDarkSvg from '~/images/ag-grid-dark.svg'
 import agGridLightSvg from '~/images/ag-grid-light.svg'
+import agGridImage from '~/images/ag-grid.png'
 import nozzleImage from '~/images/nozzle.png'
 import bytesFireshipImage from '~/images/bytes-fireship.png'
 import vercelLightSvg from '~/images/vercel-light.svg'
@@ -30,7 +31,7 @@ import strapiLightSvg from '~/images/strapi-light.svg'
 import strapiDarkSvg from '~/images/strapi-dark.svg'
 import serpapiWhiteSvg from '~/images/serpapi-white.svg'
 import serpapiBlackSvg from '~/images/serpapi-black.svg'
-import { libraries, type Library } from '~/libraries'
+import type { Library } from '~/libraries'
 import cloudflareWhiteSvg from '~/images/cloudflare-white.svg'
 import cloudflareBlackSvg from '~/images/cloudflare-black.svg'
 import workosBlackSvg from '~/images/workos-black.svg'
@@ -64,7 +65,23 @@ type PartnerApplicationStarterIcon = {
   src: string
 }
 
+export const partnerResourceKinds = [
+  'documentation',
+  'example',
+  'announcement',
+] as const
+
+export type PartnerResourceKind = (typeof partnerResourceKinds)[number]
+
+export type PartnerResource = {
+  href: string
+  kind: PartnerResourceKind
+  label: string
+}
+
 type ApplicationStarterPartnerTier = 1 | 2 | 3
+
+const currentPartnerReviewDate = '2026-07-21'
 
 export const partnerUniqueConstraints = ['auth-provider', 'hosting'] as const
 export type PartnerUniqueConstraint = (typeof partnerUniqueConstraints)[number]
@@ -106,7 +123,7 @@ export const partnerTierFlares: Record<
     gradientStops:
       'from-yellow-400 via-amber-500 to-orange-600 dark:from-yellow-300 dark:via-amber-400 dark:to-orange-400',
     iconColor: 'text-amber-500 dark:text-amber-300',
-    labelColor: 'text-amber-600 dark:text-amber-300',
+    labelColor: 'text-amber-700 dark:text-amber-300',
     // 5-point star
     icon: (
       <svg viewBox="0 0 12 12" className="h-3 w-3 fill-current" aria-hidden>
@@ -223,31 +240,48 @@ export const partnerCategoryLabels: Record<PartnerCategory, string> = {
   database: 'Databases',
   monitoring: 'Error Monitoring',
   cms: 'CMS',
-  api: 'API Management',
+  api: 'API Infrastructure',
   ai: 'AI/LLM',
   learning: 'Learning Resources',
 }
 
-export type Partner = {
+type PartnerBase = {
   applicationStarterPromptInstructions?: Array<string>
   name: string
   id: string
-  libraries?: Library['id'][]
+  relatedProducts?: ReadonlyArray<Library['id']>
   href: string
   applicationStarterIcon?: PartnerApplicationStarterIcon
   image: PartnerImageConfig
   content: JSX.Element
   llmDescription: string
   category: PartnerCategory
-  status?: 'active' | 'inactive'
-  startDate?: string
-  endDate?: string
+  lastReviewedAt?: string
   score: number
-  uniqueConstraints?: Array<PartnerUniqueConstraint>
-  tier?: PartnerTier
+  uniqueConstraints?: ReadonlyArray<PartnerUniqueConstraint>
   brandColor?: string // Primary brand color for game elements
   tagline?: string // Short tagline for game info cards
 }
+
+export type Partner =
+  | (PartnerBase & {
+      canonicalHref: string
+      endDate?: never
+      lastReviewedAt: string
+      resources: readonly [PartnerResource, ...Array<PartnerResource>]
+      startDate?: string
+      status: 'active'
+      tier: PartnerTier
+    })
+  | (PartnerBase & {
+      canonicalHref?: string
+      resources?: ReadonlyArray<PartnerResource>
+      status: 'inactive'
+      tier?: PartnerTier
+    } & (
+        | { endDate: string; startDate: string }
+        | { endDate?: string; startDate?: undefined }
+      ))
 
 export type ApplicationStarterPartnerSuggestion = {
   brandColor?: Partner['brandColor']
@@ -333,13 +367,13 @@ export function getApplicationStarterInferredPartnerIds(input: string) {
   })
 }
 
-const neon = (() => {
+const neon = ((): Partner => {
   const href = 'https://neon.tech?utm_source=tanstack'
 
   return {
     name: 'Neon',
     id: 'neon',
-    libraries: ['start', 'router'],
+    relatedProducts: ['start', 'router'],
     status: 'inactive' as const,
     endDate: 'Apr 2026',
     score: 0.297,
@@ -367,13 +401,13 @@ const neon = (() => {
   }
 })()
 
-const convex = (() => {
+const convex = ((): Partner => {
   const href = 'https://convex.dev?utm_source=tanstack'
 
   return {
     name: 'Convex',
     id: 'convex',
-    libraries: ['start', 'router'],
+    relatedProducts: ['start', 'router'],
     status: 'inactive' as const,
     startDate: 'May 2024',
     endDate: 'Mar 2026',
@@ -402,15 +436,29 @@ const convex = (() => {
   }
 })()
 
-const clerk = (() => {
+const clerk = ((): Partner => {
   const href = 'https://go.clerk.com/wOwHtuJ'
 
   return {
     name: 'Clerk',
     id: 'clerk',
     href,
-    libraries: ['start', 'router'],
+    canonicalHref: 'https://clerk.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Clerk TanStack Start quickstart',
+        href: 'https://clerk.com/docs/tanstack-react-start/getting-started/quickstart',
+      },
+      {
+        kind: 'example',
+        label: 'TanStack Start Clerk example',
+        href: '/start/latest/docs/framework/react/examples/start-clerk-basic',
+      },
+    ],
+    relatedProducts: ['start', 'router'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.286,
     tier: 'silver' as const,
     uniqueConstraints: [
@@ -418,6 +466,10 @@ const clerk = (() => {
     ] satisfies Array<PartnerUniqueConstraint>,
     brandColor: '#6C47FF',
     tagline: 'Authentication',
+    applicationStarterIcon: {
+      mode: 'contain',
+      src: clerkLightSvg,
+    },
     image: {
       light: clerkLightSvg,
       dark: clerkDarkSvg,
@@ -441,15 +493,29 @@ const clerk = (() => {
   }
 })()
 
-const workos = (() => {
+const workos = ((): Partner => {
   const href = 'https://workos.com?utm_source=tanstack'
 
   return {
     name: 'WorkOS',
     id: 'workos',
     href,
-    libraries: ['start', 'router'] as const,
+    canonicalHref: 'https://workos.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'WorkOS AuthKit TanStack Start SDK',
+        href: 'https://workos.com/docs/sdks/authkit-tanstack-start',
+      },
+      {
+        kind: 'example',
+        label: 'TanStack Start WorkOS example',
+        href: '/start/latest/docs/framework/react/examples/start-workos',
+      },
+    ],
+    relatedProducts: ['start', 'router'] as const,
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.314,
     tier: 'silver' as const,
     uniqueConstraints: [
@@ -482,23 +548,37 @@ const workos = (() => {
   }
 })()
 
-const agGrid = (() => {
+const agGrid = ((): Partner => {
   const href =
     'https://ag-grid.com/react-data-grid/?utm_source=reacttable&utm_campaign=githubreacttable'
 
   return {
     name: 'AG Grid',
     id: 'ag-grid',
-    libraries: ['table'] as const,
+    relatedProducts: ['table'] as const,
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.497,
     tier: 'silver' as const,
     href,
+    canonicalHref: 'https://www.ag-grid.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'AG Grid with TanStack Table',
+        href: '/table/latest/docs/enterprise/ag-grid',
+      },
+      {
+        kind: 'announcement',
+        label: 'TanStack + AG Grid partnership',
+        href: '/blog/ag-grid-partnership',
+      },
+    ],
     brandColor: '#FF8C00',
     tagline: 'Enterprise Data Grid',
     applicationStarterIcon: {
       mode: 'contain',
-      src: 'https://www.ag-grid.com/_astro/favicon-32.WDuB-104.png',
+      src: agGridImage,
     },
     applicationStarterPromptInstructions: [
       'Install ag-grid-react and ag-grid-community and use AG Grid Community by default for a real working demo.',
@@ -536,23 +616,37 @@ const agGrid = (() => {
   }
 })()
 
-const netlify = (() => {
+const netlify = ((): Partner => {
   const href = 'https://netlify.com?utm_source=tanstack'
 
   return {
     name: 'Netlify',
     id: 'netlify',
-    libraries: ['start', 'router'],
+    relatedProducts: ['start', 'router'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.343,
     tier: 'gold' as const,
     uniqueConstraints: ['hosting'] satisfies Array<PartnerUniqueConstraint>,
     href,
+    canonicalHref: 'https://www.netlify.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'TanStack Start hosting guide',
+        href: '/start/latest/docs/framework/react/guide/hosting',
+      },
+      {
+        kind: 'announcement',
+        label: 'TanStack + Netlify partnership',
+        href: '/blog/netlify-partnership',
+      },
+    ],
     brandColor: '#00C7B7',
     tagline: 'Web Deployment',
     applicationStarterIcon: {
       mode: 'contain',
-      src: 'https://www.netlify.com/favicon/icon.svg',
+      src: netlifyLightSvg,
     },
     image: {
       light: netlifyLightSvg,
@@ -576,16 +670,29 @@ const netlify = (() => {
   }
 })()
 
-const cloudflare = (() => {
+const cloudflare = ((): Partner => {
   const href = 'https://www.cloudflare.com?utm_source=tanstack'
 
   return {
     name: 'Cloudflare',
     id: 'cloudflare',
     href,
-    // Show on every repo
-    libraries: libraries.map((l) => l.id),
+    canonicalHref: 'https://www.cloudflare.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Cloudflare TanStack Start guide',
+        href: 'https://developers.cloudflare.com/workers/framework-guides/web-apps/tanstack-start/',
+      },
+      {
+        kind: 'documentation',
+        label: 'TanStack Start hosting guide',
+        href: '/start/latest/docs/framework/react/guide/hosting',
+      },
+    ],
+    relatedProducts: ['start'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.857,
     tier: 'gold' as const,
     uniqueConstraints: ['hosting'] satisfies Array<PartnerUniqueConstraint>,
@@ -612,15 +719,29 @@ const cloudflare = (() => {
   }
 })()
 
-const lovable = (() => {
+const lovable = ((): Partner => {
   const href = 'https://lovable.dev?utm_source=tanstack'
 
   return {
     name: 'Lovable',
     id: 'lovable',
     href,
-    libraries: ['start', 'router'] as const,
+    canonicalHref: 'https://lovable.dev/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Build with a URL in Lovable',
+        href: 'https://docs.lovable.dev/integrations/build-with-url',
+      },
+      {
+        kind: 'announcement',
+        label: 'Building TanStack Start apps with Lovable',
+        href: 'https://lovable.dev/blog/building-apps-using-tanstack-start',
+      },
+    ],
+    relatedProducts: ['start', 'router'] as const,
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.714,
     tier: 'gold' as const,
     uniqueConstraints: ['hosting'] satisfies Array<PartnerUniqueConstraint>,
@@ -654,17 +775,26 @@ const lovable = (() => {
   }
 })()
 
-const sentry = (() => {
+const sentry = ((): Partner => {
   const href = 'https://sentry.io?utm_source=tanstack'
 
   return {
     name: 'Sentry',
     id: 'sentry',
-    libraries: ['start', 'router'],
+    relatedProducts: ['start', 'router'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.229,
     tier: 'bronze' as const,
     href,
+    canonicalHref: 'https://sentry.io/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Sentry for TanStack Start',
+        href: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/',
+      },
+    ],
     brandColor: '#362D59',
     tagline: 'Error Monitoring',
     image: {
@@ -672,7 +802,7 @@ const sentry = (() => {
       dark: sentryWordMarkLightSvg,
     },
     llmDescription:
-      'Application monitoring platform for error tracking, tracing, replay, profiling, and logs. It also offers TanStack Router integration and an alpha TanStack Start React SDK.',
+      'Application monitoring platform for error tracking, tracing, replay, profiling, and logs, with TanStack Router support and an alpha TanStack Start React SDK.',
     category: 'monitoring',
     content: (
       <>
@@ -688,13 +818,13 @@ const sentry = (() => {
   }
 })()
 
-const fireship = (() => {
+const fireship = ((): Partner => {
   const href = 'https://bytes.dev?utm_source-tanstack&utm_campaign=tanstack'
 
   return {
     name: 'Fireship',
     id: 'fireship',
-    libraries: [],
+    relatedProducts: [],
     status: 'inactive' as const,
     score: 0.014,
     href,
@@ -744,7 +874,7 @@ const fireship = (() => {
   }
 })()
 
-const nozzle = (() => {
+const nozzle = ((): Partner => {
   const href = 'https://nozzle.io/?utm_source=tanstack&utm_campaign=tanstack'
 
   return {
@@ -774,7 +904,7 @@ const nozzle = (() => {
   }
 })()
 
-const speakeasy = (() => {
+const speakeasy = ((): Partner => {
   const href =
     'https://www.speakeasy.com/product/react-query?utm_source=tanstack&utm_campaign=tanstack'
 
@@ -782,10 +912,11 @@ const speakeasy = (() => {
     name: 'Speakeasy',
     id: 'speakeasy',
     href,
-    libraries: ['query'] as const,
+    relatedProducts: ['query'] as const,
     status: 'inactive' as const,
     startDate: 'Feb 2025',
     endDate: 'Jul 2025',
+    score: 0,
     image: {
       light: speakeasyLightSvg,
       dark: speakeasyDarkSvg,
@@ -809,17 +940,31 @@ const speakeasy = (() => {
   }
 })()
 
-const unkey = (() => {
+const unkey = ((): Partner => {
   const href = 'https://www.unkey.com/?utm_source=tanstack'
 
   return {
     name: 'Unkey',
     id: 'unkey',
-    libraries: ['pacer'] as const,
+    relatedProducts: ['start'] as const,
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.051,
     tier: 'bronze' as const,
     href,
+    canonicalHref: 'https://www.unkey.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Unkey server-side rate limiting',
+        href: 'https://www.unkey.com/docs/platform/ratelimiting/introduction',
+      },
+      {
+        kind: 'documentation',
+        label: 'Unkey API key quickstart',
+        href: 'https://www.unkey.com/docs/quickstart/quickstart',
+      },
+    ],
     brandColor: '#222222',
     tagline: 'API Key Management',
     applicationStarterPromptInstructions: [
@@ -849,19 +994,37 @@ const unkey = (() => {
   }
 })()
 
-const serpApi = (() => {
+const serpApi = ((): Partner => {
   const href = 'https://serpapi.com?utm_source=tanstack'
 
   return {
     name: 'SerpApi',
     id: 'serpapi',
-    libraries: libraries.map((l) => l.id),
+    relatedProducts: ['start', 'ai', 'mcp'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.41,
     tier: 'silver' as const,
     href,
+    canonicalHref: 'https://serpapi.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'SerpApi JavaScript integration',
+        href: 'https://serpapi.com/integrations/javascript',
+      },
+      {
+        kind: 'documentation',
+        label: 'SerpApi MCP integration',
+        href: 'https://serpapi.com/integrations/mcp',
+      },
+    ],
     brandColor: '#6361EC',
     tagline: 'Real-time SERP API',
+    applicationStarterIcon: {
+      mode: 'contain',
+      src: serpapiBlackSvg,
+    },
     applicationStarterPromptInstructions: [
       'Install the official serpapi package and keep all SerpApi usage server-side behind an app-owned endpoint or server function.',
       'Read SERPAPI_API_KEY from environment variables and choose one explicit search engine instead of pretending to support every engine at once.',
@@ -889,17 +1052,26 @@ const serpApi = (() => {
   }
 })()
 
-const electric = (() => {
-  const href = 'https://electric-sql.com'
+const electric = ((): Partner => {
+  const href = 'https://electric.ax/?utm_source=tanstack'
 
   return {
     name: 'Electric',
     id: 'electric',
-    libraries: ['db'] as const,
+    relatedProducts: ['db'] as const,
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.283,
     tier: 'bronze' as const,
     href,
+    canonicalHref: 'https://electric.ax/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'TanStack DB Electric collection',
+        href: '/db/latest/docs/collections/electric-collection',
+      },
+    ],
     brandColor: '#7e78db',
     tagline: 'Sync Engine',
     applicationStarterPromptInstructions: [
@@ -929,17 +1101,18 @@ const electric = (() => {
   }
 })()
 
-const vercel = (() => {
+const vercel = ((): Partner => {
   const href = 'https://vercel.com?utm_source=tanstack'
 
   return {
     name: 'Vercel',
     id: 'vercel',
     href,
-    libraries: ['start', 'router'] as const,
+    relatedProducts: ['start', 'router'] as const,
     status: 'inactive' as const,
     startDate: 'May 2024',
     endDate: 'Oct 2024',
+    score: 0,
     uniqueConstraints: ['hosting'] satisfies Array<PartnerUniqueConstraint>,
     image: {
       light: vercelLightSvg,
@@ -962,15 +1135,24 @@ const vercel = (() => {
   }
 })()
 
-const prisma = (() => {
+const prisma = ((): Partner => {
   const href = 'https://www.prisma.io/?utm_source=tanstack&via=tanstack'
 
   return {
     name: 'Prisma',
     id: 'prisma',
     href,
+    canonicalHref: 'https://www.prisma.io/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'Prisma with TanStack Start',
+        href: 'https://docs.prisma.io/docs/guides/frameworks/tanstack-start',
+      },
+    ],
     status: 'active' as const,
-    libraries: ['db', 'start'] as const,
+    lastReviewedAt: currentPartnerReviewDate,
+    relatedProducts: ['db', 'start'] as const,
     startDate: 'Aug 2025',
     score: 0.143,
     tier: 'bronze' as const,
@@ -997,7 +1179,7 @@ const prisma = (() => {
   }
 })()
 
-const codeRabbit = (() => {
+const codeRabbit = ((): Partner => {
   const href =
     'https://coderabbit.link/tanstack?utm_source=tanstack&via=tanstack'
 
@@ -1005,8 +1187,17 @@ const codeRabbit = (() => {
     name: 'CodeRabbit',
     id: 'coderabbit',
     href,
+    canonicalHref: 'https://www.coderabbit.ai/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'CodeRabbit quickstart',
+        href: 'https://docs.coderabbit.ai/getting-started/quickstart',
+      },
+    ],
     status: 'active' as const,
-    libraries: libraries.map((l) => l.id),
+    lastReviewedAt: currentPartnerReviewDate,
+    relatedProducts: [],
     startDate: 'Aug 2025',
     score: 1,
     tier: 'gold' as const,
@@ -1038,13 +1229,13 @@ const codeRabbit = (() => {
   }
 })()
 
-const strapi = (() => {
+const strapi = ((): Partner => {
   const href = 'https://strapi.link/tanstack-start'
 
   return {
     name: 'Strapi',
     id: 'strapi',
-    libraries: ['start', 'router'] as const,
+    relatedProducts: ['start', 'router'] as const,
     status: 'inactive' as const,
     score: 0.069,
     tier: 'bronze' as const,
@@ -1073,19 +1264,33 @@ const strapi = (() => {
   }
 })()
 
-const powerSync = (() => {
+const powerSync = ((): Partner => {
   const href =
     'https://powersync.com?utm_source=tanstack&utm_campaign=tanstack_partner'
 
   return {
     name: 'PowerSync',
     id: 'powersync',
-    libraries: ['db', 'query'] as const,
+    relatedProducts: ['db', 'query'] as const,
     status: 'inactive' as const,
     startDate: 'Jan 2026',
+    endDate: 'Jun 2026',
     score: 0.143,
     tier: 'bronze' as const,
     href,
+    canonicalHref: 'https://www.powersync.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'PowerSync TanStack SDK guide',
+        href: 'https://docs.powersync.com/client-sdks/frameworks/tanstack',
+      },
+      {
+        kind: 'documentation',
+        label: 'TanStack DB PowerSync collection',
+        href: '/db/latest/docs/collections/powersync-collection',
+      },
+    ],
     tagline: 'Offline-first Sync',
     applicationStarterPromptInstructions: [
       'Install the official PowerSync web client packages such as @powersync/web and @journeyapps/wa-sqlite when PowerSync is explicitly requested.',
@@ -1114,21 +1319,30 @@ const powerSync = (() => {
   }
 })()
 
-const railway = (() => {
+const railway = ((): Partner => {
   const href =
     'https://railway.com/?utm_medium=sponsor&utm_source=oss&utm_campaign=tanstack'
 
   return {
     name: 'Railway',
     id: 'railway',
-    libraries: libraries.map((l) => l.id),
+    relatedProducts: ['start'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     score: 0.145,
     tier: 'gold' as const,
     uniqueConstraints: ['hosting'] satisfies Array<PartnerUniqueConstraint>,
     href,
+    canonicalHref: 'https://railway.com/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'TanStack Start hosting guide',
+        href: '/start/latest/docs/framework/react/guide/hosting',
+      },
+    ],
     brandColor: '#0B0D0E',
-    tagline: 'Instant Deployment',
+    tagline: 'Full-stack Hosting',
     image: {
       light: railwayBlackSvg,
       dark: railwayWhiteSvg,
@@ -1151,22 +1365,40 @@ const railway = (() => {
   }
 })()
 
-const openRouter = (() => {
+const openRouter = ((): Partner => {
   const href = 'https://openrouter.ai?utm_source=tanstack'
 
   return {
     name: 'OpenRouter',
     id: 'openrouter',
     href,
-    libraries: libraries.map((l) => l.id),
+    canonicalHref: 'https://openrouter.ai/',
+    resources: [
+      {
+        kind: 'documentation',
+        label: 'TanStack AI OpenRouter adapter',
+        href: '/ai/latest/docs/adapters/openrouter',
+      },
+      {
+        kind: 'announcement',
+        label: 'TanStack + OpenRouter partnership',
+        href: '/blog/openrouter-partnership',
+      },
+    ],
+    relatedProducts: ['ai'],
     status: 'active' as const,
+    lastReviewedAt: currentPartnerReviewDate,
     startDate: 'Mar 2026',
     score: 0.344,
     tier: 'silver' as const,
     brandColor: '#7C3AED',
     tagline: 'Unified LLM API',
+    applicationStarterIcon: {
+      mode: 'contain',
+      src: openrouterBlackSvg,
+    },
     applicationStarterPromptInstructions: [
-      'Use the official @openrouter/sdk on the server and read OPENROUTER_API_KEY from environment variables.',
+      'When the app uses TanStack AI, integrate OpenRouter through the official @tanstack/ai-openrouter adapter. Otherwise, use the official @openrouter/sdk on the server. Read OPENROUTER_API_KEY from environment variables.',
       'Keep model selection explicit and easy to swap, and do not expose provider keys in client code.',
       'If AI functionality is demoed, route requests through app-owned server functions instead of calling OpenRouter directly from the browser.',
     ],
@@ -1200,7 +1432,7 @@ const openRouter = (() => {
   }
 })()
 
-export const partners: Partner[] = [
+export const partners = [
   codeRabbit,
   cloudflare,
   lovable,
@@ -1223,7 +1455,7 @@ export const partners: Partner[] = [
   nozzle,
   vercel,
   speakeasy,
-] as Partner[]
+] satisfies Array<Partner>
 
 const applicationStarterBrandColorOverrides = new Map<string, string>([
   ['powersync', '#00D5FF'],
@@ -1241,7 +1473,7 @@ const applicationStarterPlacementContext = getPartnerPlacementContext({
 function getPartnerUniqueConstraints(
   partner: Pick<Partner, 'uniqueConstraints'>,
 ) {
-  return partner.uniqueConstraints ?? []
+  return [...(partner.uniqueConstraints ?? [])]
 }
 
 function hasSharedUniqueConstraint(
@@ -1402,15 +1634,11 @@ const applicationStarterInferenceRules: Array<{
 }> = [
   {
     partnerId: 'workos',
-    patterns: [
-      /\b(sso|saml|scim|directory sync|enterprise auth|enterprise identity|b2b auth)\b/i,
-    ],
+    patterns: [/\b(workos|authkit)\b/i],
   },
   {
     partnerId: 'clerk',
-    patterns: [
-      /\b(authentication|sign[ -]?in|sign[ -]?up|login|oauth|mfa|user management|sessions?)\b/i,
-    ],
+    patterns: [/\bclerk\b/i],
   },
   {
     partnerId: 'cloudflare',
@@ -1434,9 +1662,7 @@ const applicationStarterInferenceRules: Array<{
   },
   {
     partnerId: 'sentry',
-    patterns: [
-      /\b(error tracking|exception monitoring|observability|tracing|trace(s|ing)?|session replay|profiling|application monitoring)\b/i,
-    ],
+    patterns: [/\bsentry\b/i],
   },
   {
     partnerId: 'strapi',
@@ -1496,10 +1722,6 @@ function getApplicationStarterPartnerTier(
   partner: Pick<Partner, 'tier'>,
 ): ApplicationStarterPartnerTier {
   return partner.tier ? partnerTierToBuilderTier[partner.tier] : 3
-}
-
-function getApplicationStarterPartnerFaviconUrl(href: string) {
-  return `${new URL(href).origin}/favicon.ico`
 }
 
 function getApplicationStarterPartnerDescription(
@@ -1621,11 +1843,7 @@ function createApplicationStarterPartnerSuggestion(
     description: getApplicationStarterPartnerDescription(partner),
     hint: `${partner.name} (${partnerCategoryLabels[partner.category]})`,
     iconMode,
-    iconSrc:
-      tier === 2
-        ? (partner.applicationStarterIcon?.src ??
-          getApplicationStarterPartnerFaviconUrl(partner.href))
-        : undefined,
+    iconSrc: tier === 2 ? partner.applicationStarterIcon?.src : undefined,
     image: partner.image,
     tags: getApplicationStarterPartnerTags(partner),
     brandColor:

--- a/src/utils/partners.tsx
+++ b/src/utils/partners.tsx
@@ -275,13 +275,12 @@ export type Partner =
     })
   | (PartnerBase & {
       canonicalHref?: string
+      endDate: string | null
       resources?: ReadonlyArray<PartnerResource>
+      startDate: string | null
       status: 'inactive'
       tier?: PartnerTier
-    } & (
-        | { endDate: string; startDate: string }
-        | { endDate?: string; startDate?: undefined }
-      ))
+    })
 
 export type ApplicationStarterPartnerSuggestion = {
   brandColor?: Partner['brandColor']
@@ -375,6 +374,7 @@ const neon = ((): Partner => {
     id: 'neon',
     relatedProducts: ['start', 'router'],
     status: 'inactive' as const,
+    startDate: null,
     endDate: 'Apr 2026',
     score: 0.297,
     href,
@@ -826,6 +826,8 @@ const fireship = ((): Partner => {
     id: 'fireship',
     relatedProducts: [],
     status: 'inactive' as const,
+    startDate: null,
+    endDate: null,
     score: 0.014,
     href,
     tagline: 'Dev Education',
@@ -882,6 +884,8 @@ const nozzle = ((): Partner => {
     id: 'nozzle',
     href,
     status: 'inactive' as const,
+    startDate: null,
+    endDate: null,
     score: 0.014,
     tagline: 'Enterprise SEO',
     image: {
@@ -1237,6 +1241,8 @@ const strapi = ((): Partner => {
     id: 'strapi',
     relatedProducts: ['start', 'router'] as const,
     status: 'inactive' as const,
+    startDate: null,
+    endDate: null,
     score: 0.069,
     tier: 'bronze' as const,
     href,

--- a/src/utils/provider-config.server.ts
+++ b/src/utils/provider-config.server.ts
@@ -6,31 +6,56 @@
  */
 
 export type DeployProvider = 'cloudflare' | 'netlify' | 'railway'
+type StartFramework = 'react' | 'solid'
 
 interface ProviderConfigResult {
   files: Record<string, string>
   devDependencies: Record<string, string>
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function hasDependency(packageJson: unknown, dependency: string): boolean {
+  if (!isObject(packageJson)) return false
+
+  return [packageJson.dependencies, packageJson.devDependencies].some(
+    (dependencies) => isObject(dependencies) && dependency in dependencies,
+  )
+}
+
+/**
+ * Get the TanStack Start framework used by an example from package.json.
+ */
+export function getStartFramework(
+  files: Record<string, string>,
+): StartFramework | null {
+  const packageJson = files['package.json']
+  if (!packageJson) return null
+
+  try {
+    const parsedPackageJson: unknown = JSON.parse(packageJson)
+
+    if (hasDependency(parsedPackageJson, '@tanstack/solid-start')) {
+      return 'solid'
+    }
+
+    if (hasDependency(parsedPackageJson, '@tanstack/react-start')) {
+      return 'react'
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Check if an example is a TanStack Start app by looking at package.json
  */
 export function isStartApp(files: Record<string, string>): boolean {
-  const packageJson = files['package.json']
-  if (!packageJson) return false
-
-  try {
-    const pkg = JSON.parse(packageJson)
-    const allDeps = {
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    }
-    return (
-      '@tanstack/react-start' in allDeps || '@tanstack/solid-start' in allDeps
-    )
-  } catch {
-    return false
-  }
+  return getStartFramework(files) !== null
 }
 
 /**
@@ -39,10 +64,11 @@ export function isStartApp(files: Record<string, string>): boolean {
 export function getProviderConfig(
   provider: DeployProvider,
   projectName: string,
+  framework: StartFramework,
 ): ProviderConfigResult {
   switch (provider) {
     case 'cloudflare':
-      return getCloudflareConfig(projectName)
+      return getCloudflareConfig(projectName, framework)
     case 'netlify':
       return getNetlifyConfig()
     case 'railway':
@@ -55,13 +81,16 @@ export function getProviderConfig(
 /**
  * Cloudflare Workers configuration
  */
-function getCloudflareConfig(projectName: string): ProviderConfigResult {
+function getCloudflareConfig(
+  projectName: string,
+  framework: StartFramework,
+): ProviderConfigResult {
   const wranglerConfig = {
     $schema: 'node_modules/wrangler/config-schema.json',
     name: sanitizeProjectName(projectName),
-    compatibility_date: '2025-01-01',
+    compatibility_date: '2025-09-02',
     compatibility_flags: ['nodejs_compat'],
-    main: '@tanstack/react-start/server-entry',
+    main: `@tanstack/${framework}-start/server-entry`,
   }
 
   return {
@@ -137,15 +166,15 @@ export function applyProviderConfig(
   provider: DeployProvider,
   projectName: string,
 ): Record<string, string> {
-  const isStart = isStartApp(files)
+  const framework = getStartFramework(files)
   const result = { ...files }
 
-  if (isStart) {
+  if (framework) {
     // Full server-side config for Start apps
     console.log(
       '[applyProviderConfig] Start app, applying full provider config',
     )
-    const config = getProviderConfig(provider, projectName)
+    const config = getProviderConfig(provider, projectName, framework)
 
     // Add provider-specific config files
     for (const [path, content] of Object.entries(config.files)) {
@@ -323,10 +352,12 @@ function updateViteConfig(content: string, provider: DeployProvider): string {
       }
 
       // Add cloudflare() to plugins array
-      result = addPluginToConfig(
-        result,
-        `cloudflare({ viteEnvironment: { name: 'ssr' } })`,
-      )
+      if (!hasPluginCall(result, 'cloudflare')) {
+        result = addPluginToConfig(
+          result,
+          `cloudflare({ viteEnvironment: { name: 'ssr' } })`,
+        )
+      }
       break
     }
 
@@ -342,7 +373,9 @@ function updateViteConfig(content: string, provider: DeployProvider): string {
       }
 
       // Add netlify() to plugins array
-      result = addPluginToConfig(result, 'netlify()')
+      if (!hasPluginCall(result, 'netlify')) {
+        result = addPluginToConfig(result, 'netlify()')
+      }
       break
     }
 
@@ -358,12 +391,21 @@ function updateViteConfig(content: string, provider: DeployProvider): string {
       }
 
       // Add nitro() to plugins array
-      result = addPluginToConfig(result, 'nitro()')
+      if (!hasPluginCall(result, 'nitro')) {
+        result = addPluginToConfig(result, 'nitro()')
+      }
       break
     }
   }
 
   return result
+}
+
+function hasPluginCall(
+  content: string,
+  pluginName: 'cloudflare' | 'netlify' | 'nitro',
+) {
+  return new RegExp(`\\b${pluginName}\\s*\\(`).test(content)
 }
 
 /**

--- a/src/utils/provider-config.server.ts
+++ b/src/utils/provider-config.server.ts
@@ -5,12 +5,110 @@
  * This enables 1-click deploys to Cloudflare, Netlify, Railway, etc.
  */
 
+import {
+  addOn as reactCloudflareAddOn,
+  renderManifestTemplate as renderReactCloudflareTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/react/add-ons/cloudflare'
+import {
+  addOn as reactNetlifyAddOn,
+  renderManifestTemplate as renderReactNetlifyTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/react/add-ons/netlify'
+import {
+  addOn as reactRailwayAddOn,
+  renderManifestTemplate as renderReactRailwayTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/react/add-ons/railway'
+import {
+  addOn as solidCloudflareAddOn,
+  renderManifestTemplate as renderSolidCloudflareTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/solid/add-ons/cloudflare'
+import {
+  addOn as solidNetlifyAddOn,
+  renderManifestTemplate as renderSolidNetlifyTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/solid/add-ons/netlify'
+import {
+  addOn as solidRailwayAddOn,
+  renderManifestTemplate as renderSolidRailwayTemplate,
+} from '@tanstack/create/worker-manifest/frameworks/solid/add-ons/railway'
+import type { WorkerAddOnManifestModule } from '@tanstack/create/worker'
+import { parseDocument } from 'yaml'
+
 export type DeployProvider = 'cloudflare' | 'netlify' | 'railway'
 type StartFramework = 'react' | 'solid'
+type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno'
+type PackageAdditions = NonNullable<
+  WorkerAddOnManifestModule['addOn']['packageAdditions']
+>
+type DeploymentTemplateContext = Parameters<
+  typeof renderReactCloudflareTemplate
+>[1]
+
+type ViteIntegration = {
+  type?: string
+  import?: string
+  code?: string
+}
+
+type DeploymentManifest = {
+  files: Record<string, string>
+  deletedFiles?: ReadonlyArray<string>
+  integrations?: ReadonlyArray<ViteIntegration>
+  packageAdditions?: PackageAdditions
+  packageTemplate?: string
+}
+
+type DeploymentManifestModule = {
+  addOn: DeploymentManifest
+  renderManifestTemplate:
+    | typeof renderReactCloudflareTemplate
+    | typeof renderReactNetlifyTemplate
+    | typeof renderReactRailwayTemplate
+    | typeof renderSolidCloudflareTemplate
+    | typeof renderSolidNetlifyTemplate
+    | typeof renderSolidRailwayTemplate
+}
 
 interface ProviderConfigResult {
   files: Record<string, string>
-  devDependencies: Record<string, string>
+  deletedFiles: ReadonlyArray<string>
+  packageAdditions: PackageAdditions
+  viteIntegration: ViteIntegration | undefined
+}
+
+function defineDeploymentManifestModule(
+  module: DeploymentManifestModule,
+): DeploymentManifestModule {
+  return module
+}
+
+const deploymentManifestModules = {
+  react: {
+    cloudflare: defineDeploymentManifestModule({
+      addOn: reactCloudflareAddOn,
+      renderManifestTemplate: renderReactCloudflareTemplate,
+    }),
+    netlify: defineDeploymentManifestModule({
+      addOn: reactNetlifyAddOn,
+      renderManifestTemplate: renderReactNetlifyTemplate,
+    }),
+    railway: defineDeploymentManifestModule({
+      addOn: reactRailwayAddOn,
+      renderManifestTemplate: renderReactRailwayTemplate,
+    }),
+  },
+  solid: {
+    cloudflare: defineDeploymentManifestModule({
+      addOn: solidCloudflareAddOn,
+      renderManifestTemplate: renderSolidCloudflareTemplate,
+    }),
+    netlify: defineDeploymentManifestModule({
+      addOn: solidNetlifyAddOn,
+      renderManifestTemplate: renderSolidNetlifyTemplate,
+    }),
+    railway: defineDeploymentManifestModule({
+      addOn: solidRailwayAddOn,
+      renderManifestTemplate: renderSolidRailwayTemplate,
+    }),
+  },
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -65,80 +163,194 @@ export function getProviderConfig(
   provider: DeployProvider,
   projectName: string,
   framework: StartFramework,
+  sourceFiles: Record<string, string> = {},
 ): ProviderConfigResult {
-  switch (provider) {
-    case 'cloudflare':
-      return getCloudflareConfig(projectName, framework)
-    case 'netlify':
-      return getNetlifyConfig()
-    case 'railway':
-      return getRailwayConfig()
-    default:
-      return { files: {}, devDependencies: {} }
+  const manifestModule = deploymentManifestModules[framework][provider]
+  const { addOn } = manifestModule
+  const files = getManifestFiles(addOn, provider, projectName)
+  let packageAdditions = addOn.packageAdditions ?? {}
+
+  if (addOn.packageTemplate) {
+    const renderedPackageTemplate = manifestModule.renderManifestTemplate(
+      addOn.packageTemplate,
+      getDeploymentTemplateContext(sourceFiles, projectName),
+    )
+
+    packageAdditions = parsePackageAdditions(renderedPackageTemplate)
+  }
+
+  return {
+    files,
+    deletedFiles: addOn.deletedFiles ?? [],
+    packageAdditions,
+    viteIntegration: addOn.integrations?.find(
+      (integration) =>
+        integration.type === 'vite-plugin' &&
+        integration.import !== undefined &&
+        integration.code !== undefined,
+    ),
   }
 }
 
-/**
- * Cloudflare Workers configuration
- */
-function getCloudflareConfig(
+function getManifestFiles(
+  manifest: DeploymentManifest,
+  provider: DeployProvider,
   projectName: string,
-  framework: StartFramework,
-): ProviderConfigResult {
-  const wranglerConfig = {
-    $schema: 'node_modules/wrangler/config-schema.json',
-    name: sanitizeProjectName(projectName),
-    compatibility_date: '2025-09-02',
-    compatibility_flags: ['nodejs_compat'],
-    main: `@tanstack/${framework}-start/server-entry`,
+): Record<string, string> {
+  const files = { ...manifest.files }
+  const wranglerConfig = files['wrangler.jsonc']
+
+  if (provider === 'cloudflare' && wranglerConfig) {
+    const parsedWranglerConfig: unknown = JSON.parse(wranglerConfig)
+    if (!isObject(parsedWranglerConfig)) {
+      throw new Error(
+        'Create Cloudflare manifest has an invalid wrangler.jsonc',
+      )
+    }
+
+    files['wrangler.jsonc'] = JSON.stringify(
+      {
+        ...parsedWranglerConfig,
+        name: sanitizeProjectName(projectName),
+      },
+      null,
+      2,
+    )
   }
 
+  return files
+}
+
+function getDeploymentTemplateContext(
+  files: Record<string, string>,
+  projectName: string,
+): DeploymentTemplateContext {
   return {
-    files: {
-      'wrangler.jsonc': JSON.stringify(wranglerConfig, null, 2),
+    packageManager: getProjectPackageManager(files),
+    projectName,
+    typescript: true,
+    tailwind: false,
+    blank: false,
+    js: 'ts',
+    jsx: 'tsx',
+    fileRouter: true,
+    codeRouter: false,
+    routerOnly: false,
+    includeExamples: true,
+    addOnEnabled: {
+      sentry: hasCompleteSentrySetup(files),
     },
-    devDependencies: {
-      '@cloudflare/vite-plugin': '^1.0.0',
-      wrangler: '^4.0.0',
+    addOnOption: {},
+    addOns: [],
+    integrations: [],
+    routes: [],
+    getPackageManagerAddScript: () => '',
+    getPackageManagerRunScript: () => '',
+    getPackageManagerExecuteScript: () => '',
+    relativePath: () => '',
+    integrationImportContent: () => '',
+    integrationImportCode: () => undefined,
+    renderTemplate: (content) => content,
+    ignoreFile() {
+      throw new Error('Package templates cannot ignore files')
     },
   }
 }
 
-/**
- * Netlify configuration
- */
-function getNetlifyConfig(): ProviderConfigResult {
-  const netlifyToml = `[build]
-  command = "npm run build"
-  publish = "dist/client"
+function getProjectPackageManager(
+  files: Record<string, string>,
+): PackageManager {
+  const packageJson = parsePackageJson(files['package.json'])
+  if (isObject(packageJson) && typeof packageJson.packageManager === 'string') {
+    const packageManagerName = packageJson.packageManager.split('@')[0]
+    if (isPackageManager(packageManagerName)) {
+      return packageManagerName
+    }
+  }
 
-[dev]
-  command = "npm run dev"
-  port = 3000
-`
+  if ('pnpm-lock.yaml' in files) return 'pnpm'
+  if ('yarn.lock' in files) return 'yarn'
+  if ('bun.lock' in files || 'bun.lockb' in files) return 'bun'
+  if ('deno.lock' in files) return 'deno'
+  return 'npm'
+}
 
-  return {
-    files: {
-      'netlify.toml': netlifyToml,
-    },
-    devDependencies: {
-      '@netlify/vite-plugin-tanstack-start': '^1.0.0',
-    },
+function isPackageManager(value: string): value is PackageManager {
+  return ['npm', 'yarn', 'pnpm', 'bun', 'deno'].includes(value)
+}
+
+function parsePackageJson(content: string | undefined): unknown {
+  if (!content) return undefined
+
+  try {
+    return JSON.parse(content)
+  } catch {
+    return undefined
   }
 }
 
-/**
- * Railway configuration (uses Nitro)
- */
-function getRailwayConfig(): ProviderConfigResult {
-  // Railway uses Nitro for the Node server build, no additional config files needed
-  // Just need the nitro dependency
-  return {
-    files: {},
-    devDependencies: {
-      nitro: 'latest',
-    },
+function hasCompleteSentrySetup(files: Record<string, string>): boolean {
+  const packageJson = parsePackageJson(files['package.json'])
+  if (
+    !hasDependency(packageJson, '@sentry/tanstackstart-react') ||
+    !('instrument.server.mjs' in files) ||
+    !isObject(packageJson) ||
+    !isObject(packageJson.scripts) ||
+    typeof packageJson.scripts.build !== 'string'
+  ) {
+    return false
   }
+
+  return packageJson.scripts.build.includes(
+    'cp instrument.server.mjs .output/server',
+  )
+}
+
+function parsePackageAdditions(content: string | undefined): PackageAdditions {
+  if (!content) return {}
+
+  const parsedPackageAdditions: unknown = JSON.parse(content)
+  if (!isObject(parsedPackageAdditions)) {
+    throw new Error('Create deployment manifest has invalid package additions')
+  }
+
+  return {
+    dependencies: getStringRecord(parsedPackageAdditions.dependencies),
+    devDependencies: getStringRecord(parsedPackageAdditions.devDependencies),
+    engines: getStringRecord(parsedPackageAdditions.engines),
+    pnpm: getPnpmConfig(parsedPackageAdditions.pnpm),
+    scripts: getStringRecord(parsedPackageAdditions.scripts),
+  }
+}
+
+function getStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isObject(value)) return undefined
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string',
+  )
+  return entries.length ? Object.fromEntries(entries) : undefined
+}
+
+function getStringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value.filter((entry): entry is string => typeof entry === 'string')
+}
+
+function getPnpmConfig(value: unknown): PackageAdditions['pnpm'] {
+  if (!isObject(value)) return undefined
+
+  const onlyBuiltDependencies = value.onlyBuiltDependencies
+  if (
+    !Array.isArray(onlyBuiltDependencies) ||
+    !onlyBuiltDependencies.every(
+      (dependency): dependency is string => typeof dependency === 'string',
+    )
+  ) {
+    return undefined
+  }
+
+  return { onlyBuiltDependencies }
 }
 
 /**
@@ -174,19 +386,34 @@ export function applyProviderConfig(
     console.log(
       '[applyProviderConfig] Start app, applying full provider config',
     )
-    const config = getProviderConfig(provider, projectName, framework)
+    const config = getProviderConfig(provider, projectName, framework, result)
 
     // Add provider-specific config files
     for (const [path, content] of Object.entries(config.files)) {
       result[path] = content
     }
 
+    for (const path of config.deletedFiles) {
+      delete result[path]
+    }
+
     // Update package.json with dependencies and scripts
     if (result['package.json']) {
       result['package.json'] = updatePackageJson(
         result['package.json'],
-        provider,
-        config.devDependencies,
+        config.packageAdditions,
+      )
+    }
+
+    const pnpmBuildDependencies =
+      config.packageAdditions.pnpm?.onlyBuiltDependencies ?? []
+    if (
+      getProjectPackageManager(result) === 'pnpm' &&
+      pnpmBuildDependencies.length
+    ) {
+      result['pnpm-workspace.yaml'] = updatePnpmWorkspace(
+        result['pnpm-workspace.yaml'],
+        pnpmBuildDependencies,
       )
     }
 
@@ -195,7 +422,7 @@ export function applyProviderConfig(
     if (viteConfigPath) {
       result[viteConfigPath] = updateViteConfig(
         result[viteConfigPath],
-        provider,
+        config.viteIntegration,
       )
     }
   } else {
@@ -285,127 +512,154 @@ function findViteConfig(files: Record<string, string>): string | null {
  */
 function updatePackageJson(
   content: string,
-  provider: DeployProvider,
-  devDependencies: Record<string, string>,
+  packageAdditions: PackageAdditions,
 ): string {
-  try {
-    const pkg = JSON.parse(content)
+  const parsedPackageJson = parsePackageJson(content)
+  if (!isObject(parsedPackageJson)) return content
 
-    // Add dev dependencies
-    pkg.devDependencies = {
-      ...pkg.devDependencies,
-      ...devDependencies,
-    }
+  const packageJson = { ...parsedPackageJson }
 
-    // Update scripts based on provider
-    pkg.scripts = pkg.scripts ?? {}
-
-    switch (provider) {
-      case 'cloudflare':
-        pkg.scripts.preview = 'vite preview'
-        pkg.scripts.deploy = 'npm run build && wrangler deploy'
-        // Remove node-based start script if present
-        if (pkg.scripts.start?.includes('node')) {
-          delete pkg.scripts.start
-        }
-        break
-
-      case 'netlify':
-        // Netlify handles deployment via their platform
-        // Just ensure build script exists
-        pkg.scripts.build = pkg.scripts.build ?? 'vite build'
-        break
-
-      case 'railway':
-        // Railway needs node-based start script for Nitro
-        pkg.scripts.build = 'vite build'
-        pkg.scripts.start = 'node .output/server/index.mjs'
-        break
-    }
-
-    return JSON.stringify(pkg, null, 2)
-  } catch {
-    return content
+  packageJson.dependencies = {
+    ...getStringRecord(packageJson.dependencies),
+    ...packageAdditions.dependencies,
   }
+  packageJson.devDependencies = {
+    ...getStringRecord(packageJson.devDependencies),
+    ...packageAdditions.devDependencies,
+  }
+  packageJson.scripts = {
+    ...getStringRecord(packageJson.scripts),
+    ...packageAdditions.scripts,
+  }
+
+  if (packageAdditions.engines) {
+    packageJson.engines = {
+      ...getStringRecord(packageJson.engines),
+      ...packageAdditions.engines,
+    }
+  }
+
+  const existingPnpm = isObject(packageJson.pnpm) ? packageJson.pnpm : undefined
+  const existingOnlyBuiltDependencies = getStringArray(
+    existingPnpm?.onlyBuiltDependencies,
+  )
+  const addedOnlyBuiltDependencies =
+    packageAdditions.pnpm?.onlyBuiltDependencies ?? []
+  const onlyBuiltDependencies = [
+    ...new Set([
+      ...existingOnlyBuiltDependencies,
+      ...addedOnlyBuiltDependencies,
+    ]),
+  ]
+
+  if (existingPnpm || packageAdditions.pnpm) {
+    const pnpm: Record<string, unknown> = {
+      ...existingPnpm,
+      ...packageAdditions.pnpm,
+    }
+    if (onlyBuiltDependencies.length) {
+      pnpm.onlyBuiltDependencies = onlyBuiltDependencies
+    }
+    packageJson.pnpm = pnpm
+  }
+
+  return JSON.stringify(packageJson, null, 2)
+}
+
+function updatePnpmWorkspace(
+  content: string | undefined,
+  buildDependencies: ReadonlyArray<string>,
+): string {
+  const document = parseDocument(content ?? '')
+  if (document.errors.length) {
+    throw new Error('Cannot update an invalid pnpm-workspace.yaml')
+  }
+
+  for (const dependency of buildDependencies) {
+    try {
+      document.setIn(['allowBuilds', dependency], true)
+    } catch {
+      throw new Error(
+        'pnpm-workspace.yaml must define allowBuilds as a mapping',
+      )
+    }
+  }
+
+  return document.toString()
 }
 
 /**
  * Update vite.config.ts with provider-specific plugin
  */
-function updateViteConfig(content: string, provider: DeployProvider): string {
-  // This is a best-effort transformation
-  // It adds the necessary import and plugin to the vite config
-
+function updateViteConfig(
+  content: string,
+  integration: ViteIntegration | undefined,
+): string {
   let result = content
+  if (!integration?.import || !integration.code) {
+    return result
+  }
 
-  switch (provider) {
-    case 'cloudflare': {
-      // Add cloudflare import if not present
-      if (!result.includes('@cloudflare/vite-plugin')) {
-        // Find a good place to add the import (after other imports)
-        const lastImportIndex = findLastImportIndex(result)
-        const importStatement = `import { cloudflare } from '@cloudflare/vite-plugin'\n`
-        result =
-          result.slice(0, lastImportIndex) +
-          importStatement +
-          result.slice(lastImportIndex)
-      }
+  if (!hasEquivalentImport(result, integration.import)) {
+    const lastImportIndex = findLastImportIndex(result)
+    result =
+      result.slice(0, lastImportIndex) +
+      `${integration.import}\n` +
+      result.slice(lastImportIndex)
+  }
 
-      // Add cloudflare() to plugins array
-      if (!hasPluginCall(result, 'cloudflare')) {
-        result = addPluginToConfig(
-          result,
-          `cloudflare({ viteEnvironment: { name: 'ssr' } })`,
-        )
-      }
-      break
-    }
-
-    case 'netlify': {
-      // Add netlify import if not present
-      if (!result.includes('@netlify/vite-plugin-tanstack-start')) {
-        const lastImportIndex = findLastImportIndex(result)
-        const importStatement = `import netlify from '@netlify/vite-plugin-tanstack-start'\n`
-        result =
-          result.slice(0, lastImportIndex) +
-          importStatement +
-          result.slice(lastImportIndex)
-      }
-
-      // Add netlify() to plugins array
-      if (!hasPluginCall(result, 'netlify')) {
-        result = addPluginToConfig(result, 'netlify()')
-      }
-      break
-    }
-
-    case 'railway': {
-      // Add nitro import if not present
-      if (!result.includes('nitro/vite')) {
-        const lastImportIndex = findLastImportIndex(result)
-        const importStatement = `import { nitro } from 'nitro/vite'\n`
-        result =
-          result.slice(0, lastImportIndex) +
-          importStatement +
-          result.slice(lastImportIndex)
-      }
-
-      // Add nitro() to plugins array
-      if (!hasPluginCall(result, 'nitro')) {
-        result = addPluginToConfig(result, 'nitro()')
-      }
-      break
-    }
+  const pluginName = getPluginName(integration.code)
+  if (pluginName) {
+    result = upsertPluginCall(result, pluginName, integration.code)
   }
 
   return result
 }
 
-function hasPluginCall(
+function normalizeImportStatement(importStatement: string): string {
+  return importStatement
+    .trim()
+    .replace(/;$/, '')
+    .replaceAll('"', "'")
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([{},])\s*/g, '$1')
+}
+
+function hasEquivalentImport(
   content: string,
-  pluginName: 'cloudflare' | 'netlify' | 'nitro',
-) {
+  importStatement: string,
+): boolean {
+  const normalizedImport = normalizeImportStatement(importStatement)
+  const existingImports = content.match(/^import\s.+$/gm) ?? []
+  return existingImports.some(
+    (existingImport) =>
+      normalizeImportStatement(existingImport) === normalizedImport,
+  )
+}
+
+function getPluginName(pluginCall: string): string | undefined {
+  return /^([A-Za-z_$][\w$]*)\s*\(/.exec(pluginCall)?.[1]
+}
+
+function hasPluginCall(content: string, pluginName: string) {
   return new RegExp(`\\b${pluginName}\\s*\\(`).test(content)
+}
+
+function upsertPluginCall(
+  content: string,
+  pluginName: string,
+  pluginCall: string,
+): string {
+  const emptyPluginCall = new RegExp(`\\b${pluginName}\\s*\\(\\s*\\)`)
+  if (emptyPluginCall.test(content)) {
+    return content.replace(emptyPluginCall, pluginCall)
+  }
+
+  if (hasPluginCall(content, pluginName)) {
+    return content
+  }
+
+  return addPluginToConfig(content, pluginCall)
 }
 
 /**

--- a/src/utils/railway-partner.ts
+++ b/src/utils/railway-partner.ts
@@ -1,0 +1,39 @@
+import { getPartnerById, type Partner } from '~/utils/partners'
+
+const RAILWAY_PARTNER_ID = 'railway'
+const RAILWAY_DEPLOYMENT_ID = 'railway'
+const RAILWAY_DOCS_HASH = 'railway-official-partner'
+const RAILWAY_CREATE_COMMAND = `npx @tanstack/cli@latest create my-tanstack-app --deployment ${RAILWAY_DEPLOYMENT_ID}`
+
+export function createRailwayPartnerPageModel(partner: Partner | undefined) {
+  if (!partner || partner.id !== RAILWAY_PARTNER_ID) {
+    throw new Error('The Railway partner page requires the Railway record')
+  }
+
+  const docsResource = partner.resources?.find(
+    (resource) =>
+      resource.kind === 'documentation' &&
+      resource.href.startsWith('/start/') &&
+      resource.href.includes('/guide/hosting'),
+  )
+
+  if (!docsResource) {
+    throw new Error(
+      'The Railway partner page requires a TanStack Start hosting resource',
+    )
+  }
+
+  return {
+    create: {
+      command: RAILWAY_CREATE_COMMAND,
+      deploymentId: RAILWAY_DEPLOYMENT_ID,
+    },
+    docsHash: RAILWAY_DOCS_HASH,
+    docsResource,
+    partner,
+  }
+}
+
+export function getRailwayPartnerPageModel() {
+  return createRailwayPartnerPageModel(getPartnerById(RAILWAY_PARTNER_ID))
+}

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,6 +1,12 @@
 import { SITE_URL } from '~/utils/site'
 
-const NON_INDEXABLE_PATH_PREFIXES = ['/account', '/admin', '/login'] as const
+const NON_INDEXABLE_PATH_PREFIXES = [
+  '/account',
+  '/admin',
+  '/login',
+  '/partners-embed',
+  '/sponsors-embed',
+] as const
 
 function trimTrailingSlash(value: string) {
   return value.replace(/\/$/, '')

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -2,7 +2,7 @@ import { getBranch, libraries } from '~/libraries'
 import type { LibrarySlim } from '~/libraries/types'
 import { getPublishedPosts } from '~/utils/blog'
 import { getDocsManifest } from '~/utils/docs'
-import { partners } from '~/utils/partners'
+import { getPartnerSitemapEntries } from '~/utils/partner-pages'
 import { SITE_URL } from '~/utils/site'
 
 export type SitemapEntry = {
@@ -19,7 +19,6 @@ const HIGH_VALUE_NON_DOC_PAGES = [
   '/support',
   '/workshops',
   '/paid-support',
-  '/partners',
 ] as const satisfies ReadonlyArray<string>
 
 const LOW_VALUE_DOCS_SITEMAP_SEGMENTS = new Set(['examples', 'community'])
@@ -105,15 +104,6 @@ function getBlogEntries(): Array<SitemapEntry> {
   }))
 }
 
-function getPartnerEntries(): Array<SitemapEntry> {
-  return partners.map((partner) => ({
-    path: `/partners/${partner.id}`,
-    lastModified: partner.lastReviewedAt
-      ? asLastModified(partner.lastReviewedAt)
-      : undefined,
-  }))
-}
-
 export function getSiteOrigin() {
   return trimTrailingSlash(SITE_URL)
 }
@@ -128,7 +118,7 @@ export async function getSitemapEntries(): Promise<Array<SitemapEntry>> {
     ...getLibraryEntries(),
     ...docsEntries.flat(),
     ...getBlogEntries(),
-    ...getPartnerEntries(),
+    ...getPartnerSitemapEntries(),
   ].filter(
     (entry) =>
       entry.path !== '/intent/registry' &&

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -2,6 +2,7 @@ import { getBranch, libraries } from '~/libraries'
 import type { LibrarySlim } from '~/libraries/types'
 import { getPublishedPosts } from '~/utils/blog'
 import { getDocsManifest } from '~/utils/docs'
+import { partners } from '~/utils/partners'
 import { SITE_URL } from '~/utils/site'
 
 export type SitemapEntry = {
@@ -18,6 +19,7 @@ const HIGH_VALUE_NON_DOC_PAGES = [
   '/support',
   '/workshops',
   '/paid-support',
+  '/partners',
 ] as const satisfies ReadonlyArray<string>
 
 const LOW_VALUE_DOCS_SITEMAP_SEGMENTS = new Set(['examples', 'community'])
@@ -103,6 +105,15 @@ function getBlogEntries(): Array<SitemapEntry> {
   }))
 }
 
+function getPartnerEntries(): Array<SitemapEntry> {
+  return partners.map((partner) => ({
+    path: `/partners/${partner.id}`,
+    lastModified: partner.lastReviewedAt
+      ? asLastModified(partner.lastReviewedAt)
+      : undefined,
+  }))
+}
+
 export function getSiteOrigin() {
   return trimTrailingSlash(SITE_URL)
 }
@@ -117,6 +128,7 @@ export async function getSitemapEntries(): Promise<Array<SitemapEntry>> {
     ...getLibraryEntries(),
     ...docsEntries.flat(),
     ...getBlogEntries(),
+    ...getPartnerEntries(),
   ].filter(
     (entry) =>
       entry.path !== '/intent/registry' &&

--- a/tests/application-starter-partners.test.ts
+++ b/tests/application-starter-partners.test.ts
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+
+const require = createRequire(import.meta.url)
+const loadAsset: NodeJS.RequireExtensions[string] = (module, filename) => {
+  module.exports = filename
+}
+
+require.extensions['.png'] = loadAsset
+require.extensions['.svg'] = loadAsset
+
+const {
+  resolveApplicationStarterDeterministically,
+}: typeof import('../src/utils/application-starter') = require('../src/utils/application-starter')
+const {
+  composeApplicationStarterInput,
+  getInferredApplicationStarterPartnerIdsFromUserInput,
+  partners,
+}: typeof import('../src/utils/partners') = require('../src/utils/partners')
+const {
+  TEMPLATES,
+}: typeof import('../src/builder/templates') = require('../src/builder/templates')
+
+const formerPartnerFeatures = ['convex', 'neon', 'strapi']
+
+test('active partner records include the audit contract', () => {
+  for (const partner of partners) {
+    if (partner.status !== 'active') continue
+
+    assert.match(partner.lastReviewedAt, /^\d{4}-\d{2}-\d{2}$/)
+    assert.match(partner.canonicalHref, /^https:\/\//)
+    assert.ok(partner.resources.length > 0)
+    assert.equal(Object.hasOwn(partner, 'libraries'), false)
+  }
+})
+
+function assertDoesNotDefaultToFormerPartners(features: Array<string>) {
+  for (const feature of formerPartnerFeatures) {
+    assert.equal(features.includes(feature), false)
+  }
+}
+
+test('starter recipes do not silently select former partners', async () => {
+  const prompts = [
+    'Build a SaaS app with auth and a database.',
+    'Build a content site backed by a CMS.',
+    'Build a realtime collaborative app.',
+    'Migrate an existing Next.js app.',
+  ]
+
+  for (const input of prompts) {
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input,
+    })
+
+    assertDoesNotDefaultToFormerPartners(result.recipe.features)
+  }
+})
+
+test('starter recipes do not silently select unsafe monitoring defaults', async () => {
+  for (const input of [
+    'Build a SaaS app with auth and a database.',
+    'Build a full-stack TanStack Start app with auth, database access, and forms.',
+    'Build a product app with authentication, Postgres, and forms. Use pnpm.',
+    'Migrate an existing Next.js app.',
+  ]) {
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input,
+    })
+
+    assert.equal(result.recipe.features.includes('sentry'), false)
+  }
+})
+
+test('generic auth and monitoring requests do not infer vendor partners', async () => {
+  for (const { input, excludedPartners } of [
+    {
+      input: 'Build an app with authentication.',
+      excludedPartners: ['clerk', 'workos'],
+    },
+    {
+      input: 'Build an app with error tracking and observability.',
+      excludedPartners: ['sentry'],
+    },
+  ]) {
+    const inferredPartners =
+      getInferredApplicationStarterPartnerIdsFromUserInput(input, [])
+    const composedInput = composeApplicationStarterInput(
+      input,
+      [],
+      inferredPartners,
+    )
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input: composedInput,
+    })
+
+    for (const partnerId of excludedPartners) {
+      assert.equal(inferredPartners.includes(partnerId), false)
+      assert.equal(result.recipe.features.includes(partnerId), false)
+    }
+  }
+})
+
+test('selected auth partners survive generic auth language', async () => {
+  for (const partnerId of ['clerk', 'workos']) {
+    const input = composeApplicationStarterInput(
+      'Build an app with authentication.',
+      [partnerId],
+      [],
+    )
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input,
+    })
+
+    assert.ok(result.recipe.features.includes(partnerId))
+    assert.equal(result.recipe.features.includes('better-auth'), false)
+  }
+})
+
+test('starter presets do not silently select former partners', () => {
+  for (const template of TEMPLATES) {
+    assertDoesNotDefaultToFormerPartners(template.features)
+  }
+
+  assert.ok(
+    TEMPLATES.find((template) => template.id === 'saas')?.features.includes(
+      'prisma',
+    ),
+  )
+  assert.ok(
+    TEMPLATES.find((template) => template.id === 'realtime')?.features.includes(
+      'db',
+    ),
+  )
+})
+
+test('Prisma and Drizzle no longer pull in Neon', async () => {
+  for (const input of [
+    'Build an app with Prisma.',
+    'Build an app with Drizzle.',
+  ]) {
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input,
+    })
+
+    assert.equal(result.recipe.features.includes('neon'), false)
+  }
+})
+
+test('database constraints survive starter defaults and inference', async () => {
+  const withoutHosted = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input: 'Build a SaaS app without a hosted database.',
+  })
+  assert.ok(withoutHosted.recipe.features.includes('prisma'))
+  assert.deepEqual(withoutHosted.recipe.featureOptions.prisma, {
+    database: 'sqlite',
+  })
+  assert.match(withoutHosted.cliCommand, /prisma/)
+  assert.match(withoutHosted.cliCommand, /database.*sqlite/)
+  assert.match(
+    withoutHosted.advancedBuilderUrl ?? '',
+    /prisma\.database=sqlite/,
+  )
+  assert.match(withoutHosted.downloadUrl ?? '', /prisma\.database=sqlite/)
+
+  const withoutDatabase = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input: 'Build a SaaS app without a database.',
+  })
+  for (const feature of ['convex', 'db', 'drizzle', 'neon', 'prisma']) {
+    assert.equal(withoutDatabase.recipe.features.includes(feature), false)
+  }
+
+  const withoutPrisma = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input: 'Build a SaaS app without Prisma.',
+  })
+  assert.equal(withoutPrisma.recipe.features.includes('prisma'), false)
+  assert.ok(withoutPrisma.recipe.features.includes('drizzle'))
+
+  const withoutTanStackDb = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input: 'Build a realtime collaborative app without TanStack DB.',
+  })
+  assert.equal(withoutTanStackDb.recipe.features.includes('db'), false)
+})
+
+test('an explicitly selected Prisma integration survives realtime inference', async () => {
+  const input = composeApplicationStarterInput(
+    'Build a realtime collaborative app.',
+    ['prisma'],
+    [],
+  )
+  const result = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input,
+  })
+
+  assert.ok(result.recipe.features.includes('prisma'))
+  assert.equal(result.recipe.features.includes('neon'), false)
+})
+
+test('former partner integrations remain available when explicitly requested', async () => {
+  for (const feature of formerPartnerFeatures) {
+    const result = await resolveApplicationStarterDeterministically({
+      context: 'home',
+      input: `Build an app with ${feature}.`,
+    })
+
+    assert.ok(result.recipe.features.includes(feature))
+  }
+})
+
+test('OpenRouter guidance prefers the TanStack AI adapter', async () => {
+  const input = composeApplicationStarterInput(
+    'Build an AI chat app with TanStack AI.',
+    ['openrouter'],
+    [],
+  )
+  const result = await resolveApplicationStarterDeterministically({
+    context: 'home',
+    input,
+  })
+
+  assert.match(result.prompt, /@tanstack\/ai-openrouter/)
+})

--- a/tests/application-starter-partners.test.ts
+++ b/tests/application-starter-partners.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { test } from 'node:test'
 
@@ -21,6 +22,16 @@ const {
 const {
   TEMPLATES,
 }: typeof import('../src/builder/templates') = require('../src/builder/templates')
+const {
+  getPartnerSitemapEntries,
+}: typeof import('../src/utils/partner-pages') = require('../src/utils/partner-pages')
+const {
+  createRailwayPartnerPageModel,
+  getRailwayPartnerPageModel,
+}: typeof import('../src/utils/railway-partner') = require('../src/utils/railway-partner')
+const {
+  addOn: reactRailwayAddOn,
+}: typeof import('@tanstack/create/worker-manifest/frameworks/react/add-ons/railway') = require('@tanstack/create/worker-manifest/frameworks/react/add-ons/railway')
 
 const formerPartnerFeatures = ['convex', 'neon', 'strapi']
 
@@ -33,6 +44,121 @@ test('active partner records include the audit contract', () => {
     assert.ok(partner.resources.length > 0)
     assert.equal(Object.hasOwn(partner, 'libraries'), false)
   }
+})
+
+test('partner records have stable ids and explicit lifecycle data', () => {
+  const partnerIds = new Set<string>()
+
+  for (const partner of partners) {
+    assert.match(partner.id, /^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+    assert.equal(
+      partnerIds.has(partner.id),
+      false,
+      `duplicate id: ${partner.id}`,
+    )
+    partnerIds.add(partner.id)
+
+    if (partner.status === 'inactive') {
+      assert.equal(Object.hasOwn(partner, 'startDate'), true)
+      assert.equal(Object.hasOwn(partner, 'endDate'), true)
+    }
+  }
+})
+
+test('active partner reviews stay fresh', () => {
+  const dayMs = 24 * 60 * 60 * 1000
+  const maximumReviewAgeMs = 120 * dayMs
+  const now = Date.now()
+
+  for (const partner of partners) {
+    if (partner.status !== 'active') continue
+
+    const reviewedAt = Date.parse(`${partner.lastReviewedAt}T12:00:00.000Z`)
+    assert.equal(Number.isNaN(reviewedAt), false)
+    assert.ok(
+      reviewedAt <= now + dayMs,
+      `${partner.id} review is in the future`,
+    )
+    assert.ok(
+      now - reviewedAt <= maximumReviewAgeMs,
+      `${partner.id} review is more than 120 days old`,
+    )
+  }
+})
+
+test('internal partner resources point at matching TanStack content', () => {
+  for (const partner of partners) {
+    for (const resource of partner.resources ?? []) {
+      if (!resource.href.startsWith('/')) {
+        assert.doesNotThrow(() => new URL(resource.href))
+        continue
+      }
+
+      const url = new URL(resource.href, 'https://tanstack.com')
+      assert.equal(url.origin, 'https://tanstack.com')
+
+      if (url.pathname.startsWith('/blog/')) {
+        const slug = url.pathname.slice('/blog/'.length)
+        assert.ok(
+          existsSync(new URL(`../src/blog/${slug}.md`, import.meta.url)),
+          `${partner.id} references missing blog post ${url.pathname}`,
+        )
+        continue
+      }
+
+      assert.match(url.pathname, /^\/[^/]+\/latest\/docs\//)
+      const libraryId = url.pathname.split('/')[1]
+      const relatedProductIds = new Set<string>(partner.relatedProducts ?? [])
+      assert.ok(
+        libraryId && relatedProductIds.has(libraryId),
+        `${partner.id} resource ${url.pathname} does not match a related product`,
+      )
+    }
+  }
+})
+
+test('partner sitemap exposes both directory states and every detail page', () => {
+  const entries = getPartnerSitemapEntries()
+  const paths = entries.map((entry) => entry.path)
+
+  assert.equal(new Set(paths).size, paths.length)
+  assert.ok(paths.includes('/partners'))
+  assert.ok(paths.includes('/partners?status=inactive'))
+
+  for (const partner of partners) {
+    assert.ok(paths.includes(`/partners/${partner.id}`))
+  }
+})
+
+test('custom Railway page derives its partner contract from central data', () => {
+  const model = getRailwayPartnerPageModel()
+  const { create, docsResource, partner } = model
+  const centralPartner = partners.find(
+    (candidate) => candidate.id === 'railway',
+  )
+
+  assert.equal(partner, centralPartner)
+  assert.ok(partner)
+  assert.equal(centralPartner?.category, 'deployment')
+  assert.ok(centralPartner?.resources?.includes(docsResource))
+  assert.equal(create.deploymentId, reactRailwayAddOn.id)
+  assert.equal(reactRailwayAddOn.partner.id, partner.id)
+  assert.equal(
+    create.command,
+    `npx @tanstack/cli@latest create my-tanstack-app --deployment ${reactRailwayAddOn.id}`,
+  )
+
+  const previousModel = createRailwayPartnerPageModel({
+    ...partner,
+    status: 'inactive',
+    startDate: null,
+    endDate: null,
+    tier: undefined,
+  })
+
+  assert.equal(previousModel.partner.status, 'inactive')
+  assert.equal(previousModel.partner.tier, undefined)
+  assert.equal(previousModel.docsResource, docsResource)
 })
 
 function assertDoesNotDefaultToFormerPartners(features: Array<string>) {

--- a/tests/create-worker.test.ts
+++ b/tests/create-worker.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { create } from '../src/builder/api/create-worker'
+
+const react = await create.getFrameworkById('react')
+if (!react) throw new Error('React framework not found')
+
+const addOns = create.getAllAddOns(react, 'file-router')
+const workos = addOns.find((addOn) => addOn.id === 'workos')
+const sentry = addOns.find((addOn) => addOn.id === 'sentry')
+
+if (!workos) throw new Error('WorkOS add-on not found')
+if (!sentry) throw new Error('Sentry add-on not found')
+assert.deepEqual(workos.partner, {
+  id: 'workos',
+  tier: 'silver',
+})
+assert.deepEqual(workos.packageAdditions?.engines, {
+  node: '>=22.11.0',
+})
+assert.deepEqual(sentry.packageAdditions?.pnpm, {
+  onlyBuiltDependencies: ['@sentry/cli'],
+})
+
+const [materializedWorkos] = await create.finalizeAddOns(react, 'file-router', [
+  'workos',
+])
+assert.deepEqual(materializedWorkos?.partner, {
+  id: 'workos',
+  tier: 'silver',
+})
+
+console.log('create worker tests passed')

--- a/tests/partner-directory.test.ts
+++ b/tests/partner-directory.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { defaultStringifySearch } from '@tanstack/react-router'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import * as v from 'valibot'
+import { PartnerStatusFilter } from '../src/components/PartnerStatusFilter'
+import {
+  getPartnerDirectoryMetadata,
+  getPartnerDirectorySearch,
+  normalizePartnerDirectorySearch,
+  partnerDirectorySearchSchema,
+} from '../src/utils/partner-directory'
+
+test('current partners use the bare directory canonical', () => {
+  const search = v.parse(partnerDirectorySearchSchema, { status: 'active' })
+
+  assert.equal(defaultStringifySearch(search), '')
+  assert.deepEqual(normalizePartnerDirectorySearch(search), {
+    status: 'active',
+  })
+  assert.deepEqual(getPartnerDirectorySearch('active'), {
+    status: undefined,
+  })
+})
+
+test('invalid partner status falls back to the bare current directory', () => {
+  const search = v.parse(partnerDirectorySearchSchema, { status: 'bogus' })
+
+  assert.equal(defaultStringifySearch(search), '')
+  assert.deepEqual(normalizePartnerDirectorySearch(search), {
+    status: 'active',
+  })
+})
+
+test('previous partners keep a distinct canonical and metadata', () => {
+  const search = v.parse(partnerDirectorySearchSchema, {
+    status: 'inactive',
+  })
+  const metadata = getPartnerDirectoryMetadata('inactive')
+
+  assert.equal(defaultStringifySearch(search), '?status=inactive')
+  assert.deepEqual(normalizePartnerDirectorySearch(search), {
+    status: 'inactive',
+  })
+  assert.match(metadata.title, /Previous/)
+  assert.match(metadata.description, /previously supported/)
+})
+
+test('status filter uses a keyboard-native radio group', () => {
+  const html = renderToStaticMarkup(
+    createElement(PartnerStatusFilter, {
+      selectedStatus: 'active',
+      onStatusChange: () => {},
+    }),
+  )
+
+  assert.equal((html.match(/type="radio"/g) ?? []).length, 2)
+  assert.equal((html.match(/name="partner-status"/g) ?? []).length, 2)
+  assert.equal((html.match(/checked=""/g) ?? []).length, 1)
+  assert.match(html, /<fieldset/)
+  assert.match(html, /<legend/)
+  assert.match(html, /peer-focus-visible:outline/)
+})

--- a/tests/partner-pages.test.ts
+++ b/tests/partner-pages.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import {
+  getPartnerWindowLabel,
+  type PartnerLifecycle,
+} from '../src/utils/partner-lifecycle'
+
+const basePartner = {
+  status: 'inactive',
+  startDate: 'Jan 2026',
+} satisfies PartnerLifecycle
+
+assert.equal(
+  getPartnerWindowLabel(basePartner),
+  'Started Jan 2026',
+  'inactive partners without a known end date must not render as present',
+)
+
+assert.equal(
+  getPartnerWindowLabel({ ...basePartner, status: 'active' }),
+  'Jan 2026 - Present',
+  'active partners without an end date render as present',
+)
+
+assert.equal(
+  getPartnerWindowLabel({ ...basePartner, endDate: 'Jun 2026' }),
+  'Jan 2026 - Jun 2026',
+  'known partner windows include both dates',
+)
+
+assert.equal(
+  getPartnerWindowLabel({ status: 'inactive', endDate: 'Jun 2026' }),
+  'Ended Jun 2026',
+  'end-only partner windows still communicate when the relationship ended',
+)
+
+console.log('partner page tests passed')

--- a/tests/partner-pages.test.ts
+++ b/tests/partner-pages.test.ts
@@ -4,15 +4,16 @@ import {
   type PartnerLifecycle,
 } from '../src/utils/partner-lifecycle'
 
-const basePartner = {
+const basePartner: PartnerLifecycle = {
   status: 'inactive',
   startDate: 'Jan 2026',
-} satisfies PartnerLifecycle
+  endDate: null,
+}
 
 assert.equal(
   getPartnerWindowLabel(basePartner),
-  'Started Jan 2026',
-  'inactive partners without a known end date must not render as present',
+  'Jan 2026 - End date unknown',
+  'inactive partners must label an unknown end date',
 )
 
 assert.equal(
@@ -28,9 +29,23 @@ assert.equal(
 )
 
 assert.equal(
-  getPartnerWindowLabel({ status: 'inactive', endDate: 'Jun 2026' }),
-  'Ended Jun 2026',
-  'end-only partner windows still communicate when the relationship ended',
+  getPartnerWindowLabel({
+    status: 'inactive',
+    startDate: null,
+    endDate: 'Jun 2026',
+  }),
+  'Start date unknown - Jun 2026',
+  'inactive partners must label an unknown start date',
+)
+
+assert.equal(
+  getPartnerWindowLabel({
+    status: 'inactive',
+    startDate: null,
+    endDate: null,
+  }),
+  'Dates unavailable',
+  'fully unknown partner windows remain explicit',
 )
 
 console.log('partner page tests passed')

--- a/tests/provider-config.test.ts
+++ b/tests/provider-config.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import {
+  applyProviderConfig,
+  getStartFramework,
+} from '../src/utils/provider-config.server'
+
+function createStartFiles(startPackage: string) {
+  return {
+    'package.json': JSON.stringify({
+      dependencies: {
+        [startPackage]: 'latest',
+      },
+      scripts: {
+        build: 'vite build',
+      },
+    }),
+    'vite.config.ts': `import { defineConfig } from 'vite'
+
+export default defineConfig({ plugins: [] })
+`,
+  }
+}
+
+const reactFiles = createStartFiles('@tanstack/react-start')
+const solidFiles = createStartFiles('@tanstack/solid-start')
+
+assert.equal(getStartFramework(reactFiles), 'react')
+assert.equal(getStartFramework(solidFiles), 'solid')
+assert.equal(getStartFramework({ 'package.json': '{invalid' }), null)
+
+const reactResult = applyProviderConfig(
+  reactFiles,
+  'cloudflare',
+  'React Example',
+)
+const solidResult = applyProviderConfig(
+  solidFiles,
+  'cloudflare',
+  'Solid Example',
+)
+
+assert.equal(
+  (reactResult['wrangler.jsonc'] ?? '').includes(
+    '"main": "@tanstack/react-start/server-entry"',
+  ),
+  true,
+)
+assert.equal(
+  (solidResult['wrangler.jsonc'] ?? '').includes(
+    '"main": "@tanstack/solid-start/server-entry"',
+  ),
+  true,
+)
+assert.equal(
+  (reactResult['wrangler.jsonc'] ?? '').includes(
+    '"compatibility_date": "2025-09-02"',
+  ),
+  true,
+)
+
+for (const provider of ['cloudflare', 'netlify', 'railway'] as const) {
+  const firstResult = applyProviderConfig(reactFiles, provider, 'React Example')
+  const secondResult = applyProviderConfig(
+    firstResult,
+    provider,
+    'React Example',
+  )
+
+  assert.deepEqual(
+    secondResult,
+    firstResult,
+    `${provider} provider configuration must be idempotent`,
+  )
+}
+
+console.log('provider config tests passed')

--- a/tests/provider-config.test.ts
+++ b/tests/provider-config.test.ts
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict'
+import { addOn as reactNetlifyAddOn } from '@tanstack/create/worker-manifest/frameworks/react/add-ons/netlify'
+import { addOn as reactRailwayAddOn } from '@tanstack/create/worker-manifest/frameworks/react/add-ons/railway'
+import { parseDocument } from 'yaml'
 import {
   applyProviderConfig,
   getStartFramework,
 } from '../src/utils/provider-config.server'
+import type { DeployProvider } from '../src/utils/provider-config.server'
 
-function createStartFiles(startPackage: string) {
+function createStartFiles(
+  startPackage: string,
+  packageJsonAdditions: Record<string, unknown> = {},
+) {
   return {
     'package.json': JSON.stringify({
       dependencies: {
@@ -13,6 +20,7 @@ function createStartFiles(startPackage: string) {
       scripts: {
         build: 'vite build',
       },
+      ...packageJsonAdditions,
     }),
     'vite.config.ts': `import { defineConfig } from 'vite'
 
@@ -58,7 +66,176 @@ assert.equal(
   true,
 )
 
-for (const provider of ['cloudflare', 'netlify', 'railway'] as const) {
+const reactPackageManagerResult = applyProviderConfig(
+  {
+    ...createStartFiles('@tanstack/react-start', {
+      packageManager: 'pnpm@11.1.0',
+      pnpm: {
+        onlyBuiltDependencies: ['esbuild'],
+      },
+    }),
+    'pnpm-lock.yaml': '',
+    'pnpm-workspace.yaml': `# Preserve this comment
+packages:
+  - .
+overrides:
+  react: 19.2.3
+allowBuilds:
+  esbuild: true
+  sharp: false
+`,
+  },
+  'cloudflare',
+  'React Example',
+)
+const reactCloudflarePackage = JSON.parse(
+  reactPackageManagerResult['package.json'] ?? '{}',
+)
+
+assert.equal(
+  reactCloudflarePackage.devDependencies['@cloudflare/vite-plugin'],
+  '^1.26.0',
+)
+assert.equal(reactCloudflarePackage.devDependencies.wrangler, '^4.70.0')
+assert.equal(
+  reactCloudflarePackage.scripts.deploy,
+  'pnpm run build && wrangler deploy',
+)
+assert.deepEqual(reactCloudflarePackage.pnpm.onlyBuiltDependencies, [
+  'esbuild',
+  'sharp',
+  'workerd',
+])
+const reactCloudflareWorkspaceContent =
+  reactPackageManagerResult['pnpm-workspace.yaml'] ?? ''
+const reactCloudflareWorkspace = parseDocument(reactCloudflareWorkspaceContent)
+assert.equal(reactCloudflareWorkspace.errors.length, 0)
+assert.equal(reactCloudflareWorkspace.getIn(['allowBuilds', 'esbuild']), true)
+assert.equal(reactCloudflareWorkspace.getIn(['allowBuilds', 'sharp']), true)
+assert.equal(reactCloudflareWorkspace.getIn(['allowBuilds', 'workerd']), true)
+assert.equal(reactCloudflareWorkspace.getIn(['overrides', 'react']), '19.2.3')
+assert.match(reactCloudflareWorkspaceContent, /# Preserve this comment/)
+assert.match(
+  reactPackageManagerResult['vite.config.ts'] ?? '',
+  /cloudflare\(\{ viteEnvironment: \{ name: 'ssr' \} \}\)/,
+)
+assert.deepEqual(
+  applyProviderConfig(reactPackageManagerResult, 'cloudflare', 'React Example'),
+  reactPackageManagerResult,
+)
+
+const newPnpmWorkspaceResult = applyProviderConfig(
+  {
+    ...createStartFiles('@tanstack/react-start', {
+      packageManager: 'pnpm@11.1.0',
+    }),
+    'pnpm-lock.yaml': '',
+  },
+  'cloudflare',
+  'React Example',
+)
+const newPnpmWorkspace = parseDocument(
+  newPnpmWorkspaceResult['pnpm-workspace.yaml'] ?? '',
+)
+assert.equal(newPnpmWorkspace.getIn(['allowBuilds', 'sharp']), true)
+assert.equal(newPnpmWorkspace.getIn(['allowBuilds', 'workerd']), true)
+
+const solidCloudflareResult = applyProviderConfig(
+  solidFiles,
+  'cloudflare',
+  'Solid Example',
+)
+const solidCloudflarePackage = JSON.parse(
+  solidCloudflareResult['package.json'] ?? '{}',
+)
+assert.equal(
+  solidCloudflarePackage.dependencies['@cloudflare/vite-plugin'],
+  '^1.26.0',
+)
+
+const netlifyResult = applyProviderConfig(
+  reactFiles,
+  'netlify',
+  'React Example',
+)
+assert.equal(
+  netlifyResult['netlify.toml'],
+  reactNetlifyAddOn.files['netlify.toml'],
+)
+
+const railwayResult = applyProviderConfig(
+  {
+    ...createStartFiles('@tanstack/react-start', {
+      dependencies: {
+        '@tanstack/react-start': 'latest',
+        '@sentry/tanstackstart-react': '^10.67.0',
+      },
+    }),
+    'nixpacks.toml': 'legacy config',
+  },
+  'railway',
+  'React Example',
+)
+const railwayPackage = JSON.parse(railwayResult['package.json'] ?? '{}')
+assert.equal(railwayPackage.dependencies.nitro, '3.0.260610-beta')
+assert.equal(railwayPackage.scripts.start, 'node .output/server/index.mjs')
+assert.equal('nixpacks.toml' in railwayResult, false)
+
+const sentryRailwayResult = applyProviderConfig(
+  {
+    ...createStartFiles('@tanstack/react-start', {
+      dependencies: {
+        '@tanstack/react-start': 'latest',
+        '@sentry/tanstackstart-react': '^10.67.0',
+      },
+      scripts: {
+        build: 'vite build && cp instrument.server.mjs .output/server',
+      },
+    }),
+    'instrument.server.mjs': 'import * as Sentry from "sentry"',
+  },
+  'railway',
+  'React Example',
+)
+const sentryRailwayPackage = JSON.parse(
+  sentryRailwayResult['package.json'] ?? '{}',
+)
+assert.equal(
+  sentryRailwayPackage.scripts.start,
+  'node --import ./.output/server/instrument.server.mjs .output/server/index.mjs',
+)
+assert.equal(
+  (sentryRailwayResult['vite.config.ts'] ?? '').includes(
+    reactRailwayAddOn.integrations[0].code,
+  ),
+  true,
+)
+
+const existingNitroResult = applyProviderConfig(
+  {
+    ...createStartFiles('@tanstack/react-start'),
+    'vite.config.ts': `import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
+
+export default defineConfig({ plugins: [nitro()] });
+`,
+  },
+  'railway',
+  'React Example',
+)
+const existingNitroViteConfig = existingNitroResult['vite.config.ts'] ?? ''
+assert.equal(
+  existingNitroViteConfig.match(/from ['"]nitro\/vite['"]/g)?.length,
+  1,
+)
+assert.equal(
+  existingNitroViteConfig.includes(reactRailwayAddOn.integrations[0].code),
+  true,
+)
+assert.equal(/\bnitro\s*\(\s*\)/.test(existingNitroViteConfig), false)
+
+const providers: Array<DeployProvider> = ['cloudflare', 'netlify', 'railway']
+for (const provider of providers) {
   const firstResult = applyProviderConfig(reactFiles, provider, 'React Example')
   const secondResult = applyProviderConfig(
     firstResult,

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getCanonicalPath, shouldIndexPath } from '../src/utils/seo'
+
+test('public partner pages remain indexable', () => {
+  assert.equal(shouldIndexPath('/partners'), true)
+  assert.equal(shouldIndexPath('/partners/cloudflare'), true)
+})
+
+test('transparent embed pages are not indexed', () => {
+  for (const path of ['/partners-embed', '/sponsors-embed']) {
+    assert.equal(getCanonicalPath(path), null)
+    assert.equal(shouldIndexPath(path), false)
+  }
+})


### PR DESCRIPTION
## Summary

- treat sponsors consistently as TanStack partners and strengthen partner data, pages, placement, and lifecycle handling
- sync the site builder and example deployment path with `@tanstack/create` 0.69, including pnpm 11 build approvals
- make the Railway Create path primary, fix partner SEO/accessibility/inquiry tracking, and add drift/recency/integrity coverage

## Validation

- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the partner directory with Current/Previous filtering, tier badges, resources, partnership history, and improved empty states.
  * Added partner inquiry links and tracking from the navigation, directory, and partner callouts.
  * Improved generated app setup and deployment configuration for TanStack Start projects.
  * Added partner pages to the sitemap and enhanced partner resource links.

* **Documentation**
  * Updated Netlify and OpenRouter partnership content with revised deployment and integration guidance.

* **Style**
  * Removed the Nozzle.io link from the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->