### PR TITLE
Fix docs table of contents scrolling

### DIFF
--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -63,7 +63,6 @@ export function Toc({ headings, activeHeadings, currentFramework }: TocProps) {
                   ? 'border-current text-text-primary opacity-100'
                   : 'border-transparent',
               )}
-              resetScroll={false}
               hashScrollIntoView={{
                 behavior: 'smooth',
               }}


### PR DESCRIPTION
Fixes #937.

The docs TOC configured `resetScroll={false}` on same-page hash links. TanStack Router returns early from scroll restoration when that flag is set, so the following `hashScrollIntoView` behavior never runs.

This removes the conflicting flag and lets the existing smooth hash scrolling work.

Impact: “On this page” links navigate to their target headings again.

Validation: `pnpm test` (TypeScript, lint, 115 unit tests: 114 passed, 1 skipped).

Risk: Low. The change only restores the router’s default scroll handling for TOC hash links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-of-contents navigation with smooth scrolling when selecting a heading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->