### PR TITLE
Fix text contrast in menu elements

### DIFF
--- a/src/components/MegaMenuItem.tsx
+++ b/src/components/MegaMenuItem.tsx
@@ -83,7 +83,9 @@ export function MegaMenuItem({
           {/* Rest = neutral tint (Figma neutral/tint/200); brightens to
               text-primary on hover. Plain string (not twMerge) so the DS size
               utility and the color utilities coexist. */}
-          <span className="font-ds-display text-ds-heading-5 whitespace-nowrap text-text-menu-title transition-colors group-hover/mmi:text-text-primary group-active/mmi:text-text-primary">
+          <span
+            className={`font-ds-display text-ds-heading-5 whitespace-nowrap ${variant === 'mobile' ? 'text-ds-neutral-tint-200' : 'text-text-menu-title'} transition-colors group-hover/mmi:text-text-primary group-active/mmi:text-text-primary`}
+          >
             {title}
           </span>
           {badge ? (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1019,7 +1019,9 @@ function MegaMenuContent({
                 variant === 'mobile' && sectionIndex > 0 && 'pt-3',
               )}
             >
-              <div className="mb-2 px-2 font-ds-mono text-ds-mono-sm uppercase text-ds-neutral-100">
+              <div
+                className={`mb-2 px-2 font-ds-mono text-ds-mono-sm uppercase ${variant === 'mobile' ? 'text-ds-neutral-100' : 'text-ds-neutral-300 dark:text-ds-neutral-100'}`}
+              >
                 {section.label}
               </div>
               <div
@@ -1303,7 +1305,9 @@ function BlogMenuContent({
       )}
     >
       <section>
-        <div className="mb-3 px-1 font-ds-mono text-ds-mono-xs uppercase tracking-wider text-ds-neutral-100">
+        <div
+          className={`mb-3 px-1 font-ds-mono text-ds-mono-xs uppercase tracking-wider ${variant === 'mobile' ? 'text-ds-neutral-100' : 'text-ds-neutral-300 dark:text-ds-neutral-100'}`}
+        >
           Blog &amp; Release Notes
         </div>
         <div
@@ -1341,7 +1345,9 @@ function BlogMenuContent({
 
       {aboutSection && aboutSection.items.length > 0 ? (
         <section className="border-t border-border-subtle pt-4">
-          <div className="mb-2 px-1 font-ds-mono text-ds-mono-xs uppercase tracking-wider text-ds-neutral-100">
+          <div
+            className={`mb-2 px-1 font-ds-mono text-ds-mono-xs uppercase tracking-wider ${variant === 'mobile' ? 'text-ds-neutral-100' : 'text-ds-neutral-300 dark:text-ds-neutral-100'}`}
+          >
             {aboutSection.label}
           </div>
           <div
@@ -1577,7 +1583,7 @@ function MenuRail({
         <div className="flex flex-col items-start gap-2.5">
           {/* "Work with" + the TanStack lockup read together as "Work with
               TanStack" (Figma: terracotta/200 label above the landscape mark). */}
-          <div className="font-ds-display text-base font-normal text-ds-terracotta-200">
+          <div className="font-ds-display text-base font-normal text-ds-terracotta-400 dark:text-ds-terracotta-200">
             {rail.title}
           </div>
           <img


### PR DESCRIPTION
## Before

<img width="2156" height="1108" alt="Screenshot 2026-08-02 at 13 59 57" src="https://github.com/user-attachments/assets/8b18fafe-8686-43b0-b6d0-929224efff7a" />
<img width="1654" height="494" alt="Screenshot 2026-08-02 at 13 59 53" src="https://github.com/user-attachments/assets/dc3f4749-0a8b-44ae-85ee-8b02d6b69122" />
<img width="1694" height="834" alt="Screenshot 2026-08-02 at 13 59 48" src="https://github.com/user-attachments/assets/50c23fd3-d509-4183-be1e-c17fe1d8efad" />
<img width="1902" height="1190" alt="Screenshot 2026-08-02 at 13 59 43" src="https://github.com/user-attachments/assets/7a8209e4-088b-48e1-81fe-d866e59b53da" />
<img width="549" height="904" alt="image" src="https://github.com/user-attachments/assets/6b5eca97-1c69-4020-854a-67fed9f73106" />

## After
<img width="1656" height="496" alt="Screenshot 2026-08-02 at 14 01 53" src="https://github.com/user-attachments/assets/7b5eb3d7-ad49-4c0f-9fc4-a4b160341a2e" />
<img width="1684" height="812" alt="Screenshot 2026-08-02 at 14 01 50" src="https://github.com/user-attachments/assets/30278b19-6632-4978-8f73-3b438496db81" />
<img width="1916" height="1196" alt="Screenshot 2026-08-02 at 14 01 47" src="https://github.com/user-attachments/assets/bbfe9db8-e166-42d8-8e39-c1ed7b0c505c" />
<img width="1057" height="499" alt="image" src="https://github.com/user-attachments/assets/982ec830-757d-43db-a28d-2729dfc14e30" />
<img width="543" height="829" alt="image" src="https://github.com/user-attachments/assets/436acabe-6538-459e-aaac-68549c6cd75e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved mega-menu text colors across mobile and desktop layouts.
  * Enhanced label contrast in light and dark modes.
  * Updated the desktop partner rail title color for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->