### PR TITLE
Load AI dock on first open

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -56,6 +56,7 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
 
   const openAiDock = React.useCallback(() => {
     cancelAiDockHoverClose()
+    setHasLoadedSearch(true)
     setIsOpen(false)
     setIsAiDockOpen(true)
   }, [cancelAiDockHoverClose])
@@ -68,6 +69,7 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
       }
 
       cancelAiDockHoverClose()
+      setHasLoadedSearch(true)
       setIsOpen(false)
       setIsAiDockDirty(true)
       setIsAiDockOpen(true)


### PR DESCRIPTION
## Summary

- Mount the lazy search/AI bundle when the AI dock is opened directly.
- Apply the same invariant to questions routed directly into the dock.

## Evidence

`SearchProvider` rendered `LazySearchModal` only after `hasLoadedSearch` became true. `openSearch` set that flag, but `openAiDock` and `askAiDock` did not, so a first direct Ask AI action could set the dock state without mounting the component that renders it. This matches the missing sidebar reported in #1116 and is independent of extension behavior.

## Impact

The desktop and mobile Ask AI actions now render the dock on first use while keeping the search/AI bundle lazy until the user invokes it.

## Validation

- `pnpm test` (144 pass, 1 intentional skip; TypeScript and lint clean)
- Commit hook reran formatting and `pnpm test` successfully
- `git diff --check`

## Risk

Low. The change only flips the existing lazy-mount flag in the two AI entry points; subsequent opens and normal Search behavior are unchanged.

Fixes #1116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI dock interactions by ensuring search is initialized before opening the dock or submitting a question.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->