### PR TITLE
Fix highlighted code line spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tanstack/ai-client": "^0.11.3",
     "@tanstack/ai-openai": "^0.9.5",
     "@tanstack/create": "^0.69.0",
-    "@tanstack/highlight": "^0.0.8",
+    "@tanstack/highlight": "^0.0.9",
     "@tanstack/markdown": "^0.0.11",
     "@tanstack/pacer": "^0.21.1",
     "@tanstack/react-hotkeys": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.69.0
         version: 0.69.0(tslib@2.8.1)
       '@tanstack/highlight':
-        specifier: ^0.0.8
-        version: 0.0.8
+        specifier: ^0.0.9
+        version: 0.0.9
       '@tanstack/markdown':
         specifier: ^0.0.11
         version: 0.0.11(react@19.2.3)
@@ -3323,8 +3323,8 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/highlight@0.0.8':
-    resolution: {integrity: sha512-v+QMPdA/g8ni3/wpd6UzRVvpBvKlxBXwe6XlCOZIUbamUaMWcBBFdrk4fvKKh2ArgFghWcP0rAQc5X8iQGNDYg==}
+  '@tanstack/highlight@0.0.9':
+    resolution: {integrity: sha512-vWuVpuSprbsEq5gle5vp2CEBNVue65m09idkbv0rcCPFn3XnxzZg1Q9kownk24iCag6tJdfd/gtKSwllPbQvSA==}
     engines: {node: '>=18'}
 
   '@tanstack/history@1.162.0':
@@ -9641,7 +9641,7 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/highlight@0.0.8': {}
+  '@tanstack/highlight@0.0.9': {}
 
   '@tanstack/history@1.162.0': {}
 

--- a/tests/code-highlighting.test.ts
+++ b/tests/code-highlighting.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { defaultHighlighter } from '@tanstack/highlight'
 import { renderCodeFence } from '@tanstack/highlight/markdown'
+import { createThemeBaseCss } from '@tanstack/highlight/theme'
 
 test('inline diff notation renders as line decorations', () => {
   const rendered = renderCodeFence(
@@ -22,4 +23,14 @@ test('inline diff notation renders as line decorations', () => {
   assert.match(rendered.htmlMarkup, /th-line--deleted/)
   assert.match(rendered.htmlMarkup, /th-line--inserted/)
   assert.doesNotMatch(rendered.htmlMarkup, /!code/)
+})
+
+test('wrapped code lines occupy one visual row each', () => {
+  const css = createThemeBaseCss()
+
+  assert.match(
+    css,
+    /\.th-line \{ display: inline-block; min-width: 100%; width: max-content; \}/,
+  )
+  assert.doesNotMatch(css, /\.th-line \{ display: block;/)
 })


### PR DESCRIPTION
## What changed

- upgrade `@tanstack/highlight` to `0.0.9`
- add a regression test for the wrapped-line layout contract

## Root cause

Highlight preserved newline text nodes between line wrappers but styled the wrappers as block boxes. The newline after each block therefore occupied an extra visual row. Version `0.0.9` uses full-width inline-block wrappers, preserving source newlines without doubling the rendered spacing.

## Validation

- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code highlighting so wrapped lines remain grouped as a single visual line.
  * Prevented wrapped code from displaying with unintended spacing or block-level breaks.
* **Tests**
  * Added coverage to verify consistent rendering of wrapped code lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->