### PR TITLE
refactor(auth/repositories): drop redundant 'Capability[]' casts

### DIFF
--- a/src/auth/repositories.server.ts
+++ b/src/auth/repositories.server.ts
@@ -118,7 +118,7 @@ export class DrizzleUserRepository implements IUserRepository {
       image: user.image,
       oauthImage: user.oauthImage,
       displayUsername: user.displayUsername,
-      capabilities: user.capabilities as Capability[],
+      capabilities: user.capabilities,
       adsDisabled: user.adsDisabled,
       interestedInHidingAds: user.interestedInHidingAds,
       lastUsedFramework: user.lastUsedFramework,
@@ -241,16 +241,13 @@ export class DrizzleCapabilitiesRepository implements ICapabilitiesRepository {
     }
 
     // Extract user capabilities (same for all rows)
-    const directCapabilities = (result[0]?.userCapabilities ||
-      []) as Capability[]
+    const directCapabilities = result[0]?.userCapabilities ?? []
 
     // Collect all role capabilities from all rows
     const roleCapabilities = result
       .map((r) => r.roleCapabilities)
-      .filter(
-        (caps): caps is Capability[] => caps !== null && Array.isArray(caps),
-      )
-      .flat() as Capability[]
+      .filter((caps) => caps !== null)
+      .flat()
 
     // Union of direct capabilities and role capabilities
     const effectiveCapabilities = Array.from(
@@ -288,18 +285,15 @@ export class DrizzleCapabilitiesRepository implements ICapabilitiesRepository {
 
       // Store direct capabilities (same for all rows of the same user)
       if (!userCapabilitiesMap[userId]) {
-        userCapabilitiesMap[userId] = (row.userCapabilities ||
-          []) as Capability[]
+        userCapabilitiesMap[userId] = row.userCapabilities ?? []
       }
 
       // Collect role capabilities
-      if (row.roleCapabilities && Array.isArray(row.roleCapabilities)) {
+      if (row.roleCapabilities) {
         if (!userRoleCapabilitiesMap[userId]) {
           userRoleCapabilitiesMap[userId] = []
         }
-        userRoleCapabilitiesMap[userId].push(
-          ...(row.roleCapabilities as Capability[]),
-        )
+        userRoleCapabilitiesMap[userId].push(...row.roleCapabilities)
       }
     }
 


### PR DESCRIPTION
CLAUDE.md says never to cast types and to fix at the source instead. `repositories.server.ts` carried five `as Capability[]` casts reading capability columns.

**None of them were needed.** The schema already produces the right type:

```ts
export const capabilityEnum = pgEnum('capability', CAPABILITIES)
capabilities: capabilityEnum('capabilities').array().notNull().default([])
```

`CAPABILITIES` is an `as const` tuple used as the single source of truth, so Drizzle infers `Capability[]` on its own. Verified with a throwaway probe:

```ts
const probe = (c: InferSelectModel<typeof users>['capabilities']): Capability[] => c
// compiles with no cast
```

So this is a straight deletion — no schema change, no new types.

## Two things went with them

**A type guard that wasn't doing anything.** `roles.capabilities` is `.array().notNull()`, so a `leftJoin` can produce `null` but never a non-array. The `Array.isArray` half of the guard was unreachable:

```diff
-      .filter(
-        (caps): caps is Capability[] => caps !== null && Array.isArray(caps),
-      )
-      .flat() as Capability[]
+      .filter((caps) => caps !== null)
+      .flat()
```

TypeScript narrows out the `null` from the predicate alone.

**`||` → `??`.** An empty array is a valid value here (it is the column default), and `||` reads as though it isn't. Behaviour is identical — `[]` is truthy, so only `null` ever hit the fallback — but the intent is clearer.

## Consistency

Removing the guard in `getEffectiveCapabilities` left `getBulkEffectiveCapabilities` as the only place still calling `Array.isArray` on the same column from the same kind of join. Its `row.roleCapabilities &&` check already excludes `null`, so the `Array.isArray` was dropped there too rather than leaving the two functions treating identical data differently.

## Testing

`tsc` clean, `oxlint --type-aware` reports 0 errors across 916 files, and the unit suite passes (144/145, 1 pre-existing skip).

Worth flagging: **there is no test covering this file.** The reasoning above is type-level and from the schema definitions; nothing here was exercised at runtime. Since it is role-based capability resolution, a quick check that a user with an assigned role still shows the right capabilities in the admin UI would be worth doing before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved capability handling during authentication and authorization checks.
  - Ensured direct and role-based permissions are processed reliably, including cases where capability data is unavailable.
  - Preserved existing default behavior while reducing inconsistencies in permission evaluation.
  - Improved handling of missing or incomplete permission data to support more consistent access decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->