### PR TITLE
Update TanStack Highlight to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tanstack/ai-client": "^0.11.3",
     "@tanstack/ai-openai": "^0.9.5",
     "@tanstack/create": "^0.69.0",
-    "@tanstack/highlight": "^0.0.3",
+    "@tanstack/highlight": "^0.0.7",
     "@tanstack/markdown": "^0.0.11",
     "@tanstack/pacer": "^0.21.1",
     "@tanstack/react-hotkeys": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.69.0
         version: 0.69.0(tslib@2.8.1)
       '@tanstack/highlight':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.7
+        version: 0.0.7
       '@tanstack/markdown':
         specifier: ^0.0.11
         version: 0.0.11(react@19.2.3)
@@ -3323,8 +3323,9 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/highlight@0.0.3':
-    resolution: {integrity: sha512-U+4VEcxpRH1hazU9DHkeK31+O3V3pjU71UUNzTs+C4w2PtVsC5hDcnxbJxMC+fCvl9aLJGEIPc78Uw4tpd6mUw==}
+  '@tanstack/highlight@0.0.7':
+    resolution: {integrity: sha512-i7GwU+BNROlPGn4jA94iI7qcQa3nVprcveg3eYWRwQA5mJbtQmgZP97tl1A0eulTln+YoCQ82xoNmHJkuviEfA==}
+    engines: {node: '>=18'}
 
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
@@ -9640,7 +9641,7 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/highlight@0.0.3': {}
+  '@tanstack/highlight@0.0.7': {}
 
   '@tanstack/history@1.162.0': {}
 


### PR DESCRIPTION
Updates `@tanstack/highlight` from 0.0.3 to 0.0.7 so tanstack.com can render TSRX/Octane syntax highlighting.

Validation:

- `pnpm test`
- Verified the installed renderer normalizes `tsrx` and emits keyword and tag token classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the syntax highlighting dependency to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->