### PR TITLE
Clean up Explore autosave lifecycle

### DIFF
--- a/src/components/game/IslandExplorer.client.tsx
+++ b/src/components/game/IslandExplorer.client.tsx
@@ -20,6 +20,7 @@ import { StatsHUD } from './ui/StatsHUD'
 import { GameMachineProvider } from './machines/GameMachineProvider'
 import { ProgressionSync } from './machines/ProgressionSync'
 import { BadgeOverlay } from './ui/BadgeOverlay'
+import { useGamePersistence } from './hooks/useGameStore'
 
 const LOADING_MESSAGES = [
   ['Convincing the waves to behave...', 'They never listen'],
@@ -58,6 +59,7 @@ function LoadingOverlay() {
 
 export default function IslandExplorer() {
   const [isLoading, setIsLoading] = useState(true)
+  useGamePersistence()
 
   return (
     <GameMachineProvider>

--- a/src/components/game/hooks/useGameStore.ts
+++ b/src/components/game/hooks/useGameStore.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { create } from 'zustand'
 import type { IslandData } from '../utils/islandGenerator'
 import {
@@ -997,20 +998,24 @@ export const useGameStore = create<GameState>()((set, get) => ({
   },
 }))
 
-// Periodic auto-save and beforeunload handler (client-side only)
-if (typeof window !== 'undefined') {
-  // Auto-save every 5 seconds
-  setInterval(() => {
-    const state = useGameStore.getState()
-    // Only save if game is active
-    if (state.phase === 'playing' || state.phase === 'gameover') {
+export function useGamePersistence() {
+  useEffect(() => {
+    const persist = () => {
+      const state = useGameStore.getState()
       saveToLocalStorage(extractPersistedState(state))
     }
-  }, 5000)
+    const interval = window.setInterval(() => {
+      const state = useGameStore.getState()
+      if (state.phase === 'playing' || state.phase === 'gameover') {
+        saveToLocalStorage(extractPersistedState(state))
+      }
+    }, 5000)
 
-  // Also save when page is about to unload
-  window.addEventListener('beforeunload', () => {
-    const state = useGameStore.getState()
-    saveToLocalStorage(extractPersistedState(state))
-  })
+    window.addEventListener('beforeunload', persist)
+    return () => {
+      window.clearInterval(interval)
+      window.removeEventListener('beforeunload', persist)
+      persist()
+    }
+  }, [])
 }


### PR DESCRIPTION
## What changed

Move Explore's periodic save timer and `beforeunload` listener from module scope into the `IslandExplorer` component lifecycle.

The lifecycle hook now:

- starts one autosave timer while Explore is mounted
- removes the timer and listener when navigating away
- saves once during cleanup so the latest progress is retained

## Evidence and impact

Importing `useGameStore.ts` previously started a permanent five-second interval and registered an anonymous `beforeunload` listener. TanStack Router keeps that loaded module alive after SPA navigation, so an active game continued writing to `localStorage` every five seconds after leaving `/explore`; HMR could also register additional timers and listeners.

This change ties both resources to the only UI that needs them and prevents background work after leaving Explore.

## Validation

- `pnpm test` — TypeScript and type-aware lint clean; 135 tests (134 passed, 1 skipped)
- commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. Save cadence and unload behavior are unchanged while Explore is mounted. Cleanup adds one final save before stopping persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game progress is now saved automatically during gameplay.
  * Progress is also saved when leaving or closing the game, helping prevent lost changes.
* **Bug Fixes**
  * Improved persistence handling so save operations are managed consistently while the game is active and stopped cleanly when it is no longer in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->