### PR TITLE
Scope Intent registry loader dependencies

### DIFF
--- a/src/routes/intent/registry/index.tsx
+++ b/src/routes/intent/registry/index.tsx
@@ -39,7 +39,12 @@ const searchSchema = v.object({
 
 export const Route = createFileRoute('/intent/registry/')({
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => search,
+  loaderDeps: ({ search }) => ({
+    q: search.q,
+    framework: search.framework,
+    sort: search.sort,
+    page: search.page,
+  }),
   loader: ({ deps, context: { queryClient } }) =>
     Promise.all([
       queryClient.ensureQueryData(intentStatsQueryOptions()),


### PR DESCRIPTION
## What changed

Narrow the Intent registry route loader dependencies to the four search values the loader actually consumes: `q`, `framework`, `sort`, and `page`.

## Evidence and impact

The route previously returned the entire validated search object from `loaderDeps`. Changing client-only `tab` or `view` state therefore invalidated the loader and reran its stats and directory query checks even though neither value is read by the loader.

This follows the repository's TanStack guidance that loader dependencies include only values used by the loader. Package search, framework filtering, sorting, and pagination still invalidate it as before.

## Validation

- `pnpm test`
- TypeScript clean
- oxlint clean
- 143 tests passed; 1 environment-gated docs smoke test skipped
- Commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. The change only removes two unused loader dependencies. Both values remain validated URL state and continue to drive client rendering and skill search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result updates by responding only to relevant filters, sorting, and pagination changes.
  * Prevented unrelated URL parameter changes from triggering unnecessary reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->