### PR TITLE
Pause offscreen homepage adapter motion

### DIFF
--- a/src/components/landing/ChartsCatalogGallery.tsx
+++ b/src/components/landing/ChartsCatalogGallery.tsx
@@ -6,6 +6,7 @@ import {
   ChartsCatalogChart,
   type ChartsCatalogModuleReference,
 } from '~/components/charts/ChartsCatalogChart'
+import { useInView } from '~/hooks/useInView'
 import type { ChartsCatalogCase } from '~/utils/charts-catalog'
 
 type CatalogCase = Pick<
@@ -49,7 +50,7 @@ export function CatalogChartsHero({
   )
   const [focused, setFocused] = React.useState(false)
   const [hovered, setHovered] = React.useState(false)
-  const [inView, setInView] = React.useState(true)
+  const inView = useInView(rootRef, { threshold: 0.2 })
   const [pageVisible, setPageVisible] = React.useState(true)
   const [paused, setPaused] = React.useState(false)
   const reducedMotion = useReducedMotion()
@@ -76,18 +77,6 @@ export function CatalogChartsHero({
 
     return () => intervals.forEach((interval) => window.clearInterval(interval))
   }, [orderedCases.length, running, visibleTileCount])
-
-  React.useEffect(() => {
-    const root = rootRef.current
-    if (!root || !('IntersectionObserver' in window)) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setInView(Boolean(entry?.isIntersecting)),
-      { threshold: 0.2 },
-    )
-    observer.observe(root)
-    return () => observer.disconnect()
-  }, [])
 
   React.useEffect(() => {
     const updateVisibility = () =>

--- a/src/components/landing/ChartsLandingGraphics.tsx
+++ b/src/components/landing/ChartsLandingGraphics.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Pause, Play, Shuffle } from '@phosphor-icons/react'
 
 import { useIsDark } from '~/hooks/useIsDark'
+import { useInView } from '~/hooks/useInView'
 
 import kineticBarChartSource from '../../../scripts/charts-landing/kinetic-bar-chart.ts?raw'
 import kineticDonutChartSource from '../../../scripts/charts-landing/kinetic-donut-chart.ts?raw'
@@ -377,7 +378,7 @@ export function KineticChartsHero() {
   const [outgoingIndex, setOutgoingIndex] = React.useState<number | null>(null)
   const [focusWithin, setFocusWithin] = React.useState(false)
   const [hovered, setHovered] = React.useState(false)
-  const [inView, setInView] = React.useState(true)
+  const inView = useInView(rootRef, { threshold: 0.18 })
   const [autoAdvanceOverride, setAutoAdvanceOverride] = React.useState(false)
   const [pageVisible, setPageVisible] = React.useState(true)
   const [paused, setPaused] = React.useState(false)
@@ -437,20 +438,6 @@ export function KineticChartsHero() {
     )
     return () => window.clearInterval(interval)
   }, [autoPlay, interacting, showNewVariation])
