### PR TITLE
Fix Intent registry package search

### DIFF
--- a/src/utils/intent.functions.ts
+++ b/src/utils/intent.functions.ts
@@ -24,6 +24,7 @@ import {
   selectVersionsToSync,
   extractSkillsFromTarball,
   fetchBulkDownloads,
+  npmPackageMatchesSearch,
   searchIntentPackagesByText,
 } from './intent.server'
 import { fetchCached } from './cache.server'
@@ -203,8 +204,13 @@ export const getIntentDirectory = createServerFn({ method: 'GET' })
     })
 
     // Build the set of packages to show: union of NPM results + DB name matches
+    const matchingNpmObjects = search
+      ? npmData.objects.filter((obj) =>
+          npmPackageMatchesSearch(obj.package, search),
+        )
+      : npmData.objects
     const npmByName = new Map(
-      npmData.objects.map((obj) => [obj.package.name, obj]),
+      matchingNpmObjects.map((obj) => [obj.package.name, obj]),
     )
     const dbMatchNames = new Set(dbSearchMatches.map((p) => p.name))
     const summaryByPackageName = new Map(

--- a/src/utils/intent.server.ts
+++ b/src/utils/intent.server.ts
@@ -35,6 +35,34 @@ export interface NpmSearchResult {
   time: string
 }
 
+type SearchableNpmPackage = {
+  name: string
+  description: string
+  keywords?: Array<string>
+}
+
+export function npmPackageMatchesSearch(
+  pkg: SearchableNpmPackage,
+  search: string,
+) {
+  const normalizedSearch = search.trim().toLowerCase()
+  if (!normalizedSearch) return true
+
+  const packageText = [
+    pkg.name,
+    pkg.description,
+    ...(pkg.keywords?.filter(
+      (keyword) => keyword.toLowerCase() !== 'tanstack-intent',
+    ) ?? []),
+  ]
+    .join(' ')
+    .toLowerCase()
+
+  return normalizedSearch
+    .split(/\s+/)
+    .every((term) => packageText.includes(term))
+}
+
 export interface NpmPackument {
   name: string
   description?: string

--- a/tests/intent-package-search.test.ts
+++ b/tests/intent-package-search.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { npmPackageMatchesSearch } from '../src/utils/intent.server'
+
+const pkg = {
+  name: '@apollo/client',
+  description: 'A fully-featured caching GraphQL client.',
+  keywords: ['apollo', 'graphql', 'react', 'tanstack-intent'],
+}
+
+test('matches package metadata without treating the registry keyword as a match', () => {
+  assert.equal(npmPackageMatchesSearch(pkg, 'apollo client'), true)
+  assert.equal(npmPackageMatchesSearch(pkg, 'caching graphql'), true)
+  assert.equal(npmPackageMatchesSearch(pkg, 'react'), true)
+  assert.equal(npmPackageMatchesSearch(pkg, 'intent'), false)
+  assert.equal(npmPackageMatchesSearch(pkg, 'asdfasdfasdfasdf'), false)
+})


### PR DESCRIPTION
## What changed

- filter npm's package-search response against package name, description, and keywords before merging it into the verified Intent directory
- ignore the shared `tanstack-intent` registry marker when matching user queries
- require every whitespace-separated search term to match package metadata
- add a focused regression test

## Evidence and impact

The npm search API treats `keywords:tanstack-intent` as sufficient even when the user term does not match. The reported nonsense query returned all 243 Intent-tagged packages, so the UI could not produce an empty or meaningfully narrowed package result. Local filtering preserves npm metadata search while removing unrelated results.

Closes #1070

## Validation

- reproduced the upstream behavior directly against `registry.npmjs.org`
- `pnpm test` — TypeScript, oxlint, and 116 tests: 115 passed, 1 skipped
- commit hook reran formatting and the same full test gate successfully

## Risk

Low. The change only affects non-empty package searches. Matching is intentionally stricter than npm's fuzzy ranking: all entered terms must occur in the package name, description, or non-registry keywords.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved package search results by matching queries against package names, descriptions, and relevant keywords.
  * Multi-term searches now return only packages matching all entered terms.
  * Registry-specific keywords are excluded from search matching to reduce unrelated results.

* **Bug Fixes**
  * Fixed package listings that could previously include results unrelated to the entered search query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->