### PR TITLE
Publish TanStack Table V9 announcement

### DIFF
--- a/src/blog/announcing-tanstack-table-v9.md
+++ b/src/blog/announcing-tanstack-table-v9.md
@@ -1,7 +1,6 @@
 ---
 title: 'Announcing TanStack Table V9'
 published: 2026-08-04
-draft: true
 excerpt: TanStack Table V9 is here with a tree-shakable feature architecture, fine-grained reactivity, improved performance, and first-class support for more frameworks.
 library: table
 authors:


### PR DESCRIPTION
## What changed

- Removed the `draft` flag from the TanStack Table V9 announcement.

## Why

The announcement is live at its direct URL, but production blog listings exclude posts marked as drafts. Publishing the metadata allows the post to appear on the blog index and removes its unpublished state.

## Validation

- `pnpm run content:build`
- Full pre-commit format, TypeScript, lint, and unit test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Published the announcement blog post, now available to readers as of August 4, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->