### PR TITLE
Fix FrameworkIconTabs vertical overflow

### DIFF
--- a/src/components/FrameworkIconTabs.tsx
+++ b/src/components/FrameworkIconTabs.tsx
@@ -24,7 +24,7 @@ export function FrameworkIconTabs({
   return (
     <div
       className={twMerge(
-        `flex items-center justify-start gap-2 border-b border-gray-200 dark:border-gray-700 overflow-x-auto scrollbar-hide`,
+        `flex items-center justify-start gap-2 border-b border-gray-200 dark:border-gray-700 overflow-x-auto overflow-y-hidden scrollbar-hide`,
         className,
       )}
     >


### PR DESCRIPTION
## What changed

Add `overflow-y-hidden` to `FrameworkIconTabs`, matching the existing overflow contract used by the other horizontally scrollable tab components.

## Evidence and impact

The container currently enables horizontal overflow without suppressing the transient vertical overflow produced while scrolling on mobile. This causes the layout shift reported in #954. `src/components/markdown/Tabs.tsx` and `FileTabs.tsx` already use the same `overflow-x-auto overflow-y-hidden` pairing.

Closes #954.

## Validation

- `pnpm test` — TypeScript and type-aware lint clean; 135 tests (134 passed, 1 skipped)
- commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. The change only clips vertical overflow on the existing horizontal tab scroller; caller-provided classes can still override it through `twMerge`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab navigation styling to prevent unwanted vertical overflow while preserving horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->