### PR TITLE
Fix maintainer full card images

### DIFF
--- a/src/components/MaintainerCard.tsx
+++ b/src/components/MaintainerCard.tsx
@@ -405,7 +405,15 @@ export function MaintainerCard({ maintainer }: MaintainerCardProps) {
         aria-label={`View ${maintainer.name}'s GitHub profile`}
         className="block aspect-square w-full overflow-hidden rounded-[22px] corner-squircle bg-[#d9d9d9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
         tabIndex={0}
-      />
+      >
+        <img
+          alt={`Avatar of ${maintainer.name}`}
+          className="h-full w-full object-cover"
+          src={maintainer.avatar}
+          loading="lazy"
+          decoding="async"
+        />
+      </a>
       <div className="flex w-full flex-col items-center gap-5 pb-[27px] pt-5">
         <span
           className="text-center font-ds-mono text-ds-mono-lg text-text-primary"


### PR DESCRIPTION
Full card view now renders each maintainer's avatar image instead of an empty placeholder.

Verified locally with the full cards view.
<img width="1280" height="720" alt="maintainer-cards-fixed" src="https://github.com/user-attachments/assets/6e6ebb98-a115-426c-9323-0637733415fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintainer avatars now display correctly and link directly to the maintainer’s GitHub profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->