### PR TITLE
Fix RSS enclosure media types

### DIFF
--- a/src/routes/rss[.]xml.ts
+++ b/src/routes/rss[.]xml.ts
@@ -12,6 +12,18 @@ function escapeXml(unsafe: string): string {
     .replace(/'/g, '&apos;')
 }
 
+export function getRssImageMediaType(src: string) {
+  const extension = src.match(/\.([^.?#]+)(?:[?#]|$)/)?.[1]?.toLowerCase()
+
+  if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg'
+  if (extension === 'webp') return 'image/webp'
+  if (extension === 'svg') return 'image/svg+xml'
+  if (extension === 'gif') return 'image/gif'
+  if (extension === 'png') return 'image/png'
+
+  return 'application/octet-stream'
+}
+
 function generateRSSFeed() {
   const posts = getPublishedPosts().slice(0, 50) // Most recent 50 posts
   const siteUrl = 'https://tanstack.com'
@@ -42,7 +54,7 @@ function generateRSSFeed() {
       <pubDate>${pubDate}</pubDate>
       <author>${escapeXml(author)}</author>
       <description>${escapeXml(description)}</description>
-      ${post.headerImage ? `<enclosure url="${escapeXml(siteUrl + post.headerImage)}" type="image/png" />` : ''}
+      ${post.headerImage ? `<enclosure url="${escapeXml(siteUrl + post.headerImage)}" type="${getRssImageMediaType(post.headerImage)}" />` : ''}
     </item>`
     })
     .join('')

--- a/src/routes/rss[.]xml.ts
+++ b/src/routes/rss[.]xml.ts
@@ -13,7 +13,8 @@ function escapeXml(unsafe: string): string {
 }
 
 export function getRssImageMediaType(src: string) {
-  const extension = src.match(/\.([^.?#]+)(?:[?#]|$)/)?.[1]?.toLowerCase()
+  const path = src.split(/[?#]/, 1)[0]
+  const extension = path.match(/\.([^./]+)$/)?.[1]?.toLowerCase()
 
   if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg'
   if (extension === 'webp') return 'image/webp'

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -10,6 +10,14 @@ test('uses the image media type matching an RSS enclosure URL', () => {
   assert.equal(getRssImageMediaType('/header.svg?v=1'), 'image/svg+xml')
   assert.equal(getRssImageMediaType('/header.gif#image'), 'image/gif')
   assert.equal(
+    getRssImageMediaType('/header?source=original.png'),
+    'application/octet-stream',
+  )
+  assert.equal(
+    getRssImageMediaType('/header#preview.jpg'),
+    'application/octet-stream',
+  )
+  assert.equal(
     getRssImageMediaType('/header.unknown'),
     'application/octet-stream',
   )

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getRssImageMediaType } from '../src/routes/rss[.]xml'
+
+test('uses the image media type matching an RSS enclosure URL', () => {
+  assert.equal(getRssImageMediaType('/header.png'), 'image/png')
+  assert.equal(getRssImageMediaType('/header.jpg'), 'image/jpeg')
+  assert.equal(getRssImageMediaType('/header.jpeg'), 'image/jpeg')
+  assert.equal(getRssImageMediaType('/header.webp'), 'image/webp')
+  assert.equal(getRssImageMediaType('/header.svg?v=1'), 'image/svg+xml')
+  assert.equal(getRssImageMediaType('/header.gif#image'), 'image/gif')
+  assert.equal(
+    getRssImageMediaType('/header.unknown'),
+    'application/octet-stream',
+  )
+})


### PR DESCRIPTION
## Evidence

The RSS route hardcoded every blog image enclosure as `image/png`. Among the current 50 published posts, the feed includes 24 PNG, 13 JPG, 4 WebP, 2 JPEG, and 1 SVG header images. That left 20 enclosure media types inconsistent with their URLs.

## Change

Derive the enclosure media type from the image extension, including query strings and fragments, and use `application/octet-stream` for unknown extensions. Add focused regression coverage for the supported formats and fallback.

## Impact

RSS consumers now receive media metadata that matches each blog header asset. Enclosure URLs, post content, and site rendering are unchanged.

## Validation

- `pnpm test` — TypeScript and type-aware lint clean; 124 tests passed, 1 environment-gated smoke test skipped
- `git diff --check`
- Commit hook reran formatting and the full test gate successfully

## Risk

Low. The change only corrects RSS enclosure metadata; it does not alter asset URLs or response bodies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RSS feeds now report the correct media type for images based on their file extension.
  * Image URLs with query parameters or fragments are handled correctly.
  * Unknown image formats use a safe fallback media type, improving compatibility with RSS readers and other feed consumers.

* **Tests**
  * Added coverage for common image formats, including PNG, JPEG, WebP, SVG, and GIF, as well as unsupported extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->