### PR TITLE
fix(scripts): pin the catalog generation locale so assets are reproducible

### DIFF
--- a/scripts/generate-charts-landing-assets.ts
+++ b/scripts/generate-charts-landing-assets.ts
@@ -12,6 +12,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import './pin-catalog-locale'
 import { catalogCases } from '@tanstack/react-charts-catalog'
 import type { ComponentType } from 'react'
 import type { CatalogChartProps } from '@tanstack/react-charts-catalog'

--- a/scripts/generate-charts-landing-catalog.ts
+++ b/scripts/generate-charts-landing-catalog.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+import './pin-catalog-locale'
 import { catalogCases } from '@tanstack/react-charts-catalog'
 
 type CatalogCaseMetadata = {

--- a/scripts/pin-catalog-locale.ts
+++ b/scripts/pin-catalog-locale.ts
@@ -1,0 +1,54 @@
+// The catalog case components format axis labels with `toLocaleDateString(undefined, …)`
+// and `toLocaleString()`, which resolve against the machine's locale. Generating the
+// landing assets on a non-English machine therefore produces different SVG text — e.g.
+// `10월 6일` instead of `Oct 6` — which changes the content hash and makes
+// `--check` report the committed assets as stale.
+//
+// `@tanstack/react-charts-catalog` already pins `en-US` on every `Intl.NumberFormat` and
+// `Intl.DateTimeFormat` it constructs, so the bare prototype calls are an oversight rather
+// than a deliberate choice. Until that is fixed upstream, default them here so generation
+// is reproducible regardless of the machine's locale.
+//
+// Setting `process.env.LANG` does not work: Node resolves ICU's default locale at process
+// start, before any module code runs.
+//
+// Imported for side effects, and must be imported before the catalog case components so the
+// patch is in place when they render. Call sites that pass an explicit locale keep it.
+
+const GENERATION_LOCALE = 'en-US'
+
+const originalToLocaleDateString = Date.prototype.toLocaleDateString
+Date.prototype.toLocaleDateString = function toLocaleDateString(
+  locales?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  return originalToLocaleDateString.call(
+    this,
+    locales ?? GENERATION_LOCALE,
+    options,
+  )
+}
+
+const originalDateToLocaleString = Date.prototype.toLocaleString
+Date.prototype.toLocaleString = function toLocaleString(
+  locales?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  return originalDateToLocaleString.call(
+    this,
+    locales ?? GENERATION_LOCALE,
+    options,
+  )
+}
+
+const originalNumberToLocaleString = Number.prototype.toLocaleString
+Number.prototype.toLocaleString = function toLocaleString(
+  locales?: Intl.LocalesArgument,
+  options?: Intl.NumberFormatOptions,
+) {
+  return originalNumberToLocaleString.call(
+    this,
+    locales ?? GENERATION_LOCALE,
+    options,
+  )
+}


### PR DESCRIPTION
`pnpm test` fails for anyone whose machine is not set to an English locale. The `pretest` hook runs `charts:check-landing-catalog`, which regenerates the catalog assets in memory and compares them against what is committed — and the regenerated SVGs differ, so the check reports the committed assets as stale.

The difference is the x-axis date labels. Three cases render `Oct 6`, `Oct 8`, `Oct 10`, `Oct 12` on an English machine and `10월 6일`, `10월 8일`, … on a Korean one: `86-streaming-window-preservation`, `91-timeline-playback-scrubber`, `92-editable-event-range`. That text is part of the SVG, so it changes the content hash, which changes `chartsLandingCatalogAssetRevision`, which fails the check.

## Where it comes from

The formatting happens inside `@tanstack/react-charts-catalog` (0.7.2), not in this repo. Its catalog cases pin `en-US` in 96 places and leave 29 `toLocaleDateString` / `toLocaleString` calls without a locale, so those fall back to the machine's. The cases already fix their data and pass `timeZone: 'UTC'`, so the missing locale reads as an oversight rather than a decision.

**The real fix is TanStack/charts#68**, which pins those 29 call sites. This PR is the guard until that lands, is published, and the version is bumped here — three separate events, and the check stays broken locally in the meantime. Once the bump happens, drop the two `import './pin-catalog-locale'` lines and re-run the check under a non-English locale; if it passes, `scripts/pin-catalog-locale.ts` can be deleted.

## The change

`scripts/pin-catalog-locale.ts` defaults `Date.prototype.toLocaleDateString`, `Date.prototype.toLocaleString`, and `Number.prototype.toLocaleString` to `en-US`, and both generation scripts import it for side effects before the catalog components load. Calls that pass a locale explicitly keep it — the wrapper is `locales ?? 'en-US'`, so the 32 already-pinned call sites are untouched.

Setting `process.env.LANG` inside the script does not work: Node resolves ICU's default locale at process start, before any module code runs. Pinning in only one script is also not enough, since the pre-commit chain is `generate-charts-landing-catalog --check && generate-charts-landing-assets --check` and both load the case components.

## Verification

Under `LANG=ko_KR.UTF-8`, regenerating now produces **zero** changed files — previously three — and `chartsLandingCatalogAssetRevision` stays at `487bba6af954`. The generated assets are byte-identical to what is committed, so nothing about the rendered charts changes.

Both `--check` scripts pass under `ko_KR.UTF-8` and under `en_US.UTF-8`. This commit was made with the pre-commit hook enabled on a Korean-locale machine, which previously required `--no-verify`.

Explicit locales still work: with the patch loaded, `toLocaleDateString('ko-KR', …)` returns `10월 6일`, `('ja-JP', …)` returns `10月6日`, and `(1234.5).toLocaleString('de-DE')` returns `1.234,5`.

Scope is limited to asset generation. The scripts run as separate `tsx` processes and nothing in the app bundle imports this module, so runtime rendering — including `charts.catalog_.embed.$caseId.tsx`, which renders the same case components live — is unaffected and still follows the visitor's locale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent date and number formatting in generated chart catalogs.
  * Catalog output now uses consistent English (US) formatting regardless of the machine’s regional settings.
  * Explicitly selected locales continue to be respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
