### PR TITLE
Fix inline code diff rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tanstack/ai-client": "^0.11.3",
     "@tanstack/ai-openai": "^0.9.5",
     "@tanstack/create": "^0.69.0",
-    "@tanstack/highlight": "^0.0.7",
+    "@tanstack/highlight": "^0.0.8",
     "@tanstack/markdown": "^0.0.11",
     "@tanstack/pacer": "^0.21.1",
     "@tanstack/react-hotkeys": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.69.0
         version: 0.69.0(tslib@2.8.1)
       '@tanstack/highlight':
-        specifier: ^0.0.7
-        version: 0.0.7
+        specifier: ^0.0.8
+        version: 0.0.8
       '@tanstack/markdown':
         specifier: ^0.0.11
         version: 0.0.11(react@19.2.3)
@@ -3323,8 +3323,8 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/highlight@0.0.7':
-    resolution: {integrity: sha512-i7GwU+BNROlPGn4jA94iI7qcQa3nVprcveg3eYWRwQA5mJbtQmgZP97tl1A0eulTln+YoCQ82xoNmHJkuviEfA==}
+  '@tanstack/highlight@0.0.8':
+    resolution: {integrity: sha512-v+QMPdA/g8ni3/wpd6UzRVvpBvKlxBXwe6XlCOZIUbamUaMWcBBFdrk4fvKKh2ArgFghWcP0rAQc5X8iQGNDYg==}
     engines: {node: '>=18'}
 
   '@tanstack/history@1.162.0':
@@ -9641,7 +9641,7 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/highlight@0.0.7': {}
+  '@tanstack/highlight@0.0.8': {}
 
   '@tanstack/history@1.162.0': {}
 

--- a/src/components/markdown/CodeBlock.tsx
+++ b/src/components/markdown/CodeBlock.tsx
@@ -1,4 +1,5 @@
-import { renderCodeBlockData } from '@tanstack/highlight'
+import { defaultHighlighter } from '@tanstack/highlight'
+import { renderCodeFence } from '@tanstack/highlight/markdown'
 import * as React from 'react'
 import { CodeBlockView } from './CodeBlockView'
 import { MermaidBlock } from './MermaidBlock'
@@ -37,7 +38,7 @@ function HighlightedCodeBlock({
   title?: string
 }) {
   const rendered = React.useMemo(() => {
-    return renderCodeBlockData({ code, lang, title })
+    return renderCodeFence({ code, lang, title }, defaultHighlighter)
   }, [code, lang, title])
 
   return (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -707,25 +707,17 @@ pre {
   @apply text-black overflow-x-auto relative leading-tight;
 }
 
-span.line {
-  display: inline-block;
-  width: 100%;
+.th-line--deleted,
+.th-line--inserted {
+  margin-inline: -1rem;
+  padding-inline: 1rem;
 }
 
-pre.has-diff span.diff {
-  width: calc(100% + 20px);
-  margin-left: -10px;
-  padding-right: 20px;
-  padding-left: 10px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-pre.has-diff span.remove {
+.th-line--deleted {
   background-color: #f43f5e29;
 }
 
-pre.has-diff span.add {
+.th-line--inserted {
   background-color: #10b98129;
 }
 /* Visually differentiates twoslash code samples  */

--- a/tests/code-highlighting.test.ts
+++ b/tests/code-highlighting.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { defaultHighlighter } from '@tanstack/highlight'
+import { renderCodeFence } from '@tanstack/highlight/markdown'
+
+test('inline diff notation renders as line decorations', () => {
+  const rendered = renderCodeFence(
+    {
+      code: [
+        `- const oldValue = true // [!code --]`,
+        `+ const newValue = true // [!code ++]`,
+      ].join('\n'),
+      lang: 'tsx',
+    },
+    defaultHighlighter,
+  )
+
+  assert.equal(
+    rendered.copyText,
+    [`- const oldValue = true`, `+ const newValue = true`].join('\n'),
+  )
+  assert.match(rendered.htmlMarkup, /th-line--deleted/)
+  assert.match(rendered.htmlMarkup, /th-line--inserted/)
+  assert.doesNotMatch(rendered.htmlMarkup, /!code/)
+})


### PR DESCRIPTION
## What changed

- upgrade `@tanstack/highlight` to `0.0.8`
- route markdown code fences through its notation-aware renderer
- restore inserted/deleted line styling for the new output classes
- add a regression test proving inline diff directives are removed from rendered and copied code

## Root cause

The migration from the previous Shiki renderer removed its notation-diff transformer. TanStack docs still correctly use `[!code --]` and `[!code ++]`, so those source directives leaked into output. The parser now lives in `@tanstack/highlight`, where every consumer can use it.

## Validation

- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved syntax highlighting for code blocks, including clearer rendering of inserted and deleted lines.
  - Added support for inline diff notation in code fences.

- **Bug Fixes**
  - Copying code from highlighted diff blocks now excludes diff markers and preserves clean source content.
  - Updated diff styling for more consistent line highlighting and alignment.

- **Tests**
  - Added coverage for inline diff rendering and copied code output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->