### PR TITLE
refactor(routes/partners.railway): drop lucide-era icon aliases and fix the check weight

### DIFF
--- a/src/routes/partners.railway.tsx
+++ b/src/routes/partners.railway.tsx
@@ -2,17 +2,17 @@ import * as React from 'react'
 import { Link, createFileRoute } from '@tanstack/react-router'
 import {
   ArrowUpRightIcon,
+  ArrowUUpLeftIcon,
+  ChartLineIcon,
   CheckIcon,
-  CurrencyDollarIcon as DollarSign,
+  CurrencyDollarIcon,
   GitPullRequestIcon,
   GlobeIcon,
   InfinityIcon,
-  ChartLineIcon as LineChart,
   NetworkIcon,
   PlusIcon,
   RocketIcon,
   ShieldCheckIcon,
-  ArrowUUpLeftIcon as Undo2,
 } from '@phosphor-icons/react'
 import { twMerge } from 'tailwind-merge'
 import { Card } from '~/components/Card'
@@ -85,7 +85,7 @@ const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
     desc: 'Enable PR Environments on a GitHub-connected project to spin up isolated previews for eligible pull requests.',
   },
   {
-    Icon: LineChart,
+    Icon: ChartLineIcon,
     title: 'Logs, metrics, and alerts',
     desc: 'Logs and metrics are built in. Pro workspaces can configure Monitors that notify Slack, Discord, or email.',
   },
@@ -95,7 +95,7 @@ const features: Array<{ Icon: FeatureIcon; title: string; desc: string }> = [
     desc: 'Services in a project talk over private IPs at up to 100 Gbps. HTTP, TCP, gRPC, and WebSockets handled for you.',
   },
   {
-    Icon: Undo2,
+    Icon: ArrowUUpLeftIcon,
     title: 'Retained deployment versions',
     desc: 'Redeploy an earlier version while its image is retained. Retention ranges from 24 hours to 360 hours by plan.',
   },
@@ -283,7 +283,7 @@ export const Route = createFileRoute('/partners/railway')({
 function CheckBadge() {
   return (
     <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
-      <CheckIcon className="h-2.5 w-2.5" strokeWidth={3} />
+      <CheckIcon className="h-2.5 w-2.5" weight="bold" />
     </span>
   )
 }
@@ -673,7 +673,7 @@ function RailwayPartnerPage() {
               <ArrowUpRightIcon className="h-4 w-4" />
             </Button>
             <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-              <DollarSign className="h-3.5 w-3.5" />
+              <CurrencyDollarIcon className="h-3.5 w-3.5" />
               Per-second billing, no credit card required
             </span>
           </div>


### PR DESCRIPTION
Follow-up to #1113, which moved the Netlify partner page off `lucide-react`. The Railway page had migrated to Phosphor earlier but kept two artefacts from that move.

## `strokeWidth={3}` never applied

The check badge carried `strokeWidth={3}` — a Lucide prop. Phosphor's `IconProps` has no `strokeWidth`; it exposes `weight`, and each weight ships a different SVG path. The prop was silently dropped and the check rendered at `regular`.

Confirmed by reading the rendered path:

| | `d` attribute | Stroke |
| --- | --- | --- |
| `strokeWidth={3}` | `M229.66,77.66l-128,128a8,8,…` | 8 — regular |
| `weight="bold"` | `M232.49,80.49l-128,128a12,12,…` | 12 — bold |

So this restores the emphasis the badge had under Lucide rather than changing the design.

## Aliases

```diff
-  CurrencyDollarIcon as DollarSign,
-  ChartLineIcon as LineChart,
-  ArrowUUpLeftIcon as Undo2,
+  CurrencyDollarIcon,
+  ChartLineIcon,
+  ArrowUUpLeftIcon,
```

These preserved the old Lucide names. With #1113 landed, the two partner pages otherwise use identical Phosphor imports, so keeping the aliases here meant the same icon went by two names depending on the file. Call sites updated and the import block re-sorted.

## Verified

`tsc` and `oxlint --type-aware` clean. Rendered the page locally and diffed the badge's SVG path before and after to confirm `weight` takes effect — the visual difference at 10px is too small to judge from a screenshot alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated interface icons to use current icon names.
  * No visible changes to functionality or rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->