### PR TITLE
Prevent copied-code toast stacking

### DIFF
--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '~/components/ThemeProvider'
 
 type ToastOptions = {
   durationMs?: number
+  id?: number | string
 }
 
 type ToastContextValue = {
@@ -29,7 +30,10 @@ export function ToastProvider({
 
   const notify = React.useCallback(
     (content: React.ReactNode, options?: ToastOptions) => {
-      const id = toast(content, { duration: options?.durationMs ?? 2500 })
+      const id = toast(content, {
+        duration: options?.durationMs ?? 2500,
+        id: options?.id,
+      })
       return String(id)
     },
     [],

--- a/src/components/markdown/CodeBlockView.tsx
+++ b/src/components/markdown/CodeBlockView.tsx
@@ -55,6 +55,7 @@ export function CodeBlockView({
                     Code block copied to clipboard
                   </span>
                 </div>,
+                { id: 'code-copied' },
               )
             }}
             aria-label="Copy code to clipboard"


### PR DESCRIPTION
## What changed

Allow the shared toast wrapper to accept Sonner's stable `id` option, then reuse one ID for code-copy confirmations.

## Root cause and impact

`CodeBlockView` created a new toast for every copy action. Repeated copies therefore accumulated distinct notifications and could cover the documentation viewport, as reported in #960.

With a stable code-copy toast ID, Sonner updates the existing confirmation instead of stacking another one. Other notifications keep their current independent behavior.

Closes #960

## Validation

- `pnpm test`
- TypeScript clean
- oxlint clean
- 143 tests passed; 1 environment-gated docs smoke test skipped
- Commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. The new toast option is optional, and only code-copy confirmations opt into deduplication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-copy notifications to prevent duplicate toast messages when copying code repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->