### PR TITLE
fix(components/Doc): add spacing below the docs prev/next bar

### DIFF
--- a/src/components/Doc.tsx
+++ b/src/components/Doc.tsx
@@ -176,6 +176,7 @@ export function Doc({
             }
           />
           {footer ?? <DocNavigation />}
+          <div className="h-4" />
         </div>
 
         {isTocVisible && (


### PR DESCRIPTION
Scrolled to the bottom of a docs page, the Previous/Next cards sit flush against the footer's top edge with no gap at all.

The bar is `sticky bottom-2`. That offset spaces it from the viewport **while it floats**, but once the page bottoms out the bar settles as the last element of its flex column and there is nothing below it — the footer starts immediately.

## Fix

One spacer div after the bar in `Doc.tsx`:

```tsx
{footer ?? <DocNavigation />}
<div className="h-4" />
```

This follows the spacing idiom already used in `MarkdownContent`, which separates its sections with explicit spacer divs (`h-12` under the prose, `py-4` around the Edit on GitHub row) rather than padding on the elements themselves.

## Why not `pb-4` on the bar itself

That was my first attempt, and it was wrong: padding lives inside the sticky element's box, so it changes **both** states — the floating card would have moved from 8px to 24px off the viewport edge. `bottom-2` deliberately sets the floating gap, and that part was never the bug.

The two gaps measure different things and should stay different. Floating, the card is an overlay hovering above the text scrolling under it — tight to the edge is correct. Settled, it only needs enough room not to collide with the footer's top border; the section separation itself is already provided by the footer, which carries `py-12 lg:py-16` of its own. That is also why `h-4` and not something larger — 48px here would stack on top of the footer's own 48–64px.

## Measured on a docs page

| State | Before | After |
| --- | --- | --- |
| Floating (card → viewport bottom) | 8px | 8px |
| Settled (card → footer top) | 0px | 16px |

## Screenshot

### AS-IS

<img width="1725" height="941" alt="image" src="https://github.com/user-attachments/assets/b41358d4-70b6-4582-93a3-1727795f35c7" />

### TO-BE

<img width="1728" height="886" alt="image" src="https://github.com/user-attachments/assets/7be0919c-41d6-45c5-8909-03a5694c5082" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added extra spacing below the document footer or navigation to improve page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->