### PR TITLE
fix(intent/registry): restore 'Copy install prompt' button label

### DIFF
--- a/src/routes/intent/registry/$packageName.tsx
+++ b/src/routes/intent/registry/$packageName.tsx
@@ -364,7 +364,7 @@ This will detect all Agent Skills in ${name} and configure them for your coding 
       ) : (
         <CopyIcon className="w-3.5 h-3.5" />
       )}
-      CopyIcon install prompt
+      Copy install prompt
     </button>
   )
 }


### PR DESCRIPTION
The install-prompt button on package detail pages renders as **"CopyIcon install prompt"** instead of "Copy install prompt".

This is a regression from #1094. The codemod that renamed phosphor icons to their `Icon`-suffixed exports treated the word `Copy` in the button's JSX text as a component reference and rewrote it.

## Why CI did not catch it

The damage is in a text node, so it is valid JSX and valid TypeScript. `tsc`, `oxlint`, and the 143 unit tests all pass on the broken code — it is already live in production.

Worth noting the same masking bug went the other way in `NPMStatsChart.tsx` during #1094, where an actual `<Copy />` component was *missed*. That one raised TS2304 and got fixed before merge. Only the text-node direction is silent.

## Scope

I re-checked the whole #1094 diff for the same class of damage:

```
git diff 898909ec..main -- src/ | grep '^+' | grep 'Icon' \
  | grep -v '<[A-Z][A-Za-z0-9]*Icon' | grep -v 'Icon[,}=:)]' \
  | grep -v 'Icon as \|as [A-Z][A-Za-z0-9]*Icon' | grep -v '^+import'
```

Everything else that matched is a legitimate import alias or generated-registry entry. This is the only affected string.

## Testing

Found by opening a package page on a preview deploy — the accessibility tree exposed the button as `"CopyIcon install prompt"`. `pnpm test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the copy-install button label to “Copy install prompt” for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->