### PR TITLE
fix(routes/index): prevent npm downloads counter from overflowing on mobile

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -784,7 +784,7 @@ function AdoptionProof({ accentClassName }: { accentClassName: string }) {
           // once there is a real number for it to count from.
           ref={totalDownloads > 0 ? counterRef : undefined}
           className={twMerge(
-            'bg-linear-to-r bg-clip-text font-mono text-4xl font-black tabular-nums text-transparent',
+            'bg-linear-to-r bg-clip-text font-mono text-3xl font-black tabular-nums text-transparent sm:text-4xl',
             accentClassName,
           )}
         >


### PR DESCRIPTION
The npm downloads counter on the landing page runs out of room on small phones. Reported from an iPhone SE (375px), where the number reads as clipped.

## Measurements

At 375px the stat block has `327px` of usable width (`375 − 24 − 24` from the panel's `p-6`). The counter renders in `ui-monospace` at `text-4xl` / 36px:

| | Required | Available | Headroom |
| --- | --- | --- | --- |
| `15,906,312,010` at 36px | 303px | 327px | 24px |
| `15,906,312,010` at 30px | 253px | 327px | 74px |

24px of headroom is already tight, and the value only grows — one more digit (crossing a trillion) needs 368px at 36px and overflows outright.

## Fix

`text-4xl` → `text-3xl sm:text-4xl`, so phones render at 30px and everything from `sm` up is unchanged.

The `per week` / `github stars` pair below was checked too: at `text-xl` the widest (`133,039,817`, 132px) fits its 152px column, so it needs nothing.

## Verified

Locally below the `sm` breakpoint the counter computes to `30px` and measures `253px`; at ≥640px it stays `36px` / `303px` as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive typography for the npm downloads figure, making it more appropriately sized on smaller screens while preserving larger text on wider screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->