### PR TITLE
Sync docs config schema with what the site reads

### DIFF
--- a/tanstack-docs-config.schema.json
+++ b/tanstack-docs-config.schema.json
@@ -4,16 +4,16 @@
   "title": "TanStack Docs Config",
   "description": "Config file for the documentation of a TanStack project.",
   "type": "object",
-  "required": ["docSearch", "sections"],
+  "required": ["sections"],
   "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string"
     },
     "docSearch": {
-      "description": "Data for Algolia Search.",
+      "deprecated": true,
+      "description": "Ignored. tanstack.com no longer reads this — the site's search client and index are configured in SearchModal.tsx, not per-library. Safe to delete from your config.",
       "type": "object",
-      "required": ["appId", "apiKey", "indexName"],
       "properties": {
         "appId": {
           "type": "string"
@@ -37,6 +37,10 @@
           "label": {
             "type": "string"
           },
+          "tab": {
+            "$ref": "#/$defs/tab",
+            "description": "Default docs nav tab for every child in this section. Individual children can override it."
+          },
           "children": {
             "description": "Framework-agnostic docs go here.",
             "type": "array",
@@ -52,7 +56,8 @@
                   "type": "string"
                 },
                 "badge": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Free-form tag appended to this page's entry in the generated llms.txt (e.g. \"experimental\"). Not shown in the sidebar — the sidebar overwrites this with the page's framework provenance."
                 },
                 "addedAt": {
                   "type": "string",
@@ -63,6 +68,10 @@
                   "type": "string",
                   "format": "date",
                   "description": "Date the page was last meaningfully updated (e.g. \"2026-06-01\"). Shows an \"Updated\" pill in the sidebar for 7 days."
+                },
+                "tab": {
+                  "$ref": "#/$defs/tab",
+                  "description": "Docs nav tab this page belongs to. Overrides the section's `tab`. Omit to let the site infer one from the labels and path."
                 }
               }
             }
@@ -88,7 +97,8 @@
                         "type": "string"
                       },
                       "badge": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Free-form tag appended to this page's entry in the generated llms.txt (e.g. \"experimental\"). Not shown in the sidebar — the sidebar overwrites this with the page's framework provenance."
                       },
                       "addedAt": {
                         "type": "string",
@@ -99,6 +109,10 @@
                         "type": "string",
                         "format": "date",
                         "description": "Date the page was last meaningfully updated (e.g. \"2026-06-01\"). Shows an \"Updated\" pill in the sidebar for 7 days."
+                      },
+                      "tab": {
+                        "$ref": "#/$defs/tab",
+                        "description": "Docs nav tab this page belongs to. Overrides the section's `tab`. Omit to let the site infer one from the labels and path."
                       }
                     }
                   }
@@ -126,6 +140,13 @@
       "items": {
         "type": "string"
       }
+    }
+  },
+  "$defs": {
+    "tab": {
+      "description": "One of the docs nav tabs rendered above the sidebar.",
+      "type": "string",
+      "enum": ["home", "get-started", "tutorial", "guides", "api", "examples"]
     }
   }
 }


### PR DESCRIPTION
`tanstack-docs-config.schema.json` is the schema every library repo references from its `docs/config.json`. It had drifted from the valibot schema in `src/utils/config.ts` and from the code that actually consumes the config. Three fixes, all to the JSON Schema only — no runtime behaviour changes.

### Add `tab`

Missing since #904 introduced the tabbed docs nav. valibot accepts `tab` on sections, section children, and framework children (`config.ts:26`), and `getDocsNavTabId` reads `child.tab ?? group.tab` before falling back to inference — but because the JSON Schema sets `additionalProperties: false`, a maintainer who set `tab` got a validation error in their editor for using a supported feature.

Added in all three positions via a shared `$defs/tab` enum, sourced from `docsNavTabIds` in `src/utils/docsNavTabs.ts`. Not added to the framework *group* object: `useMenuConfig` flattens framework children into the parent section, so a tab there would never be read.

### Deprecate `docSearch` instead of requiring it

Nothing reads it. There is no reference to `docSearch` anywhere in `src`, and valibot doesn't declare it — it survives parsing only because `v.object` strips unknown keys. Search is wired to constants in the component:

```ts
// SearchModal.tsx:217-221
const searchClient = liteClient('FQ0DQ6MA3C', '10c34d6a5c89f6048cf644d601e65172')
const searchIndexName = 'tanstack-test'
```

The values don't even match what the configs declare — same Algolia app, different search-only key, and the site queries `tanstack-test` while every library config claims `tanstack`. So the schema was requiring maintainers to keep a credential block current for a feature that stopped consuming it.

**Note:** this drops `docSearch` from `required` and marks it `deprecated`, rather than deleting the property. With top-level `additionalProperties: false`, deleting it outright would make every currently-valid config invalid in its editor until that repo removed the block. Deprecating shows a strikethrough and lets each repo delete at its own pace. Happy to do the hard removal instead once the library repos have dropped it — say the word.

### Describe `badge`

`badge` was undocumented and doesn't do what it looks like it does. `useMenuConfig` overwrites it with the page's framework provenance before it reaches the sidebar:

```ts
// LibraryLayout.tsx:754-760
...section.children.map((d) => ({ ...d, badge: 'core' })),
...frameworkItems.map((d) => ({ ...d, badge: currentFramework.framework })),
```

and the sidebar no longer renders it at all — that pill was removed in 9bdc8801. It *is* still read for real in `llms.ts:317`, which walks the raw config and appends it to the generated llms.txt entry. The new description says exactly that, so nobody expects a sidebar pill from it.

### Verification

Validated with ajv against the schema:

```
ai config (docSearch present)      VALID    # no regression on existing configs
ai config (docSearch deleted)      VALID    # repos can now drop the block
tab on section/child/framework     VALID
bogus tab value rejected           yes
```

`pnpm test` passes (136 pass, 0 fail, lint clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tab navigation for documentation sections and pages, including Home, Get Started, Tutorials, Guides, API, and Examples.
* **Bug Fixes**
  * Documentation configuration no longer requires the `docSearch` setting.
* **Documentation**
  * Clarified that `docSearch` is deprecated and ignored.
  * Documented how page badges affect generated `llms.txt` content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->