### PR TITLE
Fix partial shop variant availability

### DIFF
--- a/src/components/shop/ProductDrawer.tsx
+++ b/src/components/shop/ProductDrawer.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { twMerge } from 'tailwind-merge'
 import { getProduct } from '~/utils/shop.functions'
-import type {
-  ProductDetail,
-  ProductDetailVariant,
+import {
+  hasAvailableVariant,
+  type ProductDetail,
+  type ProductDetailVariant,
 } from '~/utils/shopify-queries'
 import { formatMoney } from '~/utils/shopify-format'
 import { resolveShopProductColor, shopColorContrast } from '~/utils/shop-color'
@@ -474,15 +475,16 @@ function DrawerContent({
                         Select {option.name}
                       </option>
                       {option.values.map((value) => {
-                        const match = findMatchingVariant(
-                          variants,
-                          getCandidate(value),
-                        )
                         return (
                           <option
                             key={value}
                             value={value}
-                            disabled={!match?.availableForSale}
+                            disabled={
+                              !hasAvailableVariant(
+                                variants,
+                                getCandidate(value),
+                              )
+                            }
                           >
                             {value}
                           </option>
@@ -505,11 +507,10 @@ function DrawerContent({
                     <div className="flex flex-wrap gap-1.5">
                       {option.values.map((value) => {
                         const isSelected = selected[option.name] === value
-                        const match = findMatchingVariant(
+                        const isUnavailable = !hasAvailableVariant(
                           variants,
                           getCandidate(value),
                         )
-                        const isUnavailable = !match?.availableForSale
                         return (
                           <ShopSize
                             key={value}
@@ -545,11 +546,10 @@ function DrawerContent({
                   <div className="flex flex-wrap gap-1.5">
                     {option.values.map((value) => {
                       const isSelected = selected[option.name] === value
-                      const match = findMatchingVariant(
+                      const isUnavailable = !hasAvailableVariant(
                         variants,
                         getCandidate(value),
                       )
-                      const isUnavailable = !match?.availableForSale
                       const hex = resolveShopProductColor(value)
                       return (
                         <ShopChip

--- a/src/routes/shop.products.$handle.tsx
+++ b/src/routes/shop.products.$handle.tsx
@@ -19,6 +19,7 @@ import {
 import { useAddToCart } from '~/hooks/useCart'
 import { getProduct } from '~/utils/shop.functions'
 import {
+  hasAvailableVariant,
   type ProductDetail,
   type ProductDetailVariant,
 } from '~/utils/shopify-queries'
@@ -336,15 +337,13 @@ function VariantSelector({
                   Select {option.name}
                 </option>
                 {option.values.map((value) => {
-                  const match = findAvailableVariant(
-                    variants,
-                    getCandidate(value),
-                  )
                   return (
                     <option
                       key={value}
                       value={value}
-                      disabled={!match?.availableForSale}
+                      disabled={
+                        !hasAvailableVariant(variants, getCandidate(value))
+                      }
                     >
                       {value}
                     </option>
@@ -361,11 +360,10 @@ function VariantSelector({
               >
                 {option.values.map((value) => {
                   const isSelected = selected[option.name] === value
-                  const match = findAvailableVariant(
+                  const isUnavailable = !hasAvailableVariant(
                     variants,
                     getCandidate(value),
                   )
-                  const isUnavailable = !match?.availableForSale
                   const handleClick = () => handleChange(value)
                   if (isSizeOption) {
                     return (
@@ -516,18 +514,6 @@ function findMatchingVariant(
 ): ProductDetailVariant | undefined {
   return variants.find((v) =>
     v.selectedOptions.every((opt) => selected[opt.name] === opt.value),
-  )
-}
-
-function findAvailableVariant(
-  variants: Array<ProductDetailVariant>,
-  selected: Record<string, string>,
-): ProductDetailVariant | undefined {
-  return variants.find((variant) =>
-    variant.selectedOptions.every(
-      (option) =>
-        !selected[option.name] || selected[option.name] === option.value,
-    ),
   )
 }
 

--- a/src/utils/shopify-queries.ts
+++ b/src/utils/shopify-queries.ts
@@ -255,6 +255,22 @@ export type ProductDetailVariant = Pick<
   image: Pick<StorefrontImage, 'url' | 'altText' | 'width' | 'height'> | null
 }
 
+export function hasAvailableVariant(
+  variants: Array<
+    Pick<ProductDetailVariant, 'availableForSale' | 'selectedOptions'>
+  >,
+  selected: Record<string, string>,
+): boolean {
+  return variants.some(
+    (variant) =>
+      variant.availableForSale &&
+      variant.selectedOptions.every(
+        (option) =>
+          !selected[option.name] || selected[option.name] === option.value,
+      ),
+  )
+}
+
 export type ProductDetail = Pick<
   Product,
   'id' | 'handle' | 'title' | 'descriptionHtml'

--- a/tests/shopify-variant.test.ts
+++ b/tests/shopify-variant.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { hasAvailableVariant } from '../src/utils/shopify-queries'
+
+const variants = [
+  {
+    availableForSale: false,
+    selectedOptions: [
+      { name: 'Color', value: 'Black' },
+      { name: 'Size', value: 'Small' },
+    ],
+  },
+  {
+    availableForSale: true,
+    selectedOptions: [
+      { name: 'Color', value: 'Black' },
+      { name: 'Size', value: 'Large' },
+    ],
+  },
+  {
+    availableForSale: false,
+    selectedOptions: [
+      { name: 'Color', value: 'Blue' },
+      { name: 'Size', value: 'Large' },
+    ],
+  },
+]
+
+test('partial selections stay available when any matching variant is in stock', () => {
+  assert.equal(hasAvailableVariant(variants, { Color: 'Black' }), true)
+})
+
+test('complete selections only match the selected variant', () => {
+  assert.equal(
+    hasAvailableVariant(variants, { Color: 'Black', Size: 'Small' }),
+    false,
+  )
+  assert.equal(
+    hasAvailableVariant(variants, { Color: 'Black', Size: 'Large' }),
+    true,
+  )
+})
+
+test('partial selections are unavailable when all matches are sold out', () => {
+  assert.equal(hasAvailableVariant(variants, { Color: 'Blue' }), false)
+})


### PR DESCRIPTION
## Evidence

Commit `bf855523` made product options dependent, but its partial availability checks returned the first matching variant. If that variant was sold out, an option was marked unavailable even when a later matching variant was in stock. Large dropdowns could disable every first-step value for the same reason.

## Fix

- Treat an option as available when any matching variant is in stock.
- Use the same availability rule in the product drawer and full product page.
- Keep exact variant selection unchanged for pricing and add-to-cart.

## Impact

Customers can select valid colors and other leading options when one size is sold out but another remains available.

## Validation

- Added focused partial, exact, and all-sold-out variant tests.
- `pnpm test` passes: TypeScript, type-aware lint, and 153 unit tests (152 passed, 1 opt-in smoke test skipped).

## Risk

Low. The change only affects option availability display and disabling. Exact variant selection and cart submission are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product option availability checks across product drawers and product pages.
  * Options now remain selectable when a matching available variant exists, including partial selections.
  * Prevented unavailable options from appearing selectable when all matching variants are sold out.

* **Tests**
  * Added coverage for partial and complete variant selections, including unavailable matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->