### PR TITLE
Update Charts landing and catalog contracts

### DIFF
--- a/src/components/charts/ChartsCatalogPages.tsx
+++ b/src/components/charts/ChartsCatalogPages.tsx
@@ -1,12 +1,15 @@
 import { ArrowsOutSimple, GridFour } from '@phosphor-icons/react'
 import { Link } from '@tanstack/react-router'
 import * as React from 'react'
-import { CodeBlock } from '~/components/markdown/CodeBlock'
-import type { ChartsCatalogCase } from '~/utils/charts-catalog'
+import type {
+  ChartsCatalogAuthoredSource,
+  ChartsCatalogCase,
+} from '~/utils/charts-catalog'
 import {
   ChartsCatalogChart,
   type ChartsCatalogModuleReference,
 } from './ChartsCatalogChart'
+import { ChartsCatalogSource } from './ChartsCatalogSource'
 import { Resizable, type ResizableSizeChange } from '../npm-stats/Resizable'
 
 type CatalogCaseMetadata = Pick<
@@ -120,9 +123,9 @@ export function ChartsCatalogDetail({
   artifactRevision: string
   catalogCase: CatalogCaseMetadata & {
     modules: CatalogCaseModules
-    code: {
-      tanstack: { path: string; source: string }
-      comparison?: { path: string; source?: string }
+    authoredSource: {
+      tanstack: ChartsCatalogAuthoredSource
+      comparison?: ChartsCatalogAuthoredSource
     }
   }
 }) {
@@ -166,15 +169,15 @@ export function ChartsCatalogDetail({
       </div>
 
       <div className={`mt-6 grid gap-3 ${comparison ? 'xl:grid-cols-2' : ''}`}>
-        <SourceBlock
-          path={catalogCase.code.tanstack.path}
-          source={catalogCase.code.tanstack.source}
-        />
-        {catalogCase.code.comparison?.source ? (
-          <SourceBlock
-            path={catalogCase.code.comparison.path}
-            source={catalogCase.code.comparison.source}
-          />
+        <ChartPanel label="TanStack source">
+          <ChartsCatalogSource source={catalogCase.authoredSource.tanstack} />
+        </ChartPanel>
+        {catalogCase.authoredSource.comparison && comparison ? (
+          <ChartPanel label={`${rendererLabel(comparison.renderer)} source`}>
+            <ChartsCatalogSource
+              source={catalogCase.authoredSource.comparison}
+            />
+          </ChartPanel>
         ) : null}
       </div>
     </CatalogSurface>
@@ -307,22 +310,6 @@ function ChartPanel({
       <p className="mb-2 text-xs font-medium text-gray-500">{label}</p>
       {children}
     </div>
-  )
-}
-
-function SourceBlock({ path, source }: { path: string; source: string }) {
-  return (
-    <details className="min-w-0 rounded-lg border border-gray-200 dark:border-gray-800">
-      <summary className="cursor-pointer px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
-        {path}
-      </summary>
-      <CodeBlock
-        showTypeCopyButton={false}
-        className="max-h-[32rem] rounded-none border-x-0 border-b-0 [&_pre]:max-h-[32rem] [&_pre]:overflow-auto"
-      >
-        <code className="language-ts">{source}</code>
-      </CodeBlock>
-    </details>
   )
 }
 

--- a/src/components/charts/ChartsCatalogSource.tsx
+++ b/src/components/charts/ChartsCatalogSource.tsx
@@ -1,0 +1,144 @@
+import { CodeBlock } from '~/components/markdown/CodeBlock'
+import type {
+  ChartsCatalogAuthoredSource,
+  ChartsCatalogDataset,
+} from '~/utils/charts-catalog'
+
+export function ChartsCatalogSource({
+  source,
+}: {
+  source: ChartsCatalogAuthoredSource
+}) {
+  const chartLines = source.roles.entry.lines + source.roles.support.lines
+  const fixtureLines = source.roles.fixture.lines
+
+  return (
+    <div className="space-y-3 p-4">
+      <p className="flex flex-wrap justify-between gap-x-4 gap-y-1 text-xs text-gray-500">
+        <span>
+          {[
+            formatCount(chartLines, 'chart line'),
+            fixtureLines
+              ? formatCount(fixtureLines, 'data-selection line')
+              : '',
+            formatCount(source.totalFiles, 'file'),
+            formatBytes(source.totalBytes),
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        </span>
+        {source.excludedHarness.paths.length ? (
+          <span>
+            Benchmark harness excluded ·{' '}
+            {source.excludedHarness.paths.join(', ')}
+          </span>
+        ) : null}
+      </p>
+
+      {source.datasets.map((dataset) => (
+        <CatalogDataset key={dataset.id} dataset={dataset} />
+      ))}
+
+      {source.files.map((file) => (
+        <details
+          key={`${file.kind}:${file.path}`}
+          open={file.kind !== 'fixture'}
+          className="min-w-0 rounded-lg border border-gray-200 dark:border-gray-800"
+        >
+          <summary className="flex cursor-pointer flex-wrap items-center justify-between gap-2 px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+            <span>{file.path}</span>
+            <span>
+              {formatCount(file.lines, 'line')} · {file.kind}
+            </span>
+          </summary>
+          <CodeBlock
+            data-code-title={file.path}
+            showTypeCopyButton={false}
+            className="max-h-[32rem] rounded-none border-x-0 border-b-0 [&_pre]:max-h-[32rem] [&_pre]:overflow-auto"
+          >
+            <code className="language-ts">{file.source}</code>
+          </CodeBlock>
+        </details>
+      ))}
+    </div>
+  )
+}
+
+function CatalogDataset({ dataset }: { dataset: ChartsCatalogDataset }) {
+  return (
+    <section
+      aria-label={`${dataset.title} dataset`}
+      className="rounded-lg border border-gray-200 px-4 py-3 text-xs text-gray-600 dark:border-gray-800 dark:text-gray-400"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <strong className="text-gray-950 dark:text-white">
+          {dataset.title}
+        </strong>
+        <span>
+          {formatCount(dataset.records, 'record')} · {dataset.format} ·{' '}
+          {formatBytes(dataset.bytes)}
+        </span>
+      </div>
+      <code className="mt-2 block text-gray-700 dark:text-gray-300">
+        {dataset.specifier}
+      </code>
+      {dataset.selection ? (
+        <p className="mt-2">Selection: {dataset.selection}</p>
+      ) : null}
+      {dataset.schema.length ? (
+        <dl className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          {dataset.schema.map((field, index) => (
+            <div key={`${field.name}:${index}`} className="flex gap-1">
+              <dt className="font-medium text-gray-700 dark:text-gray-300">
+                {field.name}
+              </dt>
+              <dd>{field.types.join(' | ')}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      <p className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+        <SafeLink href={dataset.sourceUrl}>{dataset.source}</SafeLink>
+        <span>
+          {dataset.observablePackage} · revision{' '}
+          {dataset.observableRevision.slice(0, 12)} · {dataset.observableFile} ·{' '}
+          {dataset.license} · SHA-256 {dataset.sha256.slice(0, 12)}
+        </span>
+        <SafeLink href={dataset.observableUrl}>Pinned snapshot</SafeLink>
+      </p>
+    </section>
+  )
+}
+
+function SafeLink({ children, href }: { children: string; href: string }) {
+  if (!isHttpUrl(href)) return <span>{children}</span>
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="text-blue-600 hover:underline dark:text-blue-400"
+    >
+      {children}
+    </a>
+  )
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+function formatCount(value: number, noun: string) {
+  return `${value.toLocaleString('en-US')} ${noun}${value === 1 ? '' : 's'}`
+}
+
+function formatBytes(value: number) {
+  if (value < 1_000) return `${value} B`
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)} kB`
+  return `${(value / 1_000_000).toFixed(1)} MB`
+}

--- a/src/components/landing/ChartsLanding.tsx
+++ b/src/components/landing/ChartsLanding.tsx
@@ -18,7 +18,7 @@ import {
 } from './ChartsCatalogGallery'
 import { LandingCopyPromptButton } from './LandingCopyPromptButton'
 
-const chartPrompt = `Using TanStack Charts and the accounts array in this project, plot monthlyRevenue on x and retention on y. Size each point by seats, color it by segment, and keep the original Account type in tooltip and focus callbacks. Use explicit D3 scales with empty-data fallbacks, add a useful ariaLabel, and render it through the React adapter with a tooltip.`
+const chartPrompt = `Using TanStack Charts and the accounts array in this project, plot monthlyRevenue on x and retention on y. Size each point by seats, color it by segment, and keep the original Account type in tooltip and focus callbacks. Use D3 scale factories so TanStack Charts can infer the domains, enable the tooltip on the chart definition, add a useful ariaLabel, and render it through the React adapter.`
 
 export default function ChartsLanding({
   catalog,
@@ -29,7 +29,7 @@ export default function ChartsLanding({
 }) {
   return (
     <LibraryLandingShell
-      description="Build the chart you need from typed data, marks, channels, and D3 scales—then render responsive SVG in React or vanilla TypeScript."
+      description="Build from typed data, marks, channels, and D3 scales. Render responsive SVG through vanilla TypeScript or adapters for React, Vue, Svelte, Solid, Angular, Preact, Lit, Alpine, and Octane."
       headline="A chart grammar you don't have to outgrow."
       hero={<KineticChartsHero />}
       libraryId="charts"
@@ -73,8 +73,8 @@ export default function ChartsLanding({
             </h2>
             <p className="mt-6 max-w-xl text-ds-body-sm text-text-secondary sm:text-ds-body-md">
               Every example compiles under strict TypeScript. Fields, datum
-              types, domains, tooltips, and focus callbacks stay connected to
-              the source datum; the type suite rejects eight invalid
+              types, inferred domains and keys, tooltips, and focus callbacks
+              stay connected to the source datum; the type suite rejects invalid
               definitions.
             </p>
 
@@ -121,12 +121,17 @@ export default function ChartsLanding({
       <LandingSection tone="raised">
         <div className="grid gap-8 lg:grid-cols-[0.88fr_1.12fr] lg:items-end lg:gap-16">
           <h2 className="max-w-3xl font-ds-display text-ds-heading-1 md:text-ds-display-md">
-            Complete SVG charts. 18.5–19.2 kB gzip.
+            Complete SVG charts. 24.2–24.8 KiB gzip.
           </h2>
           <p className="max-w-2xl text-ds-body-sm text-text-secondary sm:text-ds-body-md">
-            Measured minified and gzipped from one-series charts using the
-            vanilla renderer. Granular imports leave unrelated marks and D3
-            modules out.
+            Measured minified and gzipped from one-series charts in the{' '}
+            <a
+              href="/charts/latest/docs/comparison"
+              className="text-[var(--landing-accent-bright)] underline decoration-current/30 underline-offset-4 hover:decoration-current"
+            >
+              reproducible comparison suite
+            </a>
+            . Granular imports leave unrelated marks and D3 modules out.
           </p>
         </div>
 
@@ -218,9 +223,6 @@ function TypedDotExample() {
           <span className="text-ds-neutral-200">{`,\n`}</span>
           <span className="text-ds-neutral-300"> z: </span>
           <span className="text-ds-amber-200">&apos;segment&apos;</span>
-          <span className="text-ds-neutral-200">{`,\n`}</span>
-          <span className="text-ds-neutral-300"> key: </span>
-          <span className="text-ds-amber-200">&apos;id&apos;</span>
           <span className="text-ds-neutral-200">{`,\n})`}</span>
         </code>
       </pre>

--- a/src/components/landing/ChartsLanding.tsx
+++ b/src/components/landing/ChartsLanding.tsx
@@ -29,7 +29,7 @@ export default function ChartsLanding({
 }) {
   return (
     <LibraryLandingShell
-      description="Build from typed data, marks, channels, and D3 scales. Render responsive SVG through vanilla TypeScript or adapters for React, Vue, Svelte, Solid, Angular, Preact, Lit, Alpine, and Octane."
+      description="These examples target unreleased source after 0.0.0. Build from typed data, marks, channels, and D3 scales. Render responsive SVG through vanilla TypeScript or adapters for React, Vue, Svelte, Solid, Angular, Preact, Lit, Alpine, and Octane."
       headline="A chart grammar you don't have to outgrow."
       hero={<KineticChartsHero />}
       libraryId="charts"

--- a/src/components/landing/ChartsLandingGraphics.tsx
+++ b/src/components/landing/ChartsLandingGraphics.tsx
@@ -324,30 +324,31 @@ const bundleRows = [
     color: 'bg-[#69bc75]',
     label: 'Scatter',
     paint: '#69bc75',
-    value: 18.515,
+    value: 24.188,
   },
   {
     color: 'bg-[#9cd5e2]',
     label: 'Area',
     paint: '#9cd5e2',
-    value: 18.687,
+    value: 24.257,
   },
   {
     color: 'bg-[#61adbf]',
     label: 'Line',
     paint: '#61adbf',
-    value: 18.701,
+    value: 24.261,
   },
   {
     color: 'bg-[#e06e49]',
     label: 'Bar',
     paint: '#e06e49',
-    value: 19.239,
+    value: 24.809,
   },
 ] as const
 
 const kineticChartIntervalMs = 4_000
 const kineticChartTransitionMs = 1_200
+const bundleChartMaximumKiB = 26
 
 export function KineticChartsHero() {
   const rootRef = React.useRef<HTMLElement>(null)
@@ -677,7 +678,7 @@ export function BundleSizeFigure() {
         {bundleRows.map((row, index) => (
           <button
             key={row.label}
-            aria-label={`${row.label}: ${row.value.toFixed(1)} kilobytes gzip`}
+            aria-label={`${row.label}: ${row.value.toFixed(1)} kibibytes gzip`}
             className={`grid w-full grid-cols-[4.5rem_1fr_4.5rem] items-center gap-3 rounded-md text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent-bright)] ${
               activeIndex === index ? 'translate-x-0.5' : ''
             }`}
@@ -697,11 +698,13 @@ export function BundleSizeFigure() {
             <span className="h-4 overflow-hidden rounded-full bg-background-subtle">
               <span
                 className={`block h-full rounded-full ${row.color}`}
-                style={{ width: `${(row.value / 20) * 100}%` }}
+                style={{
+                  width: `${(row.value / bundleChartMaximumKiB) * 100}%`,
+                }}
               />
             </span>
             <span className="text-right font-ds-mono text-ds-mono-xs text-text-primary">
-              {row.value.toFixed(1)} kB
+              {row.value.toFixed(1)} KiB
             </span>
           </button>
         ))}
@@ -714,7 +717,7 @@ export function BundleSizeFigure() {
                 {
                   color: activeRow.paint,
                   label: 'Bundle size',
-                  value: `${activeRow.value.toFixed(1)} kB`,
+                  value: `${activeRow.value.toFixed(1)} KiB`,
                 },
               ],
               title: activeRow.label,

--- a/src/routes/charts.catalog_.embed.$caseId.tsx
+++ b/src/routes/charts.catalog_.embed.$caseId.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { ChartsCatalogChart } from '~/components/charts/ChartsCatalogChart'
-import { CodeBlock } from '~/components/markdown/CodeBlock'
+import { ChartsCatalogSource } from '~/components/charts/ChartsCatalogSource'
 import {
   isChartsCatalogEmbedTheme,
   parseChartsCatalogEmbedRouteSearch,
@@ -145,7 +145,7 @@ function ChartsCatalogEmbedRoute() {
         onStatus={postStatus}
         revision={data.revision}
       />
-      {data.case.code ? (
+      {data.case.authoredSource ? (
         <details
           ref={sourceRef}
           open={data.source === 'expanded'}
@@ -154,12 +154,7 @@ function ChartsCatalogEmbedRoute() {
           <summary className="cursor-pointer px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
             Source
           </summary>
-          <CodeBlock
-            data-code-title={data.case.code.path}
-            className="max-h-[32rem] rounded-none border-x-0 border-b-0 [&_pre]:max-h-[29rem] [&_pre]:overflow-auto"
-          >
-            <code className="language-ts">{data.case.code.source}</code>
-          </CodeBlock>
+          <ChartsCatalogSource source={data.case.authoredSource} />
         </details>
       ) : null}
     </main>

--- a/src/utils/charts-catalog.functions.ts
+++ b/src/utils/charts-catalog.functions.ts
@@ -52,16 +52,19 @@ export const getChartsCatalogCase = createServerFn({ method: 'GET' })
     )
     if (!catalogCase) return null
 
-    const { getChartsCatalogSource } = await import('./charts-catalog.server')
+    const { getChartsCatalogAuthoredSource } =
+      await import('./charts-catalog.server')
     const [tanstackSource, comparisonSource] = await Promise.all([
-      getChartsCatalogSource(
-        publication.manifest.revision,
-        catalogCase.code.tanstack,
+      getChartsCatalogAuthoredSource(
+        publication.manifest,
+        catalogCase.id,
+        'tanstack',
       ),
       data.comparison
-        ? getChartsCatalogSource(
-            publication.manifest.revision,
-            catalogCase.code.reference,
+        ? getChartsCatalogAuthoredSource(
+            publication.manifest,
+            catalogCase.id,
+            'reference',
           )
         : Promise.resolve(undefined),
     ])
@@ -75,19 +78,9 @@ export const getChartsCatalogCase = createServerFn({ method: 'GET' })
         modules: data.comparison
           ? catalogCase.modules
           : { tanstack: catalogCase.modules.tanstack },
-        code: {
-          tanstack: {
-            path: catalogCase.code.tanstack,
-            source: tanstackSource,
-          },
-          ...(data.comparison
-            ? {
-                comparison: {
-                  path: catalogCase.code.reference,
-                  source: comparisonSource,
-                },
-              }
-            : {}),
+        authoredSource: {
+          tanstack: tanstackSource,
+          ...(comparisonSource ? { comparison: comparisonSource } : {}),
         },
       },
     }
@@ -102,12 +95,13 @@ export const getChartsCatalogEmbedCase = createServerFn({ method: 'GET' })
     )
     if (!catalogCase) return null
 
-    const source = data.source
+    const authoredSource = data.source
       ? await (
           await import('./charts-catalog.server')
-        ).getChartsCatalogSource(
-          publication.manifest.revision,
-          catalogCase.code.tanstack,
+        ).getChartsCatalogAuthoredSource(
+          publication.manifest,
+          catalogCase.id,
+          'tanstack',
         )
       : undefined
 
@@ -119,12 +113,7 @@ export const getChartsCatalogEmbedCase = createServerFn({ method: 'GET' })
         id: catalogCase.id,
         title: catalogCase.title,
         module: catalogCase.modules.tanstack,
-        code: source
-          ? {
-              path: catalogCase.code.tanstack,
-              source,
-            }
-          : undefined,
+        authoredSource,
       },
     }
   })

--- a/src/utils/charts-catalog.server.ts
+++ b/src/utils/charts-catalog.server.ts
@@ -9,7 +9,10 @@ import {
   chartsCatalogPublicationRef,
   chartsCatalogRepo,
   parseChartsCatalogManifest,
+  type ChartsCatalogAuthoredSource,
+  type ChartsCatalogManifest,
   type ChartsCatalogPublication,
+  type ChartsCatalogSourceKind,
 } from './charts-catalog'
 
 const catalogManifestPath = 'catalog.json'
@@ -148,6 +151,100 @@ export async function getChartsCatalogSource(
   return source
 }
 
+export async function getChartsCatalogAuthoredSource(
+  manifest: ChartsCatalogManifest,
+  caseId: string,
+  implementation: 'tanstack' | 'reference',
+): Promise<ChartsCatalogAuthoredSource> {
+  if (manifest.schemaVersion === 2) {
+    const catalogCase = manifest.cases.find((entry) => entry.id === caseId)
+    if (!catalogCase) {
+      throw new ChartsCatalogResourceNotFoundError(
+        `Charts catalog case not found: ${caseId}`,
+      )
+    }
+    const path =
+      implementation === 'tanstack'
+        ? catalogCase.code.tanstack
+        : catalogCase.code.reference
+    const source = await getChartsCatalogSource(manifest.revision, path)
+    const lines = countCatalogSourceLines(source)
+    const bytes = countCatalogSourceBytes(source)
+    return {
+      totalFiles: 1,
+      totalLines: lines,
+      totalBytes: bytes,
+      roles: {
+        entry: { files: 1, lines, bytes },
+        support: { files: 0, lines: 0, bytes: 0 },
+        fixture: { files: 0, lines: 0, bytes: 0 },
+      },
+      files: [{ path, source, kind: 'entry', lines, bytes }],
+      datasets: [],
+      excludedHarness: { files: 0, lines: 0, bytes: 0, paths: [] },
+    }
+  }
+
+  const catalogCase = manifest.cases.find((entry) => entry.id === caseId)
+  if (!catalogCase) {
+    throw new ChartsCatalogResourceNotFoundError(
+      `Charts catalog case not found: ${caseId}`,
+    )
+  }
+  const closure = catalogCase.authoredSource[implementation]
+  const sourceKinds: Array<ChartsCatalogSourceKind> = [
+    'entry',
+    'support',
+    'fixture',
+  ]
+  const files = await Promise.all(
+    sourceKinds.flatMap((kind) =>
+      closure.roles[kind].paths.map(async (path) => {
+        const source = await getChartsCatalogSource(
+          manifest.revision,
+          `${manifest.source.pathRoot}${path}`,
+        )
+        return {
+          path,
+          source,
+          kind,
+          lines: countCatalogSourceLines(source),
+          bytes: countCatalogSourceBytes(source),
+        }
+      }),
+    ),
+  )
+  const roles = {
+    entry: getCatalogSourceMetrics(files, 'entry'),
+    support: getCatalogSourceMetrics(files, 'support'),
+    fixture: getCatalogSourceMetrics(files, 'fixture'),
+  }
+
+  for (const kind of sourceKinds) {
+    const expected = closure.roles[kind]
+    const actual = roles[kind]
+    if (
+      actual.files !== expected.files ||
+      actual.lines !== expected.lines ||
+      actual.bytes !== expected.bytes
+    ) {
+      throw new ChartsCatalogIntegrityError(
+        `Charts catalog ${caseId} ${implementation} ${kind} source failed its metadata check`,
+      )
+    }
+  }
+
+  return {
+    totalFiles: closure.totalFiles,
+    totalLines: closure.totalLines,
+    totalBytes: closure.totalBytes,
+    roles,
+    files,
+    datasets: closure.datasetIds.map((id) => manifest.datasets[id]),
+    excludedHarness: closure.roles.harness,
+  }
+}
+
 async function readChartsCatalogManifest(artifactRevision: string) {
   const filePath = shouldUseLocalDocsFiles()
     ? `${localCatalogRoot}/${catalogManifestPath}`
@@ -181,6 +278,33 @@ async function readChartsCatalogManifest(artifactRevision: string) {
       error,
     )
   }
+}
+
+function getCatalogSourceMetrics(
+  files: ChartsCatalogAuthoredSource['files'],
+  kind: ChartsCatalogSourceKind,
+) {
+  return files.reduce(
+    (metrics, file) =>
+      file.kind === kind
+        ? {
+            files: metrics.files + 1,
+            lines: metrics.lines + file.lines,
+            bytes: metrics.bytes + file.bytes,
+          }
+        : metrics,
+    { files: 0, lines: 0, bytes: 0 },
+  )
+}
+
+function countCatalogSourceLines(source: string) {
+  if (source.length === 0) return 0
+  const lineBreaks = source.match(/\r\n|\r|\n/g)?.length ?? 0
+  return lineBreaks + (/(?:\r\n|\r|\n)$/.test(source) ? 0 : 1)
+}
+
+function countCatalogSourceBytes(source: string) {
+  return new TextEncoder().encode(source).byteLength
 }
 
 async function getPublishedChartsCatalogRevisions() {

--- a/src/utils/charts-catalog.ts
+++ b/src/utils/charts-catalog.ts
@@ -58,6 +58,10 @@ const sourcePathSchema = v.pipe(
   ),
 )
 
+const catalogSourcePathRoot = 'benchmarks/conformance/'
+
+const catalogAuthoredSourcePathSchema = v.string()
+
 const sourceUrlSchema = v.pipe(
   v.string(),
   v.url(),
@@ -95,7 +99,56 @@ const comparisonModuleSchema = v.strictObject({
   visibility: v.literal('debug'),
 })
 
-const catalogCaseSchema = v.strictObject({
+const catalogSourceMetricsSchema = v.strictObject({
+  files: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  lines: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  bytes: v.pipe(v.number(), v.integer(), v.minValue(0)),
+})
+
+const catalogSourceRoleSchema = v.strictObject({
+  ...catalogSourceMetricsSchema.entries,
+  paths: v.array(catalogAuthoredSourcePathSchema),
+})
+
+const catalogSourceClosureSchema = v.strictObject({
+  totalFiles: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  totalLines: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  totalBytes: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  datasetIds: v.array(v.string()),
+  roles: v.strictObject({
+    entry: catalogSourceRoleSchema,
+    support: catalogSourceRoleSchema,
+    fixture: catalogSourceRoleSchema,
+    harness: catalogSourceRoleSchema,
+  }),
+})
+
+const catalogDatasetSchema = v.strictObject({
+  id: v.string(),
+  title: v.string(),
+  specifier: v.string(),
+  format: v.picklist(['CSV', 'JSON']),
+  records: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  fields: v.array(v.string()),
+  schema: v.array(
+    v.strictObject({
+      name: v.string(),
+      types: v.array(v.string()),
+    }),
+  ),
+  bytes: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  sha256: sha256Schema,
+  selection: v.string(),
+  source: v.string(),
+  sourceUrl: v.string(),
+  observablePackage: v.string(),
+  observableRevision: v.string(),
+  observableFile: v.string(),
+  observableUrl: v.string(),
+  license: v.string(),
+})
+
+const catalogCaseEntries = {
   schemaVersion: v.literal(1),
   referenceRenderer: v.optional(rendererSchema),
   order: v.pipe(v.number(), v.integer(), v.minValue(0)),
@@ -131,6 +184,16 @@ const catalogCaseSchema = v.strictObject({
   minimumGeometrySimilarity: v.optional(
     v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
   ),
+}
+
+const catalogCaseV2Schema = v.strictObject(catalogCaseEntries)
+
+const catalogCaseV4Schema = v.strictObject({
+  ...catalogCaseEntries,
+  authoredSource: v.strictObject({
+    tanstack: catalogSourceClosureSchema,
+    reference: catalogSourceClosureSchema,
+  }),
 })
 
 const assetDescriptorSchema = v.strictObject({
@@ -140,65 +203,119 @@ const assetDescriptorSchema = v.strictObject({
   dynamicImports: v.array(chartsCatalogAssetPathSchema),
 })
 
-const chartsCatalogManifestSchema = v.strictObject({
+const catalogRuntimeSchema = v.strictObject({
+  contractVersion: v.literal(1),
+  export: v.literal('mount'),
+})
+
+const catalogSiteSchema = v.strictObject({
+  origin: v.literal('https://tanstack.com'),
+  basePath: v.literal(chartsCatalogBasePath),
+  assetBasePath: v.literal(chartsCatalogAssetBasePath),
+})
+
+const catalogEmbedSchema = v.strictObject({
+  protocol: v.strictObject({
+    type: v.literal('tanstack-charts:embed'),
+    version: v.literal(1),
+    statuses: v.tuple([
+      v.literal('ready'),
+      v.literal('resize'),
+      v.literal('error'),
+    ]),
+    commands: v.tuple([v.literal('set-theme')]),
+  }),
+  parameters: v.strictObject({
+    theme: v.strictObject({
+      values: v.tuple([
+        v.literal('system'),
+        v.literal('light'),
+        v.literal('dark'),
+      ]),
+      default: v.literal('system'),
+    }),
+    height: v.strictObject({
+      minimum: v.literal(120),
+      maximum: v.literal(1_200),
+      default: v.literal(360),
+    }),
+    revision: v.strictObject({
+      minimum: v.literal(0),
+      maximum: v.literal(10_000),
+      default: v.literal(0),
+    }),
+  }),
+})
+
+const catalogAssetsSchema = v.pipe(
+  v.record(chartsCatalogAssetPathSchema, assetDescriptorSchema),
+  v.maxEntries(1_000),
+)
+
+const chartsCatalogManifestV2Schema = v.strictObject({
   schemaVersion: v.literal(2),
   revision: gitShaSchema,
   source: v.strictObject({
     repo: v.literal(chartsCatalogRepo),
     ref: gitShaSchema,
   }),
-  runtime: v.strictObject({
-    contractVersion: v.literal(1),
-    export: v.literal('mount'),
-  }),
-  site: v.strictObject({
-    origin: v.literal('https://tanstack.com'),
-    basePath: v.literal(chartsCatalogBasePath),
-    assetBasePath: v.literal(chartsCatalogAssetBasePath),
-  }),
-  embed: v.strictObject({
-    protocol: v.strictObject({
-      type: v.literal('tanstack-charts:embed'),
-      version: v.literal(1),
-      statuses: v.tuple([
-        v.literal('ready'),
-        v.literal('resize'),
-        v.literal('error'),
-      ]),
-      commands: v.tuple([v.literal('set-theme')]),
-    }),
-    parameters: v.strictObject({
-      theme: v.strictObject({
-        values: v.tuple([
-          v.literal('system'),
-          v.literal('light'),
-          v.literal('dark'),
-        ]),
-        default: v.literal('system'),
-      }),
-      height: v.strictObject({
-        minimum: v.literal(120),
-        maximum: v.literal(1_200),
-        default: v.literal(360),
-      }),
-      revision: v.strictObject({
-        minimum: v.literal(0),
-        maximum: v.literal(10_000),
-        default: v.literal(0),
-      }),
-    }),
-  }),
-  assets: v.pipe(
-    v.record(chartsCatalogAssetPathSchema, assetDescriptorSchema),
-    v.maxEntries(1_000),
-  ),
-  cases: v.pipe(v.array(catalogCaseSchema), v.nonEmpty()),
+  runtime: catalogRuntimeSchema,
+  site: catalogSiteSchema,
+  embed: catalogEmbedSchema,
+  assets: catalogAssetsSchema,
+  cases: v.pipe(v.array(catalogCaseV2Schema), v.nonEmpty()),
 })
+
+const chartsCatalogManifestV4Schema = v.strictObject({
+  schemaVersion: v.literal(4),
+  revision: gitShaSchema,
+  source: v.strictObject({
+    repo: v.literal(chartsCatalogRepo),
+    ref: gitShaSchema,
+    pathRoot: v.literal(catalogSourcePathRoot),
+  }),
+  runtime: catalogRuntimeSchema,
+  site: catalogSiteSchema,
+  embed: catalogEmbedSchema,
+  datasets: v.record(v.string(), catalogDatasetSchema),
+  assets: catalogAssetsSchema,
+  cases: v.pipe(v.array(catalogCaseV4Schema), v.nonEmpty()),
+})
+
+const chartsCatalogManifestSchema = v.variant('schemaVersion', [
+  chartsCatalogManifestV2Schema,
+  chartsCatalogManifestV4Schema,
+])
 
 export type ChartsCatalogManifest = v.InferOutput<
   typeof chartsCatalogManifestSchema
 >
+export type ChartsCatalogManifestV4 = v.InferOutput<
+  typeof chartsCatalogManifestV4Schema
+>
 export type ChartsCatalogCase = ChartsCatalogManifest['cases'][number]
+export type ChartsCatalogDataset = v.InferOutput<typeof catalogDatasetSchema>
+
+export type ChartsCatalogSourceKind = 'entry' | 'support' | 'fixture'
+
+export type ChartsCatalogAuthoredSource = {
+  totalFiles: number
+  totalLines: number
+  totalBytes: number
+  roles: Record<
+    ChartsCatalogSourceKind,
+    v.InferOutput<typeof catalogSourceMetricsSchema>
+  >
+  files: Array<{
+    path: string
+    source: string
+    kind: ChartsCatalogSourceKind
+    lines: number
+    bytes: number
+  }>
+  datasets: Array<ChartsCatalogDataset>
+  excludedHarness: v.InferOutput<typeof catalogSourceRoleSchema>
+}
 
 export type ChartsCatalogPublication = {
   artifactRevision: string
@@ -235,7 +352,10 @@ function validateManifestRelationships(manifest: ChartsCatalogManifest) {
 
   let totalAssetBytes = 0
   for (const [assetPath, descriptor] of Object.entries(manifest.assets)) {
-    if (descriptor.bytes > 1024 * 1024) {
+    if (
+      !Number.isSafeInteger(descriptor.bytes) ||
+      descriptor.bytes > 1024 * 1024
+    ) {
       throw new TypeError(
         `Invalid Charts catalog manifest: ${assetPath} exceeds 1 MiB`,
       )
@@ -252,16 +372,29 @@ function validateManifestRelationships(manifest: ChartsCatalogManifest) {
       }
     }
   }
-  if (totalAssetBytes > 5 * 1024 * 1024) {
+  const totalAssetLimit =
+    manifest.schemaVersion === 4 ? 6 * 1024 * 1024 : 5 * 1024 * 1024
+  if (totalAssetBytes > totalAssetLimit) {
     throw new TypeError(
-      'Invalid Charts catalog manifest: assets exceed 5 MiB total',
+      `Invalid Charts catalog manifest: assets exceed ${
+        manifest.schemaVersion === 4 ? 6 : 5
+      } MiB total`,
     )
+  }
+
+  if (manifest.schemaVersion === 4) {
+    validateCatalogDatasets(manifest)
   }
 
   const caseIds = new Set<string>()
   const caseOrders = new Set<number>()
 
   for (const catalogCase of manifest.cases) {
+    if (!Number.isSafeInteger(catalogCase.order)) {
+      throw new TypeError(
+        `Invalid Charts catalog manifest: invalid case order ${catalogCase.order}`,
+      )
+    }
     if (caseIds.has(catalogCase.id)) {
       throw new TypeError(
         `Invalid Charts catalog manifest: duplicate case ID ${catalogCase.id}`,
@@ -316,6 +449,23 @@ function validateManifestRelationships(manifest: ChartsCatalogManifest) {
     )
   }
 
+  if (manifest.schemaVersion === 4) {
+    for (const catalogCase of manifest.cases) {
+      validateCatalogSourceClosure(
+        catalogCase.authoredSource.tanstack,
+        `${catalogCase.id} TanStack authored source`,
+        catalogCase.code.tanstack.slice(manifest.source.pathRoot.length),
+        manifest.datasets,
+      )
+      validateCatalogSourceClosure(
+        catalogCase.authoredSource.reference,
+        `${catalogCase.id} reference authored source`,
+        catalogCase.code.reference.slice(manifest.source.pathRoot.length),
+        manifest.datasets,
+      )
+    }
+  }
+
   const reachableAssets = new Set<string>()
   for (const catalogCase of manifest.cases) {
     validateStaticPreloadClosure(
@@ -323,6 +473,7 @@ function validateManifestRelationships(manifest: ChartsCatalogManifest) {
       'tanstack',
       catalogCase.modules.tanstack,
       manifest,
+      manifest.schemaVersion === 4,
     )
     collectReachableAssets(
       catalogCase.modules.tanstack.path,
@@ -335,6 +486,7 @@ function validateManifestRelationships(manifest: ChartsCatalogManifest) {
       'comparison',
       catalogCase.modules.comparison,
       manifest,
+      manifest.schemaVersion === 4,
     )
     collectReachableAssets(
       catalogCase.modules.comparison.path,
@@ -372,21 +524,197 @@ function validateStaticPreloadClosure(
   renderer: string,
   module: { path: string; preload: Array<string> },
   manifest: ChartsCatalogManifest,
+  requireCanonicalOrder: boolean,
 ) {
   const expectedPreload = new Set<string>()
   collectStaticImports(module.path, manifest, expectedPreload)
   expectedPreload.delete(module.path)
 
+  const expected = [...expectedPreload].sort(compareStrings)
   const actualPreload = new Set(module.preload)
-  if (
+  const invalid =
     actualPreload.size !== module.preload.length ||
-    actualPreload.size !== expectedPreload.size ||
-    [...expectedPreload].some((assetPath) => !actualPreload.has(assetPath))
-  ) {
+    actualPreload.size !== expected.length ||
+    expected.some((assetPath) => !actualPreload.has(assetPath)) ||
+    (requireCanonicalOrder &&
+      JSON.stringify(module.preload) !== JSON.stringify(expected))
+
+  if (invalid) {
     throw new TypeError(
       `Invalid Charts catalog manifest: ${caseId} ${renderer} preload does not match its static import closure`,
     )
   }
+}
+
+type ChartsCatalogSourceClosureMetadata =
+  ChartsCatalogManifestV4['cases'][number]['authoredSource']['tanstack']
+type ChartsCatalogSourceRole = keyof ChartsCatalogSourceClosureMetadata['roles']
+
+const chartsCatalogSourceRoles: Array<ChartsCatalogSourceRole> = [
+  'entry',
+  'support',
+  'fixture',
+  'harness',
+]
+
+function validateCatalogDatasets(manifest: ChartsCatalogManifestV4) {
+  for (const [id, dataset] of Object.entries(manifest.datasets)) {
+    if (
+      dataset.id !== id ||
+      dataset.specifier !== `@charts-poc/demo-data/${dataset.id}` ||
+      !Number.isSafeInteger(dataset.records) ||
+      !Number.isSafeInteger(dataset.bytes)
+    ) {
+      throw new TypeError(
+        `Invalid Charts catalog manifest: dataset ${id} metadata is invalid`,
+      )
+    }
+  }
+}
+
+function validateCatalogSourceClosure(
+  closure: ChartsCatalogSourceClosureMetadata,
+  label: string,
+  entryPath: string,
+  datasets: ChartsCatalogManifestV4['datasets'],
+) {
+  if (
+    !Number.isSafeInteger(closure.totalFiles) ||
+    !Number.isSafeInteger(closure.totalLines) ||
+    !Number.isSafeInteger(closure.totalBytes)
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} metrics are invalid`,
+    )
+  }
+
+  const sortedDatasetIds = [...new Set(closure.datasetIds)].sort(compareStrings)
+  if (
+    JSON.stringify(closure.datasetIds) !== JSON.stringify(sortedDatasetIds) ||
+    closure.datasetIds.some((id) => datasets[id] === undefined)
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} dataset IDs are invalid`,
+    )
+  }
+
+  const seenPaths = new Set<string>()
+  for (const roleName of chartsCatalogSourceRoles) {
+    validateCatalogSourceRole(
+      closure.roles[roleName],
+      roleName,
+      label,
+      seenPaths,
+    )
+  }
+
+  if (
+    closure.roles.entry.files !== 1 ||
+    closure.roles.entry.paths[0] !== entryPath
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} must contain one entry file`,
+    )
+  }
+
+  const visibleRoles: Array<ChartsCatalogSourceKind> = [
+    'entry',
+    'support',
+    'fixture',
+  ]
+  const totals = visibleRoles.reduce(
+    (result, roleName) => ({
+      files: result.files + closure.roles[roleName].files,
+      lines: result.lines + closure.roles[roleName].lines,
+      bytes: result.bytes + closure.roles[roleName].bytes,
+    }),
+    { files: 0, lines: 0, bytes: 0 },
+  )
+  if (
+    totals.files !== closure.totalFiles ||
+    totals.lines !== closure.totalLines ||
+    totals.bytes !== closure.totalBytes
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} totals include excluded or missing files`,
+    )
+  }
+}
+
+function validateCatalogSourceRole(
+  role: ChartsCatalogSourceClosureMetadata['roles'][ChartsCatalogSourceRole],
+  roleName: ChartsCatalogSourceRole,
+  label: string,
+  seenPaths: Set<string>,
+) {
+  if (
+    !Number.isSafeInteger(role.files) ||
+    !Number.isSafeInteger(role.lines) ||
+    !Number.isSafeInteger(role.bytes) ||
+    role.files !== role.paths.length ||
+    (role.files === 0 && (role.lines !== 0 || role.bytes !== 0))
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} ${roleName} role metrics are invalid`,
+    )
+  }
+
+  if (
+    JSON.stringify(role.paths) !==
+    JSON.stringify([...role.paths].sort(compareStrings))
+  ) {
+    throw new TypeError(
+      `Invalid Charts catalog manifest: ${label} ${roleName} paths must be sorted`,
+    )
+  }
+
+  for (const sourcePath of role.paths) {
+    if (!isCatalogSourcePath(sourcePath)) {
+      throw new TypeError(
+        `Invalid Charts catalog manifest: ${label} ${roleName} path is invalid`,
+      )
+    }
+    if (seenPaths.has(sourcePath)) {
+      throw new TypeError(
+        `Invalid Charts catalog manifest: ${label} has duplicate path ${sourcePath}`,
+      )
+    }
+    seenPaths.add(sourcePath)
+
+    const harness = isCatalogHarnessSourcePath(sourcePath)
+    if (roleName === 'harness' ? !harness : harness) {
+      throw new TypeError(
+        `Invalid Charts catalog manifest: ${label} ${roleName} path has the wrong role`,
+      )
+    }
+  }
+}
+
+function isCatalogSourcePath(sourcePath: string) {
+  return (
+    isSafeRepositoryPath(sourcePath) &&
+    (sourcePath.startsWith('cases/') || sourcePath.startsWith('shared/')) &&
+    sourcePath.endsWith('.ts') &&
+    !sourcePath.endsWith('.test.ts') &&
+    !sourcePath.includes('\\') &&
+    !sourcePath.includes('?') &&
+    !sourcePath.includes('#')
+  )
+}
+
+function isCatalogHarnessSourcePath(sourcePath: string) {
+  return /^shared\/(?:mount|recharts-mount|echarts-mount)\.ts$/.test(sourcePath)
+}
+
+function isSafeRepositoryPath(value: string) {
+  if (value.length === 0 || value.startsWith('/')) return false
+  return value
+    .split('/')
+    .every((segment) => segment !== '' && segment !== '.' && segment !== '..')
+}
+
+function compareStrings(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
 }
 
 function collectStaticImports(

--- a/tests/charts-catalog-manifest.test.ts
+++ b/tests/charts-catalog-manifest.test.ts
@@ -4,6 +4,8 @@ import { parseChartsCatalogManifest } from '../src/utils/charts-catalog'
 import {
   comparisonAsset,
   createChartsCatalogManifest,
+  createChartsCatalogV2Manifest,
+  datasetId,
   sharedAsset,
   sourceRevision,
   tanstackAsset,
@@ -20,13 +22,17 @@ function expectRejected(
   })
 }
 
-test('catalog manifest accepts the generated v2 contract', () => {
+test('catalog manifest accepts the generated v4 contract', () => {
   const manifest = parseChartsCatalogManifest(createChartsCatalogManifest())
 
-  assert.equal(manifest.schemaVersion, 2)
+  assert.equal(manifest.schemaVersion, 4)
   assert.equal(manifest.revision, sourceRevision)
   assert.equal(manifest.cases[0]?.id, '01-line')
   assert.equal(manifest.cases[0]?.modules.tanstack.path, tanstackAsset)
+  assert.deepEqual(manifest.cases[0]?.authoredSource.tanstack.datasetIds, [
+    datasetId,
+  ])
+  assert.equal(manifest.datasets[datasetId]?.records, 1_260)
   assert.deepEqual(Object.keys(manifest.assets).sort(), [
     comparisonAsset,
     sharedAsset,
@@ -34,8 +40,15 @@ test('catalog manifest accepts the generated v2 contract', () => {
   ])
 })
 
+test('catalog manifest keeps accepting the published v2 contract', () => {
+  const manifest = parseChartsCatalogManifest(createChartsCatalogV2Manifest())
+
+  assert.equal(manifest.schemaVersion, 2)
+  assert.equal(manifest.cases[0]?.id, '01-line')
+})
+
 expectRejected('an unsupported schema version', (manifest) => {
-  manifest.schemaVersion = 1
+  manifest.schemaVersion = 3
 })
 
 expectRejected('a mutable or malformed source revision', (manifest) => {
@@ -45,6 +58,10 @@ expectRejected('a mutable or malformed source revision', (manifest) => {
 
 expectRejected('an untrusted source repository', (manifest) => {
   manifest.source.repo = 'someone/charts'
+})
+
+expectRejected('a different authored source root', (manifest) => {
+  manifest.source.pathRoot = 'examples/conformance/'
 })
 
 expectRejected('a source ref that differs from its revision', (manifest) => {
@@ -101,6 +118,10 @@ expectRejected('duplicate case ids', (manifest) => {
   manifest.cases.push(structuredClone(manifest.cases[0]))
 })
 
+expectRejected('an unsafe case order', (manifest) => {
+  manifest.cases[0].order = Number.MAX_SAFE_INTEGER + 1
+})
+
 expectRejected('a case id outside the producer format', (manifest) => {
   manifest.cases[0].id = '01_line'
   manifest.cases[0].routes = {
@@ -142,3 +163,122 @@ expectRejected('an asset outside every implementation closure', (manifest) => {
     dynamicImports: [],
   }
 })
+
+expectRejected('a dataset key that differs from its id', (manifest) => {
+  manifest.datasets[datasetId].id = 'different'
+})
+
+expectRejected('a dataset specifier that differs from its id', (manifest) => {
+  manifest.datasets[datasetId].specifier = '@charts-poc/demo-data/different'
+})
+
+expectRejected('raw rows embedded in dataset metadata', (manifest) => {
+  manifest.datasets[datasetId].rows = [{ Date: '2024-01-01', Close: 42 }]
+})
+
+expectRejected('source metadata for an unregistered dataset', (manifest) => {
+  manifest.cases[0].authoredSource.tanstack.datasetIds = ['missing']
+})
+
+expectRejected('duplicate source dataset ids', (manifest) => {
+  manifest.cases[0].authoredSource.tanstack.datasetIds = [datasetId, datasetId]
+})
+
+expectRejected('source totals that include harness code', (manifest) => {
+  const closure = manifest.cases[0].authoredSource.tanstack
+  closure.totalLines += closure.roles.harness.lines
+})
+
+expectRejected(
+  'source role counts that differ from their paths',
+  (manifest) => {
+    manifest.cases[0].authoredSource.tanstack.roles.support.files += 1
+  },
+)
+
+expectRejected('a harness path assigned to authored source', (manifest) => {
+  manifest.cases[0].authoredSource.tanstack.roles.support.paths[0] =
+    'shared/mount.ts'
+})
+
+expectRejected('a source path assigned to multiple roles', (manifest) => {
+  manifest.cases[0].authoredSource.tanstack.roles.support.paths[0] =
+    'cases/01-line/tanstack.ts'
+})
+
+expectRejected('authored source metadata with the wrong entry', (manifest) => {
+  manifest.cases[0].authoredSource.tanstack.roles.entry.paths[0] =
+    'cases/01-line/other.ts'
+})
+
+expectRejected(
+  'a non-harness file assigned to the harness role',
+  (manifest) => {
+    manifest.cases[0].authoredSource.tanstack.roles.harness.paths[0] =
+      'shared/helper.ts'
+  },
+)
+
+test('catalog v4 accepts assets above 5 MiB through the 6 MiB limit', () => {
+  const manifest = createChartsCatalogManifest()
+  expandAssetClosureToSixMiB(manifest)
+
+  assert.doesNotThrow(() => parseChartsCatalogManifest(manifest))
+})
+
+test('catalog v2 retains its 5 MiB asset limit', () => {
+  const manifest = createChartsCatalogV2Manifest()
+  expandAssetClosureToSixMiB(manifest)
+
+  assert.throws(() => parseChartsCatalogManifest(manifest))
+})
+
+test('catalog v4 rejects assets above the 6 MiB limit', () => {
+  const manifest = createChartsCatalogManifest()
+  expandAssetClosureToSixMiB(manifest)
+  const overflowAsset = 'assets/overflow-AbC_7.js'
+  manifest.assets[overflowAsset] = {
+    bytes: 1,
+    sha256: 'f'.repeat(64),
+    imports: [],
+    dynamicImports: [],
+  }
+  manifest.assets[tanstackAsset].dynamicImports.push(overflowAsset)
+
+  assert.throws(() => parseChartsCatalogManifest(manifest))
+})
+
+test('catalog v4 requires canonical preload order', () => {
+  const manifest = createChartsCatalogManifest()
+  const extraAsset = 'assets/extra-AbC_4.js'
+  manifest.assets[extraAsset] = {
+    bytes: 1,
+    sha256: 'e'.repeat(64),
+    imports: [],
+    dynamicImports: [],
+  }
+  manifest.assets[tanstackAsset].imports.push(extraAsset)
+  manifest.cases[0].modules.tanstack.preload = [sharedAsset, extraAsset]
+
+  assert.throws(() => parseChartsCatalogManifest(manifest))
+})
+
+function expandAssetClosureToSixMiB(manifest: Record<string, any>) {
+  const extraAssets = [
+    'assets/extra-one-AbC_4.js',
+    'assets/extra-two-AbC_5.js',
+    'assets/extra-three-AbC_6.js',
+  ]
+  for (const assetPath of Object.keys(manifest.assets)) {
+    manifest.assets[assetPath].bytes = 1024 * 1024
+  }
+  for (const [index, assetPath] of extraAssets.entries()) {
+    manifest.assets[assetPath] = {
+      bytes: 1024 * 1024,
+      sha256: String(index + 4).repeat(64),
+      imports: [],
+      dynamicImports: [],
+    }
+  }
+  manifest.assets[tanstackAsset].dynamicImports = extraAssets
+}

--- a/tests/charts-catalog-source.test.ts
+++ b/tests/charts-catalog-source.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseChartsCatalogManifest } from '../src/utils/charts-catalog'
+import {
+  ChartsCatalogIntegrityError,
+  getChartsCatalogAuthoredSource,
+} from '../src/utils/charts-catalog.server'
+import { resetGitHubContentCacheForTest } from '../src/utils/github-content-cache.server'
+import {
+  catalogSources,
+  createChartsCatalogManifest,
+  createChartsCatalogV2Manifest,
+  datasetId,
+  sourceRevision,
+} from './charts-catalog-test-fixture'
+
+test('catalog v4 loads complete authored source roles without harness code', async () => {
+  const manifest = parseChartsCatalogManifest(createChartsCatalogManifest())
+  const requests = new Array<string>()
+  const originalFetch = globalThis.fetch
+  resetGitHubContentCacheForTest()
+  globalThis.fetch = createSourceFetch(requests)
+
+  try {
+    const tanstack = await getChartsCatalogAuthoredSource(
+      manifest,
+      '01-line',
+      'tanstack',
+    )
+    const reference = await getChartsCatalogAuthoredSource(
+      manifest,
+      '01-line',
+      'reference',
+    )
+
+    assert.deepEqual(
+      tanstack.files.map((file) => [file.kind, file.path]),
+      [
+        ['entry', 'cases/01-line/tanstack.ts'],
+        ['support', 'shared/transforms/normalize.ts'],
+        ['fixture', 'cases/01-line/data.ts'],
+      ],
+    )
+    assert.deepEqual(
+      reference.files.map((file) => [file.kind, file.path]),
+      [
+        ['entry', 'cases/01-line/plot.ts'],
+        ['fixture', 'cases/01-line/data.ts'],
+      ],
+    )
+    assert.deepEqual(tanstack.excludedHarness.paths, ['shared/mount.ts'])
+    const dataset = tanstack.datasets[0]
+    assert.ok(dataset)
+    assert.equal(dataset.id, datasetId)
+    assert.equal('rows' in dataset, false)
+    assert.equal(
+      requests.some((url) => url.endsWith('/shared/mount.ts')),
+      false,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    resetGitHubContentCacheForTest()
+  }
+})
+
+test('catalog source loading verifies v4 role metrics against immutable files', async () => {
+  const manifest = parseChartsCatalogManifest(createChartsCatalogManifest())
+  const originalFetch = globalThis.fetch
+  resetGitHubContentCacheForTest()
+  globalThis.fetch = async (input) => {
+    const url = String(input)
+    const path = url.split('/benchmarks/conformance/')[1]
+    const source = catalogSources[path]
+    return new Response(
+      path === 'shared/transforms/normalize.ts' ? `${source} ` : source,
+    )
+  }
+
+  try {
+    await assert.rejects(
+      getChartsCatalogAuthoredSource(manifest, '01-line', 'tanstack'),
+      ChartsCatalogIntegrityError,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+    resetGitHubContentCacheForTest()
+  }
+})
+
+test('catalog v2 source loading preserves its entry-only fallback', async () => {
+  const manifest = parseChartsCatalogManifest(createChartsCatalogV2Manifest())
+  const requests = new Array<string>()
+  const originalFetch = globalThis.fetch
+  resetGitHubContentCacheForTest()
+  globalThis.fetch = async (input) => {
+    const url = String(input)
+    requests.push(url)
+    return new Response(catalogSources['cases/01-line/tanstack.ts'])
+  }
+
+  try {
+    const source = await getChartsCatalogAuthoredSource(
+      manifest,
+      '01-line',
+      'tanstack',
+    )
+
+    assert.equal(source.totalFiles, 1)
+    assert.deepEqual(
+      source.files.map((file) => file.path),
+      ['benchmarks/conformance/cases/01-line/tanstack.ts'],
+    )
+    assert.deepEqual(source.datasets, [])
+    assert.deepEqual(source.excludedHarness.paths, [])
+    assert.deepEqual(requests, [
+      `https://raw.githubusercontent.com/tanstack/charts/${sourceRevision}/benchmarks/conformance/cases/01-line/tanstack.ts`,
+    ])
+  } finally {
+    globalThis.fetch = originalFetch
+    resetGitHubContentCacheForTest()
+  }
+})
+
+function createSourceFetch(requests: Array<string>) {
+  return async (input: string | URL | Request) => {
+    const url = String(input)
+    requests.push(url)
+    const path = url.split('/benchmarks/conformance/')[1]
+    const source = catalogSources[path]
+    return source === undefined
+      ? new Response('Not found', { status: 404 })
+      : new Response(source)
+  }
+}

--- a/tests/charts-catalog-test-fixture.ts
+++ b/tests/charts-catalog-test-fixture.ts
@@ -3,14 +3,28 @@ export const artifactRevision = '2'.repeat(40)
 export const tanstackAsset = 'assets/tanstack-AbC_1.js'
 export const sharedAsset = 'assets/shared-XyZ_2.js'
 export const comparisonAsset = 'assets/plot-QrS_3.js'
+export const datasetId = 'aapl'
+
+export const catalogSources: Record<string, string> = {
+  'cases/01-line/tanstack.ts':
+    "import { rows } from './data'\nimport { normalize } from '../../shared/transforms/normalize'\nexport { normalize, rows }\n",
+  'cases/01-line/plot.ts':
+    "import { rows } from './data'\nexport const chart = rows\n",
+  'cases/01-line/data.ts':
+    "import { aapl } from '@charts-poc/demo-data/aapl'\nexport const rows = aapl\n",
+  'shared/transforms/normalize.ts':
+    'export const normalize = (value: number) => value\n',
+  'shared/mount.ts': 'export const mount = () => undefined\n',
+}
 
 export function createChartsCatalogManifest(): Record<string, any> {
   return {
-    schemaVersion: 2,
+    schemaVersion: 4,
     revision: sourceRevision,
     source: {
       repo: 'tanstack/charts',
       ref: sourceRevision,
+      pathRoot: 'benchmarks/conformance/',
     },
     runtime: {
       contractVersion: 1,
@@ -43,6 +57,30 @@ export function createChartsCatalogManifest(): Record<string, any> {
           maximum: 10_000,
           default: 0,
         },
+      },
+    },
+    datasets: {
+      [datasetId]: {
+        id: datasetId,
+        title: 'Apple daily stock prices',
+        specifier: '@charts-poc/demo-data/aapl',
+        format: 'CSV',
+        records: 1_260,
+        fields: ['Date', 'Close'],
+        schema: [
+          { name: 'Date', types: ['Date'] },
+          { name: 'Close', types: ['number'] },
+        ],
+        bytes: 92_399,
+        sha256: 'd'.repeat(64),
+        selection: 'Complete published snapshot',
+        source: 'Yahoo! Finance',
+        sourceUrl: 'https://finance.yahoo.com/lookup',
+        observablePackage: '@observablehq/sample-datasets@1.0.1',
+        observableRevision: '3'.repeat(40),
+        observableFile: 'aapl.csv',
+        observableUrl: `https://github.com/observablehq/sample-datasets/blob/${'3'.repeat(40)}/aapl.csv`,
+        license: 'ISC distribution; upstream source credited',
       },
     },
     assets: {
@@ -93,6 +131,20 @@ export function createChartsCatalogManifest(): Record<string, any> {
           tanstack: 'benchmarks/conformance/cases/01-line/tanstack.ts',
           reference: 'benchmarks/conformance/cases/01-line/plot.ts',
         },
+        authoredSource: {
+          tanstack: createSourceClosure({
+            entry: ['cases/01-line/tanstack.ts'],
+            support: ['shared/transforms/normalize.ts'],
+            fixture: ['cases/01-line/data.ts'],
+            harness: ['shared/mount.ts'],
+          }),
+          reference: createSourceClosure({
+            entry: ['cases/01-line/plot.ts'],
+            support: [],
+            fixture: ['cases/01-line/data.ts'],
+            harness: ['shared/mount.ts'],
+          }),
+        },
         modules: {
           tanstack: {
             path: tanstackAsset,
@@ -108,4 +160,57 @@ export function createChartsCatalogManifest(): Record<string, any> {
       },
     ],
   }
+}
+
+export function createChartsCatalogV2Manifest(): Record<string, any> {
+  const manifest = createChartsCatalogManifest()
+  manifest.schemaVersion = 2
+  delete manifest.source.pathRoot
+  delete manifest.datasets
+  for (const catalogCase of manifest.cases) {
+    delete catalogCase.authoredSource
+  }
+  return manifest
+}
+
+function createSourceClosure(paths: {
+  entry: Array<string>
+  support: Array<string>
+  fixture: Array<string>
+  harness: Array<string>
+}) {
+  const roles = {
+    entry: createSourceRole(paths.entry),
+    support: createSourceRole(paths.support),
+    fixture: createSourceRole(paths.fixture),
+    harness: createSourceRole(paths.harness),
+  }
+  return {
+    totalFiles: roles.entry.files + roles.support.files + roles.fixture.files,
+    totalLines: roles.entry.lines + roles.support.lines + roles.fixture.lines,
+    totalBytes: roles.entry.bytes + roles.support.bytes + roles.fixture.bytes,
+    datasetIds: [datasetId],
+    roles,
+  }
+}
+
+function createSourceRole(paths: Array<string>) {
+  return paths.reduce(
+    (metrics, path) => {
+      const source = catalogSources[path]
+      return {
+        files: metrics.files + 1,
+        lines: metrics.lines + countLines(source),
+        bytes: metrics.bytes + new TextEncoder().encode(source).byteLength,
+        paths: [...metrics.paths, path],
+      }
+    },
+    { files: 0, lines: 0, bytes: 0, paths: new Array<string>() },
+  )
+}
+
+function countLines(source: string) {
+  if (source.length === 0) return 0
+  const lineBreaks = source.match(/\r\n|\r|\n/g)?.length ?? 0
+  return lineBreaks + (/(?:\r\n|\r|\n)$/.test(source) ? 0 : 1)
 }


### PR DESCRIPTION
## What changed

- updates the Charts landing page for the post-0.0.0 API, all nine adapters, inferred domains and keys, and current 24.2–24.8 KiB bundle evidence
- accepts both the published catalog schema v2 and the new schema v4 through separate strict validators
- renders complete v4 authored-source roles and dataset provenance while excluding harness source and raw dataset rows
- keeps the current v2 catalog working through its entry-only source fallback

## Why

The next Charts release changes definition ownership, domain and key inference, tooltip composition, and catalog artifact structure. The site must understand schema v4 before the Charts repository publishes it, while preserving the live schema-v2 routes during the cutover.

## Validation

- `pnpm test` (137 tests: 136 passed, 1 skipped; typecheck and lint clean)
- `pnpm run build`
- desktop and mobile browser audit of `/charts/latest`, `/charts/catalog`, and a catalog detail route
- no browser console errors or horizontal overflow

## Release order

Deploy this site change before publishing the schema-v4 catalog artifact. Keep schema-v2 compatibility until the production catalog routes are verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart catalog source panels now display authored source files, datasets, file metrics, and optional schema details.
  * Embedded chart views support the same enhanced source experience.

* **Improvements**
  * Catalog manifests now support richer source and dataset metadata while maintaining compatibility with existing catalogs.
  * Source display includes expandable files, syntax highlighting, safe external links, and clearer size/count formatting.
  * Landing-page guidance and bundle-size labels have been updated for greater clarity and accuracy.

* **Tests**
  * Added comprehensive validation for source integrity, datasets, asset limits, and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->