### PR TITLE
Fix Charts catalog frame embedding

### DIFF
--- a/src/utils/frame-embedding.ts
+++ b/src/utils/frame-embedding.ts
@@ -1,7 +1,11 @@
 import { isChartsCatalogEmbedPath } from './charts-catalog-embed'
 
 export function isFrameEmbeddingAllowed(pathname: string) {
-  return pathname === '/stats/npm/embed' || isChartsCatalogEmbedPath(pathname)
+  return (
+    pathname === '/stats/npm/embed' ||
+    isChartsCatalogEmbedPath(pathname) ||
+    isChartsCatalogEmbedPath(`${pathname}/`)
+  )
 }
 
 export const allowsFrameEmbedding = isFrameEmbeddingAllowed

--- a/tests/charts-catalog-frame-embedding.test.ts
+++ b/tests/charts-catalog-frame-embedding.test.ts
@@ -8,13 +8,13 @@ import { isFrameEmbeddingAllowed } from '../src/utils/frame-embedding'
 
 test('only exact catalog embed documents bypass the global frame denial', () => {
   assert.equal(isFrameEmbeddingAllowed('/charts/catalog/embed/01-line/'), true)
+  assert.equal(isFrameEmbeddingAllowed('/charts/catalog/embed/01-line'), true)
   assert.equal(isFrameEmbeddingAllowed('/stats/npm/embed'), true)
 
   for (const pathname of [
     '/charts/catalog/',
     '/charts/catalog/charts/01-line/',
     '/charts/catalog/embed/',
-    '/charts/catalog/embed/01-line',
     '/charts/catalog/embed/01-line/source/',
     '/charts/catalog/embed-malicious/01-line/',
     '/charts/catalog/embed/../admin/',


### PR DESCRIPTION
Fixes Charts documentation embeds blocked by `X-Frame-Options: DENY`.

TanStack Start canonicalizes catalog embed routes by removing the trailing slash. The frame allowlist only matched the pre-redirect trailing-slash path, so the final document inherited the global denial header.

This accepts both canonical route forms at the hosting-header boundary and adds regression coverage.

Validation:
- `pnpm exec tsx --test tests/charts-catalog-frame-embedding.test.ts` (3 passing)
- full unit suite (113 passing, 1 skipped)
- full repository hook remains blocked on current `main` by unrelated unresolved Charts landing imports (`@tanstack/charts`, `d3-scale`, `d3-shape`, and `../../packages/charts-core/src/index.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart catalog embed pages now work with or without a trailing slash in the URL.
  * Updated frame-embedding behavior to correctly allow supported catalog embed paths while continuing to block other paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->