### PR TITLE
fix(routes/index): hold the hero height with 'svh' instead of 'dvh'

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -74,7 +74,9 @@ function Index() {
               always light, so text uses a mode-stable dark token (neutral-500)
               rather than a theme-flipping semantic. */}
           <div className="mx-0 rounded-none bg-background-subtle p-0 sm:mx-2 sm:rounded-2xl sm:p-1">
-            <div className="group relative isolate flex h-[calc(100dvh-var(--navbar-height))] max-h-[720px] min-h-[560px] flex-col justify-between gap-8 overflow-hidden rounded-none px-6 py-10 [text-shadow:0_2px_8px_rgb(255_255_255/0.2)] sm:rounded-xl sm:px-10 md:flex-row md:items-end md:justify-between md:gap-8 md:[text-shadow:none] xl:gap-12 xl:px-16 xl:py-16">
+            {/* `svh`, not `dvh` — the dynamic viewport grows as iOS collapses
+                the URL bar mid-scroll, visibly stretching the hero. */}
+            <div className="group relative isolate flex h-[calc(100svh-var(--navbar-height))] max-h-[720px] min-h-[560px] flex-col justify-between gap-8 overflow-hidden rounded-none px-6 py-10 [text-shadow:0_2px_8px_rgb(255_255_255/0.2)] sm:rounded-xl sm:px-10 md:flex-row md:items-end md:justify-between md:gap-8 md:[text-shadow:none] xl:gap-12 xl:px-16 xl:py-16">
               {/* The parent supplies the 4px frame shared by the hero and stats.
                   This wrapper clips the image to the inner radius so the <img>
                   fills it exactly instead of overflowing. Plain <img> (not OptimizedImage):


### PR DESCRIPTION
On iOS, scrolling the landing page makes the hero card jump taller mid-scroll.

## Cause

The hero is sized with `h-[calc(100dvh-var(--navbar-height))]`. The **d**ynamic viewport unit tracks the URL bar: as Safari collapses it during a scroll, `100dvh` grows and the card grows with it. That is the unit behaving as specified — it just isn't what a full-bleed hero wants.

`svh` resolves against the **small** viewport (URL bar expanded) and does not change while scrolling, so the card keeps its height.

## Scope

Only the hero. I went through the other 21 `dvh` usages and none have the same problem — the symptom needs a page that scrolls, a fixed height, and an element that visibly fills the viewport, and only the hero has all three:

| Usage | Count | Why it's fine |
| --- | --- | --- |
| `h-` on game/builder/sidebar | 5 | `overflow-hidden` or self-scrolling, so the page never scrolls and the URL bar never collapses |
| `max-h` on sidebars, TOC, drawers | 9 | Growing with the URL bar gives more room — arguably the point |
| `min-h` | 5 | Only reacts when content exceeds it, so nothing jumps |
| `SearchModal` | 3 | Page scroll is locked while open, and each is bounded by a `min(...)` |

`styles/shop.css` already uses `svh` for the product sheet, so the unit is not new here.

## Testing

Confirmed on an iPhone: the hero no longer stretches mid-scroll.

Desktop is unchanged by construction — with no collapsible URL bar, `svh`, `lvh`, `dvh`, and `vh` all resolve identically (886px for all four locally), and `max-h-[720px]` caps the hero at 720px either way. The change only has an effect where `svh < lvh`, which is why a real device was the only way to verify it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the mobile hero section from resizing when the browser’s URL bar appears or disappears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
