### PR TITLE
refactor(utils): replace 'data: any' on server functions with their validated shapes

### DIFF
--- a/src/utils/intent-admin.server.ts
+++ b/src/utils/intent-admin.server.ts
@@ -246,7 +246,11 @@ export async function triggerIntentProcess() {
 // Trigger: retry a specific failed version by id
 // ---------------------------------------------------------------------------
 
-export async function retryIntentVersion({ data }: { data: any }) {
+export async function retryIntentVersion({
+  data,
+}: {
+  data: { versionId: number }
+}) {
   await requireCapability({ data: { capability: 'admin' } })
 
   const version = await db.query.intentPackageVersions.findFirst({
@@ -395,7 +399,7 @@ export async function discoverViaGitHub() {
 // Useful for packages that ship skills but haven't yet published the keyword.
 // ---------------------------------------------------------------------------
 
-export async function seedIntentPackage({ data }: { data: any }) {
+export async function seedIntentPackage({ data }: { data: { name: string } }) {
   await requireCapability({ data: { capability: 'admin' } })
 
   const packument = await fetchPackument(data.name)
@@ -426,7 +430,11 @@ export async function seedIntentPackage({ data }: { data: any }) {
 // Delete a package and all its versions/skills
 // ---------------------------------------------------------------------------
 
-export async function deleteIntentPackage({ data }: { data: any }) {
+export async function deleteIntentPackage({
+  data,
+}: {
+  data: { name: string }
+}) {
   await requireCapability({ data: { capability: 'admin' } })
 
   await db.delete(intentPackages).where(eq(intentPackages.name, data.name))

--- a/src/utils/stats-admin.server.ts
+++ b/src/utils/stats-admin.server.ts
@@ -33,7 +33,11 @@ export async function listGitHubStatsCache() {
 /**
  * Refresh GitHub stats for a specific repo or org
  */
-export async function refreshGitHubStats({ data }: { data: any }) {
+export async function refreshGitHubStats({
+  data,
+}: {
+  data: { cacheKey: string }
+}) {
   await requireCapability({ data: { capability: 'admin' } })
 
   const isOrg = data.cacheKey.startsWith('org:')
@@ -158,7 +162,7 @@ export async function refreshAllGitHubStats() {
   }
 }
 
-export async function refreshAllNpmStats({ data }: { data: any }) {
+export async function refreshAllNpmStats({ data }: { data: { org: string } }) {
   console.log(`[Admin] refreshAllNpmStats handler called with org: ${data.org}`)
 
   await requireCapability({ data: { capability: 'admin' } })

--- a/src/utils/stats.server.ts
+++ b/src/utils/stats.server.ts
@@ -888,7 +888,11 @@ export async function fetchNpmDownloadsBulk({ data }: { data: unknown }) {
  * Chunk format: YYYY (e.g., "2023" means Jan 1 - Dec 31, 2023)
  * Special chunk "current" means current year to date
  */
-export async function fetchNpmDownloadChunk({ data }: { data: any }) {
+export async function fetchNpmDownloadChunk({
+  data,
+}: {
+  data: { packageName: string; year: string }
+}) {
   const { packageName, year } = data
 
   // NPM download statistics only go back to January 10, 2015

--- a/src/utils/users.server.ts
+++ b/src/utils/users.server.ts
@@ -9,6 +9,23 @@ import { type Capability, type SignupSource } from '~/db/types'
 
 type UserRecord = InferSelectModel<typeof users>
 
+// Follows the valibot schema in `users.functions.ts`, which validates every
+// call before delegating here — deliberately looser, since the schema's
+// bounds have no type-level equivalent and `useEffectiveCapabilities` stays
+// optional to keep the `?? true` below meaningful.
+type ListUsersInput = {
+  pagination: { limit: number; page?: number }
+  emailFilter?: string
+  nameFilter?: string
+  capabilityFilter?: Array<Capability>
+  noCapabilitiesFilter?: boolean
+  adsDisabledFilter?: boolean
+  interestedInHidingAdsFilter?: boolean
+  useEffectiveCapabilities?: boolean
+  sortBy?: string
+  sortDir?: 'asc' | 'desc'
+}
+
 // Helper function to validate user capability
 // Optimized: getEffectiveCapabilities is already called in getAuthenticatedUser,
 // so we can reuse the capabilities from there
@@ -28,7 +45,7 @@ async function requireCapability({
 }
 
 // Server function wrapper for listUsers
-export async function listUsers({ data }: { data: any }) {
+export async function listUsers({ data }: { data: ListUsersInput }) {
   if (!data || !data.pagination) {
     throw new Error('Missing required')
   }
@@ -287,7 +304,7 @@ export async function listUsers({ data }: { data: any }) {
 }
 
 // Get a single user by ID (admin only)
-export async function getUser({ data }: { data: any }) {
+export async function getUser({ data }: { data: { userId: string } }) {
   await requireCapability({ data: { capability: 'admin' } })
 
   const user = await db.query.users.findFirst({
@@ -318,7 +335,11 @@ export async function getUser({ data }: { data: any }) {
 }
 
 // Server function wrapper for updateAdPreference
-export async function updateAdPreference({ data }: { data: any }) {
+export async function updateAdPreference({
+  data,
+}: {
+  data: { adsDisabled: boolean }
+}) {
   const user = await getAuthenticatedUser()
 
   // Validate disableAds capability
@@ -333,7 +354,11 @@ export async function updateAdPreference({ data }: { data: any }) {
 }
 
 // Server function wrapper for setInterestedInHidingAds
-export async function setInterestedInHidingAds({ data }: { data: any }) {
+export async function setInterestedInHidingAds({
+  data,
+}: {
+  data: { interested: boolean }
+}) {
   const user = await getAuthenticatedUser()
 
   // Verify user exists
@@ -357,7 +382,11 @@ export async function setInterestedInHidingAds({ data }: { data: any }) {
 }
 
 // Server function to update user's last used framework preference
-export async function updateLastUsedFramework({ data }: { data: any }) {
+export async function updateLastUsedFramework({
+  data,
+}: {
+  data: { framework: string }
+}) {
   const user = await getAuthenticatedUser()
 
   await db
@@ -415,7 +444,11 @@ export async function addUserSignupSource({
 }
 
 // Server function wrapper for updateUserCapabilities (admin only)
-export async function updateUserCapabilities({ data }: { data: any }) {
+export async function updateUserCapabilities({
+  data,
+}: {
+  data: { userId: string; capabilities: Array<Capability> }
+}) {
   // Validate admin capability
   const { currentUser } = await requireCapability({
     data: { capability: 'admin' },
@@ -454,7 +487,11 @@ export async function updateUserCapabilities({ data }: { data: any }) {
 }
 
 // Server function wrapper for adminSetAdsDisabled (admin only)
-export async function adminSetAdsDisabled({ data }: { data: any }) {
+export async function adminSetAdsDisabled({
+  data,
+}: {
+  data: { userId: string; adsDisabled: boolean }
+}) {
   // Validate admin capability
   const { currentUser } = await requireCapability({
     data: { capability: 'admin' },
@@ -492,7 +529,11 @@ export async function adminSetAdsDisabled({ data }: { data: any }) {
 }
 
 // Server function wrapper for bulkUpdateUserCapabilities (admin only)
-export async function bulkUpdateUserCapabilities({ data }: { data: any }) {
+export async function bulkUpdateUserCapabilities({
+  data,
+}: {
+  data: { userIds: Array<string>; capabilities: Array<Capability> }
+}) {
   // Validate admin capability
   const { currentUser } = await requireCapability({
     data: { capability: 'admin' },


### PR DESCRIPTION
CLAUDE.md says type safety is paramount and to fix at the source rather than cast. Fourteen server functions took `{ data: any }`, which drops every guarantee at the boundary where it matters most — admin mutations reading `data.userId`, `data.capabilities`, and so on with no check that those fields exist or hold the right type.

| File | Count |
| --- | --- |
| `users.server.ts` | 8 |
| `intent-admin.server.ts` | 3 |
| `stats-admin.server.ts` | 2 |
| `stats.server.ts` | 1 |

## Where the types came from

Not guessed. Each `*.server.ts` function has a sibling in `*.functions.ts` that validates the call against a valibot schema before delegating, so the schema is already the contract — these annotations just state it:

```ts
// users.functions.ts
export const getUser = createServerFn({ method: 'POST' })
  .validator(v.object({ userId: v.pipe(v.string(), v.uuid()) }))
  .handler(async ({ data }) => getUserServer({ data }))
```

For each function I pulled the fields it actually reads out of the body (`rg -o "data\.\w+"`) and matched them against that schema. That caught `retryIntentVersion`, whose `versionId` is `v.number()` — annotating it `string` by eye would have compiled and been wrong.

`listUsers` reads ten fields, so it gets a named `ListUsersInput`. The rest are inline, matching `requireCapability` in the same file.

They are deliberately looser than the schemas in two places, both noted in a comment on `ListUsersInput`:

- The schemas' bounds (`maxLength`, `minValue`, `uuid`) have no type-level equivalent.
- `useEffectiveCapabilities` is `v.optional(v.boolean(), true)`, so post-validation it is always a `boolean` — but the annotation keeps it optional, because `listUsers` guards it with `?? true` and tightening the type would make that guard dead code.

Nothing is re-checked at runtime and no behaviour changes.

## Note

`fetchNpmDownloadChunk` (`stats.server.ts`) is exported but has zero call sites anywhere in `src/`, `scripts/`, or `tests/`. It is typed here rather than deleted so this PR stays one thing; removing it is worth doing separately.

## Testing

`tsc` clean and `oxlint --type-aware` reports 0 errors across 916 files. Types-only change — no runtime code was touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved input validation and consistency across administrative, statistics, and user-management operations.
  * Requests now require clearly defined values for identifiers, preferences, capabilities, packages, and reporting parameters.
  * Incomplete or incorrectly formatted requests can be detected earlier.
  * Existing authorization, database behavior, auditing, and responses remain unchanged.
  * No changes to user-facing functionality or workflows are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