-
-  React.useEffect(() => {
-    const root = rootRef.current
-    if (!root || !('IntersectionObserver' in window)) {
-      return
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setInView(Boolean(entry?.isIntersecting)),
-      { threshold: 0.18 },
-    )
-    observer.observe(root)
-    return () => observer.disconnect()
-  }, [])
 
   React.useEffect(() => {
     const updateVisibility = () =>

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,31 @@
+import * as React from 'react'
+
+export function useInView<TElement extends Element>(
+  targetRef: React.RefObject<TElement | null>,
+  {
+    root = null,
+    rootMargin = '0px',
+    threshold = 0,
+  }: IntersectionObserverInit = {},
+) {
+  const [inView, setInView] = React.useState(false)
+
+  React.useEffect(() => {
+    const target = targetRef.current
+    if (!target) return
+
+    if (!('IntersectionObserver' in window)) {
+      setInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(Boolean(entry?.isIntersecting)),
+      { root, rootMargin, threshold },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [root, rootMargin, targetRef, threshold])
+
+  return inView
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -24,6 +24,7 @@ import { useNpmDownloadCounter } from '~/hooks/useNpmDownloadCounter'
 import { homepageNpmStatsSummaryQuery, ossStatsQuery } from '~/queries/stats'
 import { useLibrariesOverlay } from '~/contexts/LibrariesOverlayContext'
 import { fetchRecentPosts } from '~/utils/blog.functions'
+import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 import { seo } from '~/utils/seo'
 
 export const Route = createFileRoute('/')({
@@ -565,8 +566,24 @@ function FrameworkAdapterGraph({
 }) {
   const [activeAdapterIndex, setActiveAdapterIndex] = React.useState(0)
   const [flowProgress, setFlowProgress] = React.useState(0)
+  const [isVisible, setIsVisible] = React.useState(false)
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   React.useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsVisible(Boolean(entry?.isIntersecting))
+    })
+    observer.observe(root)
+    return () => observer.disconnect()
+  }, [])
+
+  React.useEffect(() => {
+    if (!isVisible || prefersReducedMotion !== false) return
+
     const intervalId = window.setInterval(() => {
       setActiveAdapterIndex(
         (currentIndex) => (currentIndex + 1) % frameworkAdapterNodes.length,
@@ -574,12 +591,10 @@ function FrameworkAdapterGraph({
     }, 1150)
 
     return () => window.clearInterval(intervalId)
-  }, [])
+  }, [isVisible, prefersReducedMotion])
 
   React.useEffect(() => {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return
-    }
+    if (!isVisible || prefersReducedMotion !== false) return
 
     let frameId = 0
     let lastUpdate = 0
@@ -597,13 +612,14 @@ function FrameworkAdapterGraph({
     frameId = window.requestAnimationFrame(update)
 
     return () => window.cancelAnimationFrame(frameId)
-  }, [])
+  }, [isVisible, prefersReducedMotion])
 
   return (
     // The node positions below are hard-coded against a 320×128 grid
     // (adapterGraphWidth/Height), so the whole graph is scaled as a unit to
     // fill the 460×233 slot rather than re-deriving every coordinate.
     <div
+      ref={rootRef}
       aria-hidden="true"
       className="relative h-32 w-[320px] shrink-0 scale-[1.35] font-mono text-[10px] font-bold"
     >

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,7 @@ import { HomeSocialProofSection } from '~/components/home/HomeSocialProofSection
 import { HomeStatsSection } from '~/components/home/HomeStatsSection'
 import { useQuery } from '@tanstack/react-query'
 import { Button, Eyebrow } from '~/components/ds/ui'
+import { useInView } from '~/hooks/useInView'
 import { useNpmDownloadCounter } from '~/hooks/useNpmDownloadCounter'
 import { homepageNpmStatsSummaryQuery, ossStatsQuery } from '~/queries/stats'
 import { useLibrariesOverlay } from '~/contexts/LibrariesOverlayContext'
@@ -566,20 +567,9 @@ function FrameworkAdapterGraph({
 }) {
   const [activeAdapterIndex, setActiveAdapterIndex] = React.useState(0)
   const [flowProgress, setFlowProgress] = React.useState(0)
-  const [isVisible, setIsVisible] = React.useState(false)
   const rootRef = React.useRef<HTMLDivElement>(null)
+  const isVisible = useInView(rootRef)
   const prefersReducedMotion = usePrefersReducedMotion()
-
-  React.useEffect(() => {
-    const root = rootRef.current
-    if (!root) return
-
-    const observer = new IntersectionObserver(([entry]) => {
-      setIsVisible(Boolean(entry?.isIntersecting))
-    })
-    observer.observe(root)
-    return () => observer.disconnect()
-  }, [])
 
   React.useEffect(() => {
     if (!isVisible || prefersReducedMotion !== false) return


### PR DESCRIPTION
## What changed

Pause the homepage framework-adapter proof's timer and animation-frame loop unless the graph intersects the viewport and the visitor allows motion.

## Evidence and impact

`FrameworkAdapterGraph`, added in #1075, mounted several sections below the fold but immediately started:

- a 1.15-second interval that updates the active adapter
- a continuous animation-frame loop that commits React state about every 33ms

The animation-frame loop therefore drove roughly 30 React renders per second from initial homepage load even when the proof had never entered the viewport. The active-adapter interval also continued offscreen and for reduced-motion visitors.

The graph now remains static until visible, stops both loops when it leaves the viewport, and keeps the existing animation unchanged while visible. Reduced-motion visitors get the same static proof without either state loop.

## Validation

- `pnpm test`
- TypeScript and type-aware lint clean
- 143 tests passed; 1 environment-gated docs smoke test skipped
- Commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. This changes only when the decorative proof runs; its visible motion, geometry, and content are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Respects reduced-motion preferences by disabling animated graph transitions when requested.
  * Provides smoother, less distracting experiences for visitors who prefer reduced motion.

* **Performance**
  * Runs graph cycling, flow animations, and chart autoplay only while visuals are visible.
  * Improves cleanup of animation resources when visualizations leave the screen or become inactive.
  * Enhances viewport-aware behavior across landing-page graphics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->