### PR TITLE
feat: remove table beta and add removed version redirects

### DIFF
--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -312,7 +312,7 @@ export const table: LibrarySlim = {
   ],
   latestVersion: 'v9',
   latestBranch: 'main',
-  availableVersions: ['v9', 'v8', 'beta'],
+  availableVersions: ['v9', 'v8'],
   scarfId: 'dc8b39e1-3fe9-4f3a-8e56-d4e2cf420a9e',
   defaultDocs: 'overview',
   sitemap: {

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -28,7 +28,7 @@ export function beforeLoadLibraryLanding(
   href: string,
 ) {
   const library = validateLibraryVersion(libraryId, version, () => {
-    throw redirect({ href: `/${libraryId}/latest` })
+    throw redirect({ href: `/${libraryId}/latest`, statusCode: 308 })
   })
 
   library.handleRedirects?.(href)

--- a/src/routes/_library/$libraryId/$version.index.tsx
+++ b/src/routes/_library/$libraryId/$version.index.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/_library/$libraryId/$version/')({
     library.handleRedirects?.(location.href)
 
     validateLibraryVersion(library.id, params.version, () => {
-      throw redirect({ href: `/${library.id}/latest` })
+      throw redirect({ href: `/${library.id}/latest`, statusCode: 308 })
     })
 
     redirectToStaticLanding(library.id, params.version)

--- a/src/routes/_library/$libraryId/$version.tsx
+++ b/src/routes/_library/$libraryId/$version.tsx
@@ -14,8 +14,14 @@ export const Route = createFileRoute('/_library/$libraryId/$version')({
   beforeLoad: async (ctx) => {
     const { libraryId, version } = ctx.params
     const library = validateLibraryVersion(libraryId, version, () => {
+      // Permanent redirect so retired versions (e.g. /table/beta/...) keep SEO
+      // equity when rewritten to /latest with the rest of the path intact.
       throw redirect({
-        params: { libraryId, version: 'latest' } as never,
+        href: ctx.location.href.replace(
+          `/${libraryId}/${version}`,
+          `/${libraryId}/latest`,
+        ),
+        statusCode: 308,
       })
     })
 


### PR DESCRIPTION
- Remove beta from TanStack Table’s available versions
- Permanently redirect unknown versions (including /table/beta/...) to latest
- Keep deep docs paths and query strings intact via 308 redirects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the retired TanStack Table beta version from the list of supported versions.
  - Updated library redirects to use permanent redirects, improving navigation and preserving URL paths when directing visitors to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->