### PR TITLE
Redesign blog index and extend the design system

### DIFF
--- a/src/components/ApplicationStarter.tsx
+++ b/src/components/ApplicationStarter.tsx
@@ -960,12 +960,42 @@ export function ApplicationStarter({
               <div
                 className={twMerge(
                   'relative overflow-hidden rounded-[1rem] border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950',
-                  // Home: 36px full-squircle corners and a tight terracotta glow.
+                  // Home: 36px full-squircle corners. `overflow-visible` lets the
+                  // focus glow (an absolute child at -z-10) bleed out from behind
+                  // the card; the inner wrapper below re-clips the card content.
                   isHomeStarter &&
-                    'rounded-[36px] [corner-shape:squircle] shadow-[0px_21px_39.2px_-38px_var(--color-ds-terracotta-300)] dark:border-transparent dark:bg-[#171717]',
+                    'overflow-visible rounded-[36px] [corner-shape:squircle] dark:border-transparent dark:bg-[#171717]',
                 )}
               >
-                <div>
+                {/* Home: a warm terracotta glow that grows in from behind the card
+                  while the prompt is focused, drifting in a slow wave. Sits at
+                  -z-10 so the opaque card hides all but the bottom bleed. */}
+                {isHomeStarter ? (
+                  <div
+                    aria-hidden
+                    className={twMerge(
+                      'pointer-events-none absolute inset-x-24 -bottom-2 -z-10 h-20 origin-bottom transition-[opacity,transform] duration-700 ease-out',
+                      isPromptFocused
+                        ? 'opacity-100 scale-100'
+                        : 'opacity-0 scale-75',
+                      reducedMotion && 'transition-none',
+                    )}
+                  >
+                    <div
+                      className={twMerge(
+                        'h-full w-full rounded-[100%] bg-ds-terracotta-300/50 blur-2xl',
+                        !reducedMotion && isPromptFocused && 'prompt-glow-flow',
+                      )}
+                    />
+                  </div>
+                ) : null}
+                <div
+                  className={
+                    isHomeStarter
+                      ? 'overflow-hidden rounded-[36px] [corner-shape:squircle]'
+                      : undefined
+                  }
+                >
                   {/* Home renders its heading above the box (see the fragment
                     above); other contexts keep the in-box header bar. */}
                   {isHomeStarter ? null : (

--- a/src/components/BlogAuthorFilter.tsx
+++ b/src/components/BlogAuthorFilter.tsx
@@ -42,13 +42,13 @@ export function BlogAuthorFilter({
               'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
               activeAuthor
                 ? 'bg-blue-50 dark:bg-blue-950/40 ring-1 ring-blue-500/50 text-blue-700 dark:text-blue-200'
-                : 'hover:bg-gray-500/10',
+                : 'hover:bg-surface-state-hover',
             )}
           >
             <span
               className={twMerge(
                 'flex items-center justify-center w-6 h-6 rounded border overflow-hidden shrink-0',
-                activeAuthor ? 'border-blue-500/30' : 'border-gray-500/20',
+                activeAuthor ? 'border-blue-500/30' : 'border-border-subtle',
               )}
             >
               <img

--- a/src/components/BlogBrowseNav.tsx
+++ b/src/components/BlogBrowseNav.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react'
+import { CaretDownIcon, RssIcon } from '@phosphor-icons/react'
+import { twMerge } from 'tailwind-merge'
+import { BlogAuthorFilter } from '~/components/BlogAuthorFilter'
+import { BlogSearchFilter } from '~/components/BlogSearchFilter'
+import { Eyebrow } from '~/components/ds/ui'
+import { categoryTextColor, libraryCategories } from '~/libraries/categories'
+import { fallbackLibraryIcon, libraryIcons } from '~/libraries/icons'
+import type { LibrarySlim } from '~/libraries'
+
+export type BlogTopic = { library: LibrarySlim; count: number }
+export type BlogYear = { year: string; count: number }
+
+type BlogBrowseNavProps = {
+  searchQuery: string
+  onSearchChange: (query: string) => void
+  topics: Array<BlogTopic>
+  totalCount: number
+  selectedLibrary: string | undefined
+  onLibraryToggle: (libraryId: string | undefined) => void
+  authors: Array<string>
+  selectedAuthor: string | undefined
+  onAuthorChange: (author: string | undefined) => void
+  years: Array<BlogYear>
+  selectedYear: string | undefined
+  onYearToggle: (year: string | undefined) => void
+  hasActiveFilters: boolean
+  onClearAll: () => void
+  /** Scopes the search input's `id` so the desktop and mobile copies of this
+   *  nav don't collide on duplicate ids. */
+  idPrefix: string
+}
+
+const rowClassName =
+  'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors'
+
+function rowStateClass(isActive: boolean) {
+  return isActive
+    ? 'bg-blue-500/10 font-semibold text-blue-700 dark:text-blue-300'
+    : 'text-text-secondary hover:bg-surface-state-hover'
+}
+
+// The count rides alongside the label in parens (ragged right edge) rather than
+// right-aligned in its own column.
+function Count({ value }: { value: number }) {
+  return <span className="text-text-muted"> ({value})</span>
+}
+
+// A collapsible section header (Eyebrow + chevron) for progressive disclosure.
+function DisclosureSummary({ label }: { label: string }) {
+  return (
+    <summary className="flex cursor-pointer list-none items-center justify-between [&::-webkit-details-marker]:hidden">
+      <Eyebrow tone="muted">{label}</Eyebrow>
+      <CaretDownIcon className="h-4 w-4 text-text-muted transition-transform group-open:rotate-180" />
+    </summary>
+  )
+}
+
+export function BlogBrowseNav({
+  searchQuery,
+  onSearchChange,
+  topics,
+  totalCount,
+  selectedLibrary,
+  onLibraryToggle,
+  authors,
+  selectedAuthor,
+  onAuthorChange,
+  years,
+  selectedYear,
+  onYearToggle,
+  hasActiveFilters,
+  onClearAll,
+  idPrefix,
+}: BlogBrowseNavProps) {
+  // Progressive disclosure: Topics and Archive start collapsed, but open on
+  // mount if that facet already has an active selection.
+  const [topicsOpen, setTopicsOpen] = React.useState(Boolean(selectedLibrary))
+  const [archiveOpen, setArchiveOpen] = React.useState(Boolean(selectedYear))
+
+  return (
+    <nav
+      aria-label="Browse the blog"
+      className="space-y-5 [&>*+*]:border-t [&>*+*]:border-border-subtle [&>*+*]:pt-5"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <BlogSearchFilter
+            id={`${idPrefix}-search`}
+            value={searchQuery}
+            onChange={onSearchChange}
+            className="flex-1"
+          />
+          <a
+            href="/rss.xml"
+            target="_blank"
+            rel="noreferrer"
+            title="RSS feed"
+            aria-label="RSS feed"
+            className="shrink-0 rounded-md border border-border-subtle p-2 text-text-muted transition-colors hover:bg-surface-state-hover hover:text-text-primary"
+          >
+            <RssIcon className="h-4 w-4" />
+          </a>
+        </div>
+        {hasActiveFilters ? (
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            Clear all filters
+          </button>
+        ) : null}
+      </div>
+
+      <details
+        className="group"
+        open={topicsOpen}
+        onToggle={(event) => setTopicsOpen(event.currentTarget.open)}
+      >
+        <DisclosureSummary label="Topics" />
+        <div className="mt-2 space-y-0.5">
+          <button
+            type="button"
+            aria-pressed={!selectedLibrary}
+            onClick={() => onLibraryToggle(undefined)}
+            className={twMerge(rowClassName, rowStateClass(!selectedLibrary))}
+          >
+            <span className="truncate">
+              All topics
+              <Count value={totalCount} />
+            </span>
+          </button>
+          {topics.map(({ library, count }) => {
+            const Icon = libraryIcons[library.id] ?? fallbackLibraryIcon
+            const category = libraryCategories[library.id] ?? 'tooling'
+            const isActive = selectedLibrary === library.id
+            return (
+              <button
+                key={library.id}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() =>
+                  onLibraryToggle(isActive ? undefined : library.id)
+                }
+                className={twMerge(rowClassName, rowStateClass(isActive))}
+              >
+                <Icon
+                  className={twMerge(
+                    'h-4 w-4 shrink-0',
+                    categoryTextColor[category],
+                  )}
+                />
+                <span className="truncate">
+                  {library.name.replace('TanStack ', '')}
+                  <Count value={count} />
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </details>
+
+      <div>
+        <Eyebrow tone="muted" className="mb-2">
+          Author
+        </Eyebrow>
+        <BlogAuthorFilter
+          authors={authors}
+          selected={selectedAuthor}
+          onSelect={onAuthorChange}
+        />
+      </div>
+
+      {years.length ? (
+        <details
+          className="group"
+          open={archiveOpen}
+          onToggle={(event) => setArchiveOpen(event.currentTarget.open)}
+        >
+          <DisclosureSummary label="Archive" />
+          <div className="mt-2 space-y-0.5">
+            {years.map(({ year, count }) => {
+              const isActive = selectedYear === year
+              return (
+                <button
+                  key={year}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => onYearToggle(isActive ? undefined : year)}
+                  className={twMerge(rowClassName, rowStateClass(isActive))}
+                >
+                  <span className="truncate">
+                    {year}
+                    <Count value={count} />
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </details>
+      ) : null}
+    </nav>
+  )
+}

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { ArrowSquareOutIcon } from '@phosphor-icons/react'
+import { twMerge } from 'tailwind-merge'
 import { Card } from '~/components/Card'
 import { CoverFallback } from '~/components/CoverFallback'
 import {
@@ -15,9 +16,16 @@ export type { BlogCardPost } from '~/utils/blog-format'
 type BlogCardProps = {
   post: BlogCardPost
   showLibraryBadges?: boolean
+  /** Hero treatment: side-by-side on wider screens with larger type. Used for
+   *  the single latest post at the top of the blog index. */
+  featured?: boolean
 }
 
-export function BlogCard({ post, showLibraryBadges = true }: BlogCardProps) {
+export function BlogCard({
+  post,
+  showLibraryBadges = true,
+  featured = false,
+}: BlogCardProps) {
   const {
     slug,
     title,
@@ -30,8 +38,15 @@ export function BlogCard({ post, showLibraryBadges = true }: BlogCardProps) {
     source,
   } = post
   const blogLibraries = showLibraryBadges ? getBlogLibraries(library) : []
-  const cardClassName =
-    'relative flex flex-col justify-between overflow-hidden transition-all hover:shadow-sm hover:border-blue-500'
+  const cardClassName = twMerge(
+    'relative flex flex-col justify-between overflow-hidden transition-all hover:shadow-sm hover:border-blue-500',
+    // Featured: image and copy sit side-by-side once there's room.
+    featured && 'md:flex-row md:justify-start',
+  )
+  const mediaClassName = twMerge(
+    'aspect-video w-full overflow-hidden bg-background-subtle',
+    featured && 'md:aspect-auto md:w-1/2',
+  )
 
   const content = (
     <>
@@ -48,16 +63,16 @@ export function BlogCard({ post, showLibraryBadges = true }: BlogCardProps) {
         </div>
       ) : null}
       {headerImage ? (
-        <div className="aspect-video overflow-hidden bg-gray-100 dark:bg-gray-800">
+        <div className={mediaClassName}>
           <img
             src={getOptimizedImageUrl(headerImage, {
               fit: 'cover',
               format: 'auto',
               quality: 80,
-              width: 800,
+              width: featured ? 1200 : 800,
             })}
             alt=""
-            loading="lazy"
+            loading={featured ? 'eager' : 'lazy'}
             decoding="async"
             className="w-full h-full object-cover"
           />
@@ -66,12 +81,24 @@ export function BlogCard({ post, showLibraryBadges = true }: BlogCardProps) {
         <CoverFallback
           slug={slug}
           library={library}
-          className="aspect-video w-full"
+          className={mediaClassName}
         />
       )}
-      <div className="p-4 md:p-8 flex flex-col gap-4 flex-1 justify-between">
+      <div
+        className={twMerge(
+          'p-4 md:p-8 flex flex-col gap-4 flex-1 justify-between',
+          featured && 'md:w-1/2 md:justify-center md:p-10',
+        )}
+      >
         <div>
-          <div className="text-lg font-extrabold">{title}</div>
+          <h2
+            className={twMerge(
+              'text-lg font-extrabold',
+              featured && 'text-2xl md:text-3xl leading-tight',
+            )}
+          >
+            {title}
+          </h2>
           <div className="text-xs italic font-light mt-1">
             by {formatAuthors(authors)}
             {published ? (
@@ -82,7 +109,12 @@ export function BlogCard({ post, showLibraryBadges = true }: BlogCardProps) {
             ) : null}
           </div>
           {excerpt ? (
-            <p className="text-sm mt-4 text-gray-600 dark:text-gray-400 leading-7 line-clamp-4">
+            <p
+              className={twMerge(
+                'text-sm mt-4 text-text-secondary leading-7 line-clamp-2',
+                featured && 'md:text-base line-clamp-3',
+              )}
+            >
               {excerpt}
             </p>
           ) : null}

--- a/src/components/BlogSearchFilter.tsx
+++ b/src/components/BlogSearchFilter.tsx
@@ -17,7 +17,7 @@ export function BlogSearchFilter({
   return (
     <div className={twMerge('relative w-full', className)}>
       <MagnifyingGlassIcon
-        className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+        className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
         aria-hidden="true"
       />
       <input
@@ -27,8 +27,8 @@ export function BlogSearchFilter({
         onChange={(event) => onChange(event.currentTarget.value)}
         placeholder="Search posts..."
         className={twMerge(
-          'w-full rounded-md border border-gray-500/20 bg-transparent py-1.5 pl-8 pr-2 text-sm transition-colors',
-          'placeholder:text-gray-500 dark:placeholder:text-gray-400',
+          'w-full rounded-md border border-border-subtle bg-transparent py-1.5 pl-8 pr-2 text-sm transition-colors',
+          'placeholder:text-text-muted',
           'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
         )}
       />

--- a/src/components/MegaMenuItem.tsx
+++ b/src/components/MegaMenuItem.tsx
@@ -54,11 +54,11 @@ export function MegaMenuItem({
   const rootClassName = twMerge(
     // Figma "Mege menu list item" (node 407:659): gap 10px, pl 12 / pr 16 /
     // py 12, radius 12px (14px on hover). Icon box + text vertically centered.
-    'group/mmi flex items-center gap-2.5 rounded-xl py-3 pl-3 pr-4 text-left transition-[background-color,border-radius]',
-    // States differ only by row background: hover white/4% + radius 14px,
-    // pressed white/12% (mode-adaptive via text-primary so it also works on
-    // light menu panels).
-    'hover:rounded-[14px] hover:bg-text-primary/[0.04] focus:bg-text-primary/[0.04] focus:outline-none active:bg-text-primary/[0.12]',
+    'group/mmi flex items-center gap-2.5 rounded-xl py-3 pl-3 pr-4 text-left transition-[background-color,border-radius,box-shadow]',
+    // Light mode: an "elevated white" hover — a bright-white row lifted off the
+    // glass with a soft shadow + hairline ring. Dark mode keeps the subtle
+    // white/4% (pressed 12%) overlay, no shadow/ring. Radius grows to 14px.
+    'hover:rounded-[14px] hover:bg-white hover:shadow-sm hover:ring-1 hover:ring-black/5 focus:bg-white focus:shadow-sm focus:ring-1 focus:ring-black/5 focus:outline-none active:bg-white dark:hover:bg-text-primary/[0.04] dark:hover:shadow-none dark:hover:ring-0 dark:focus:bg-text-primary/[0.04] dark:focus:shadow-none dark:focus:ring-0 dark:active:bg-text-primary/[0.12]',
     compact && 'border border-border-subtle bg-background-surface',
     variant === 'desktop' && !compact && 'w-full',
     variant === 'mobile' && 'py-2.5',
@@ -100,10 +100,10 @@ export function MegaMenuItem({
         {description ? (
           // Plain string (not twMerge) — the DS text-size and text-color
           // utilities both start with `text-`, and twMerge would drop the color.
-          // Desktop rows share a bounded column width, but descriptions may
-          // wrap so longer copy never overflows the panel.
+          // Desktop descriptions stay on a single line (`whitespace-nowrap`); the
+          // mega-menu panel is `w-max`, so it widens to fit the longest row.
           <span
-            className={`block text-text-secondary ${variant === 'desktop' ? 'text-ds-body-xs leading-relaxed' : 'text-ds-body-sm'}`}
+            className={`block text-text-secondary ${variant === 'desktop' ? 'whitespace-nowrap text-ds-body-xs leading-relaxed' : 'text-ds-body-sm'}`}
           >
             {description}
           </span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1163,7 +1163,7 @@ function LibraryCategoryColumn({
       >
         {column.label}
       </div>
-      <div className="flex flex-col items-stretch gap-1">
+      <div className="flex flex-col items-start gap-1">
         {column.libraries.map((library) => (
           <LibraryMenuRow
             key={library.id}
@@ -1189,12 +1189,12 @@ function LibraryMenuRow({
   const Icon = library.icon
   const external = library.to.startsWith('http')
   const className = twMerge(
-    // Subtle hover/pressed overlay matching the other mega menus (hover white/4%,
-    // pressed white/12%, mode-adaptive via text-primary). Replaces the dead
-    // `surface-state-hover` token, which was never defined.
-    'group/lib flex items-center gap-2 rounded-[14px] py-2 pl-[9px] pr-3 text-text-secondary transition-colors hover:bg-text-primary/[0.04] hover:text-text-primary focus:bg-text-primary/[0.04] focus:text-text-primary focus:outline-none active:bg-text-primary/[0.12]',
+    // Light mode: an "elevated white" hover — a bright-white pill lifted off the
+    // glass with a soft shadow + hairline ring (contrast via depth, not value).
+    // Dark mode keeps the subtle white/4% (pressed 12%) overlay, no shadow/ring.
+    'group/lib flex items-center gap-2 rounded-[14px] py-2 pl-[9px] pr-4 text-text-secondary transition-[color,background-color,box-shadow] hover:bg-white hover:text-text-primary hover:shadow-sm hover:ring-1 hover:ring-black/5 focus:bg-white focus:text-text-primary focus:shadow-sm focus:ring-1 focus:ring-black/5 focus:outline-none active:bg-white dark:hover:bg-text-primary/[0.04] dark:hover:shadow-none dark:hover:ring-0 dark:focus:bg-text-primary/[0.04] dark:focus:shadow-none dark:focus:ring-0 dark:active:bg-text-primary/[0.12]',
     variant === 'desktop'
-      ? 'h-[38px] min-[1120px]:h-[46px] min-[1120px]:gap-2.5 min-[1120px]:rounded-[17px] min-[1120px]:pl-[11px] min-[1120px]:pr-[14px]'
+      ? 'h-[38px] min-[1120px]:h-[46px] min-[1120px]:gap-2.5 min-[1120px]:rounded-[17px] min-[1120px]:pl-[11px] min-[1120px]:pr-[18px]'
       : 'py-2.5',
   )
   const content = (

--- a/src/components/ds/DsKit.tsx
+++ b/src/components/ds/DsKit.tsx
@@ -55,7 +55,7 @@ export function DsPage({
   children: React.ReactNode
 }) {
   return (
-    <div className="mx-auto max-w-7xl px-6 py-10 lg:px-10">
+    <div className="mx-auto max-w-7xl px-6 pt-10 pb-28 lg:px-10">
       <header className="mb-10">
         <h1 className="font-ds-display text-ds-display-sm text-text-primary">
           {title}

--- a/src/components/ds/ui/BlogPostCard.tsx
+++ b/src/components/ds/ui/BlogPostCard.tsx
@@ -1,54 +1,128 @@
 import { Link } from '@tanstack/react-router'
 import { twMerge } from 'tailwind-merge'
 import { CoverFallback } from '~/components/CoverFallback'
-import { formatAuthors, formatPublishedDate } from '~/utils/blog-format'
+import {
+  formatAuthors,
+  formatPublishedDate,
+  getBlogLibraries,
+} from '~/utils/blog-format'
 import type { RecentPost } from '~/utils/blog.functions'
 import { getOptimizedImageUrl } from '~/utils/optimizedImage'
+
+// The card renders library tags when the post carries a `library`; `RecentPost`
+// (nav / homepage) omits it, so those usages stay tag-free.
+type BlogPostCardPost = RecentPost & { library?: string }
 
 export function BlogPostCard({
   className,
   onNavigate,
   post,
+  size = 'sm',
+  featured = false,
 }: {
   className?: string
   onNavigate?: () => void
-  post: RecentPost
+  post: BlogPostCardPost
+  /** `lg` is the roomier grid treatment on the Blog index; `sm` (default) is the
+   *  compact card used in the nav mega-menu and homepage. */
+  size?: 'sm' | 'lg'
+  /** Hero treatment: image and copy sit side-by-side on wider screens with the
+   *  largest type. Used for the single latest post atop the Blog index. */
+  featured?: boolean
 }) {
+  const isLarge = featured || size === 'lg'
+  const blogLibraries = getBlogLibraries(post.library)
+
   const cardClassName = twMerge(
-    'group/post flex flex-col gap-3 rounded-xl corner-squircle p-3 transition-colors hover:bg-surface-state-hover focus-visible:bg-surface-state-hover focus-visible:outline-none',
+    'group/post flex flex-col rounded-xl corner-squircle transition-colors hover:bg-surface-state-hover focus-visible:bg-surface-state-hover focus-visible:outline-none',
+    featured
+      ? 'gap-4 p-4 md:flex-row md:gap-6'
+      : isLarge
+        ? 'gap-4 p-4'
+        : 'gap-3 p-3',
     className,
   )
+
   const content = (
     <>
-      {post.headerImage ? (
-        <div className="aspect-video w-full overflow-hidden rounded-lg corner-squircle border border-border-subtle">
+      <div
+        className={twMerge(
+          'relative aspect-video w-full overflow-hidden rounded-lg corner-squircle border border-border-subtle bg-background-subtle',
+          featured && 'md:aspect-auto md:w-1/2',
+        )}
+      >
+        {post.headerImage ? (
           <img
             src={getOptimizedImageUrl(post.headerImage, {
               fit: 'cover',
               format: 'auto',
               quality: 80,
-              width: 640,
+              width: featured ? 1200 : isLarge ? 900 : 640,
             })}
             alt=""
-            loading="lazy"
+            loading={featured ? 'eager' : 'lazy'}
             decoding="async"
             className="h-full w-full object-cover"
           />
-        </div>
-      ) : (
-        <CoverFallback
-          slug={post.slug}
-          className="aspect-video w-full rounded-lg corner-squircle"
-        />
-      )}
-      <div className="flex flex-col gap-1 px-1 pb-1">
-        <div className="line-clamp-1 font-ds-display text-ds-heading-5 text-text-primary">
+        ) : (
+          <CoverFallback
+            slug={post.slug}
+            library={post.library}
+            className="h-full w-full"
+          />
+        )}
+        {blogLibraries.length ? (
+          <div className="pointer-events-none absolute right-2 top-2 flex flex-wrap justify-end gap-1">
+            {blogLibraries.map((library) => (
+              <span
+                key={library.id}
+                className={twMerge(
+                  'rounded-md px-1.5 py-0.5 font-ds-mono text-ds-mono-caps-xs uppercase',
+                  library.bgStyle,
+                  library.badgeTextStyle ?? 'text-white',
+                )}
+              >
+                {library.name.replace('TanStack ', '')}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div
+        className={twMerge(
+          'flex flex-col px-1 pb-1',
+          isLarge ? 'gap-1.5' : 'gap-1',
+          featured && 'md:w-1/2 md:justify-center md:px-2',
+        )}
+      >
+        {/* Plain strings (not twMerge): the DS `text-ds-*` size utilities and the
+            `text-*` color utilities both start with `text-`, and twMerge would
+            drop the color. */}
+        <div
+          className={`font-ds-display text-text-primary ${
+            featured
+              ? 'line-clamp-3 text-ds-heading-2'
+              : isLarge
+                ? 'line-clamp-2 text-ds-heading-3'
+                : 'line-clamp-1 text-ds-heading-5'
+          }`}
+        >
           {post.title}
         </div>
-        <p className="line-clamp-2 text-ds-body-xs text-text-secondary">
+        <p
+          className={`text-text-secondary ${
+            featured
+              ? 'line-clamp-3 text-ds-body-md'
+              : isLarge
+                ? 'line-clamp-3 text-ds-body-sm'
+                : 'line-clamp-2 text-ds-body-xs'
+          }`}
+        >
           {post.excerpt}
         </p>
-        <div className="mt-0.5 font-ds-mono text-ds-mono-xs text-text-muted">
+        <div
+          className={`mt-0.5 font-ds-mono text-text-muted/70 ${isLarge ? 'text-ds-mono-sm' : 'text-ds-mono-xs'}`}
+        >
           {formatAuthors(post.authors)} · {formatPublishedDate(post.published)}
         </div>
       </div>

--- a/src/components/ds/ui/PageHeader.tsx
+++ b/src/components/ds/ui/PageHeader.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Editorial page masthead — a large display title with an optional leading mark,
+ * a lede, and an optional trailing action. Emphasized words (wrapped in `<em>`)
+ * pick up the warm accent with a soft underline.
+ *
+ * Generalized from the Merch store hero (see `ShopHero`) so any surface — blog,
+ * shop, marketing — can share one header treatment. Colors resolve through DS
+ * semantic tokens, so it adapts to the current light/dark theme automatically.
+ */
+export function PageHeader({
+  title,
+  lede,
+  icon,
+  actions,
+  align = 'left',
+  withDivider = false,
+  className,
+}: {
+  title: React.ReactNode
+  lede?: React.ReactNode
+  /** Leading mark, paired with the title. Defaults to the TanStack brand emblem
+   *  — the standard for global (non-library) pages. Pass a custom node to
+   *  override it, or `null` to omit the mark entirely. */
+  icon?: React.ReactNode
+  /** Trailing control (e.g. an RSS link), pinned to the top-right corner. */
+  actions?: React.ReactNode
+  align?: 'left' | 'center'
+  /** Draw a hairline divider beneath the header. */
+  withDivider?: boolean
+  className?: string
+}) {
+  const centered = align === 'center'
+  // The brand mark is the default so global pages pair the emblem with the page
+  // name out of the box; an explicit `icon` (including `null`) opts out.
+  const usingBrandMark = icon === undefined
+  const mark = usingBrandMark ? (
+    <span className="ds-brand-mark" aria-hidden />
+  ) : (
+    icon
+  )
+
+  return (
+    <header
+      className={twMerge(
+        'relative flex flex-col',
+        centered && 'items-center text-center',
+        withDivider && 'border-b border-border-subtle pb-6',
+        className,
+      )}
+    >
+      <h1 className="m-0 font-ds-display font-bold leading-[1.02] tracking-[-0.03em] text-text-primary text-[clamp(var(--text-ds-heading-1),5vw,var(--text-ds-display-md))] [&_em]:relative [&_em]:not-italic [&_em]:text-accent-warm [&_em]:after:absolute [&_em]:after:inset-x-0 [&_em]:after:-bottom-0.5 [&_em]:after:h-[3px] [&_em]:after:rounded-sm [&_em]:after:bg-accent-warm [&_em]:after:opacity-35">
+        <span className="inline-flex items-center gap-[0.3em]">
+          {usingBrandMark ? <span className="sr-only">TanStack </span> : null}
+          {mark}
+          <span>{title}</span>
+        </span>
+      </h1>
+      {lede ? (
+        <p
+          className={twMerge(
+            'mt-3.5 max-w-[58ch] text-ds-body-sm leading-[1.55] text-text-secondary opacity-75',
+            centered && 'mx-auto',
+          )}
+        >
+          {lede}
+        </p>
+      ) : null}
+      {actions ? <div className="absolute right-0 top-0">{actions}</div> : null}
+    </header>
+  )
+}

--- a/src/components/ds/ui/StatsSection.tsx
+++ b/src/components/ds/ui/StatsSection.tsx
@@ -197,16 +197,32 @@ function LibraryStat({ iconTop, stat }: { iconTop: boolean; stat: StatItem }) {
 
 /* --------------------------------------------------------------- hero stats -- */
 
-function HeroStat({ iconTop, stat }: { iconTop: boolean; stat: StatItem }) {
+function HeroStat({
+  iconTop,
+  stat,
+  onImage,
+}: {
+  iconTop: boolean
+  stat: StatItem
+  onImage?: boolean
+}) {
   return (
     <span
       className={twMerge(
-        'inline-flex min-w-0 gap-4 text-text-primary md:gap-3.5 xl:gap-4',
+        'inline-flex min-w-0 gap-4 md:gap-3.5 xl:gap-4',
+        // Over a (light) image the theme-adaptive text is illegible, so force
+        // dark ink; otherwise follow the surface via the semantic token.
+        onImage ? 'text-gray-900' : 'text-text-primary',
         iconTop ? 'flex-col items-start' : 'items-center',
       )}
     >
       {stat.icon ? (
-        <span className="shrink-0 text-icon-muted [&>svg]:size-6 md:[&>svg]:size-5 xl:[&>svg]:size-6">
+        <span
+          className={twMerge(
+            'shrink-0 [&>svg]:size-6 md:[&>svg]:size-5 xl:[&>svg]:size-6',
+            onImage ? 'text-gray-700' : 'text-icon-muted',
+          )}
+        >
           {stat.icon}
         </span>
       ) : null}
@@ -219,7 +235,12 @@ function HeroStat({ iconTop, stat }: { iconTop: boolean; stat: StatItem }) {
             {stat.value}
           </StatValue>
         </span>
-        <span className="font-ds-mono text-ds-mono-caps-xs font-medium uppercase tracking-[1.75px] text-text-secondary md:text-[9.5px] md:tracking-[1.5px] xl:text-ds-mono-caps-xs xl:tracking-[1.75px]">
+        <span
+          className={twMerge(
+            'font-ds-mono text-ds-mono-caps-xs font-medium uppercase tracking-[1.75px] md:text-[9.5px] md:tracking-[1.5px] xl:text-ds-mono-caps-xs xl:tracking-[1.75px]',
+            onImage ? 'text-gray-700' : 'text-text-secondary',
+          )}
+        >
           {stat.label}
         </span>
       </span>
@@ -234,11 +255,15 @@ export function StatsSection({
   layout = 'landscape',
   stats,
   className,
+  onImage = false,
 }: {
   page?: StatsPage
   layout?: StatsLayout
   stats: Array<StatItem>
   className?: string
+  /** Forces dark ink for legibility when the stats are overlaid on a light
+   *  image (the `hero` inline variant). Defaults to theme-adaptive colors. */
+  onImage?: boolean
 }) {
   if (page === 'unified') {
     const stacked = layout === 'stacked'
@@ -274,7 +299,12 @@ export function StatsSection({
         )}
       >
         {stats.map((stat) => (
-          <HeroStat key={stat.key} iconTop={iconTop} stat={stat} />
+          <HeroStat
+            key={stat.key}
+            iconTop={iconTop}
+            stat={stat}
+            onImage={onImage}
+          />
         ))}
       </div>
     )

--- a/src/components/ds/ui/index.tsx
+++ b/src/components/ds/ui/index.tsx
@@ -189,17 +189,12 @@ const roundedStyles: Record<ButtonRounded, string> = {
 }
 
 const baseStyles =
-  'inline-flex items-center justify-center gap-2 cursor-pointer transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:hover:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-1 focus-visible:ring-offset-background-default'
+  'inline-flex items-center justify-center gap-2 corner-squircle cursor-pointer transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:hover:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-1 focus-visible:ring-offset-background-default'
 
 function getDefaultSize(variant: ButtonVariant): ButtonSize {
   if (variant === 'icon') return 'icon-md'
   if (variant === 'gradient') return 'lg'
   return 'md'
-}
-
-function getDefaultRounded(size: ButtonSize): ButtonRounded {
-  if (size === 'xs' || size === 'sm') return 'md'
-  return 'lg'
 }
 
 export const Button: ButtonComponent = React.forwardRef<
@@ -218,8 +213,10 @@ export const Button: ButtonComponent = React.forwardRef<
   } = props as ButtonOwnProps & Record<string, unknown>
   const Component = as || 'button'
   const resolvedSize = size ?? getDefaultSize(variant)
-  const resolvedRounded =
-    rounded ?? (variant === 'gradient' ? 'xl' : getDefaultRounded(resolvedSize))
+  // All variants default to fully-rounded pills; the base `corner-squircle`
+  // gives the rounding an organic superellipse shape. Callers can still opt out
+  // via the `rounded` prop.
+  const resolvedRounded = rounded ?? 'full'
   const colorStyles =
     variant === 'primary'
       ? primaryColorStyles[color]
@@ -300,12 +297,13 @@ export function Badge({
 
 /* ---------------------------------------------------------------- Eyebrow -- */
 
-type EyebrowTone = 'muted' | 'secondary' | 'accent'
+type EyebrowTone = 'muted' | 'secondary' | 'accent' | 'warning'
 
 const eyebrowToneStyles: Record<EyebrowTone, string> = {
   muted: 'text-text-muted',
   secondary: 'text-text-secondary',
   accent: 'text-text-accent',
+  warning: 'text-text-warning',
 }
 
 // Libraries that ship a `--color-lib-*` brand token. Written as literal classes

--- a/src/components/landing/LibraryLanding.tsx
+++ b/src/components/landing/LibraryLanding.tsx
@@ -623,7 +623,7 @@ function FeatureSection({
           {distinction}
         </LandingEyebrow>
 
-        <div className="mt-12 grid items-stretch gap-10 lg:grid-cols-[15.5rem_minmax(0,1fr)] lg:gap-14">
+        <div className="mt-12 grid items-stretch gap-10 lg:grid-cols-[minmax(15.5rem,max-content)_minmax(0,1fr)] lg:gap-14">
           <div
             role="tablist"
             aria-label="Product capabilities"
@@ -644,7 +644,7 @@ function FeatureSection({
                   aria-controls={tabPanelId}
                   aria-selected={index === activeIndex}
                   tabIndex={index === activeIndex ? 0 : -1}
-                  className="inline-flex shrink-0 items-center gap-3 border-b border-border-default pb-4 text-left font-ds-display text-ds-heading-5 text-text-muted transition-colors hover:text-text-primary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent-bright)] aria-selected:border-[var(--landing-accent-bright)] aria-selected:text-[var(--landing-accent-bright)] lg:text-ds-heading-3"
+                  className="inline-flex shrink-0 items-center gap-3 whitespace-nowrap border-b border-border-default pb-4 text-left font-ds-display text-ds-heading-5 text-text-muted transition-colors hover:text-text-primary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent-bright)] aria-selected:border-[var(--landing-accent-bright)] aria-selected:text-[var(--landing-accent-bright)] lg:text-ds-heading-3"
                   onClick={() => setActiveIndex(index)}
                   onKeyDown={(event) => {
                     let nextIndex: number | undefined

--- a/src/routes/blog.index.tsx
+++ b/src/routes/blog.index.tsx
@@ -1,12 +1,12 @@
-import { RssIcon } from '@phosphor-icons/react'
-import { Link, createFileRoute } from '@tanstack/react-router'
+import * as React from 'react'
+import { CaretDownIcon } from '@phosphor-icons/react'
+import { createFileRoute } from '@tanstack/react-router'
 import * as v from 'valibot'
-import { BlogAuthorFilter } from '~/components/BlogAuthorFilter'
-import { BlogCard, type BlogCardPost } from '~/components/BlogCard'
-import { BlogSearchFilter } from '~/components/BlogSearchFilter'
-import { Card } from '~/components/Card'
-import { LibrariesWidget } from '~/components/LibrariesWidget'
-import { RecentPostsWidget } from '~/components/RecentPostsWidget'
+import { BlogBrowseNav } from '~/components/BlogBrowseNav'
+import { type BlogCardPost } from '~/components/BlogCard'
+import { Eyebrow } from '~/components/ds/ui'
+import { BlogPostCard } from '~/components/ds/ui/BlogPostCard'
+import { PageHeader } from '~/components/ds/ui/PageHeader'
 import { PartnersRail, RightRail } from '~/components/RightRail'
 import { libraries, type LibrarySlim } from '~/libraries'
 import {
@@ -21,7 +21,34 @@ import { PostNotFound } from './blog'
 const searchSchema = v.object({
   author: v.fallback(v.optional(v.string()), undefined),
   q: v.fallback(v.optional(v.string()), undefined),
+  library: v.fallback(v.optional(v.string()), undefined),
+  year: v.fallback(v.optional(v.string()), undefined),
 })
+
+// How many grid cards to show before "Load more"; each click reveals another batch.
+const POSTS_PER_PAGE = 12
+
+function postMatchesLibrary(post: BlogCardPost, libraryId: string): boolean {
+  return post.library?.split(',').some((id) => id.trim() === libraryId) ?? false
+}
+
+// Split an already-sorted (newest-first) list into consecutive year buckets so
+// the grid can drop in "2026 / 2025 / …" separators for temporal wayfinding.
+function groupPostsByYear(
+  posts: BlogCardPost[],
+): Array<{ year: string; posts: BlogCardPost[] }> {
+  const groups: Array<{ year: string; posts: BlogCardPost[] }> = []
+  for (const post of posts) {
+    const year = post.published?.slice(0, 4) || 'Undated'
+    const lastGroup = groups[groups.length - 1]
+    if (lastGroup?.year === year) {
+      lastGroup.posts.push(post)
+    } else {
+      groups.push({ year, posts: [post] })
+    }
+  }
+  return groups
+}
 
 export const Route = createFileRoute('/blog/')({
   staleTime: Infinity,
@@ -51,7 +78,12 @@ function getLibrariesWithPosts(posts: BlogCardPost[]): LibrarySlim[] {
 
 function BlogIndex() {
   const frontMatters = Route.useLoaderData()
-  const { author, q } = Route.useSearch()
+  const {
+    author,
+    q,
+    library: selectedLibrary,
+    year: selectedYear,
+  } = Route.useSearch()
   const navigate = Route.useNavigate()
   const activePartners = partners.filter(
     (partner) => partner.status === 'active',
@@ -62,132 +94,188 @@ function BlogIndex() {
   const authors = getDistinctAuthors(frontMatters)
   const librariesWithPosts = getLibrariesWithPosts(frontMatters)
 
+  // Counts give the browse nav its "scent" — computed once from every post.
+  const libraryCounts = new Map<string, number>()
+  const yearCounts = new Map<string, number>()
+  for (const post of frontMatters) {
+    if (post.library) {
+      for (const id of post.library.split(',')) {
+        const trimmed = id.trim()
+        libraryCounts.set(trimmed, (libraryCounts.get(trimmed) ?? 0) + 1)
+      }
+    }
+    const year = post.published?.slice(0, 4)
+    if (year) yearCounts.set(year, (yearCounts.get(year) ?? 0) + 1)
+  }
+  const topics = librariesWithPosts.map((library) => ({
+    library,
+    count: libraryCounts.get(library.id) ?? 0,
+  }))
+  const years = [...yearCounts.entries()]
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([year, count]) => ({ year, count }))
+
   const authorFilteredPosts = selectedAuthor
     ? frontMatters.filter((post) => post.authors.includes(selectedAuthor))
     : frontMatters
-  const filteredPosts = searchBlogCardPosts(authorFilteredPosts, searchQuery)
+  const libraryFilteredPosts = selectedLibrary
+    ? authorFilteredPosts.filter((post) =>
+        postMatchesLibrary(post, selectedLibrary),
+      )
+    : authorFilteredPosts
+  const yearFilteredPosts = selectedYear
+    ? libraryFilteredPosts.filter(
+        (post) => post.published?.slice(0, 4) === selectedYear,
+      )
+    : libraryFilteredPosts
+  const filteredPosts = searchBlogCardPosts(yearFilteredPosts, searchQuery)
+
+  // With no filters active, promote the latest post to a full-width hero and
+  // grid the rest; a hero makes no sense inside a filtered result set.
+  const hasActiveFilters = Boolean(
+    searchQuery || selectedAuthor || selectedLibrary || selectedYear,
+  )
+  const featuredPost = hasActiveFilters ? undefined : filteredPosts[0]
+  const gridPosts = featuredPost ? filteredPosts.slice(1) : filteredPosts
+
+  const [visibleCount, setVisibleCount] = React.useState(POSTS_PER_PAGE)
+  // Collapse back to the first page whenever the filtered set changes.
+  React.useEffect(() => {
+    setVisibleCount(POSTS_PER_PAGE)
+  }, [searchQuery, selectedAuthor, selectedLibrary, selectedYear])
+  const visiblePosts = gridPosts.slice(0, visibleCount)
+  const remainingCount = gridPosts.length - visiblePosts.length
+
+  // Shared by the desktop sidebar and the mobile disclosure copies of the nav.
+  const browseNavProps = {
+    searchQuery,
+    onSearchChange: (query: string) =>
+      navigate({
+        search: (prev) => ({ ...prev, q: query || undefined }),
+        replace: true,
+      }),
+    topics,
+    totalCount: frontMatters.length,
+    selectedLibrary,
+    onLibraryToggle: (libraryId: string | undefined) =>
+      navigate({
+        search: (prev) => ({ ...prev, library: libraryId }),
+        replace: true,
+      }),
+    authors,
+    selectedAuthor,
+    onAuthorChange: (nextAuthor: string | undefined) =>
+      navigate({
+        search: (prev) => ({ ...prev, author: nextAuthor }),
+        replace: true,
+      }),
+    years,
+    selectedYear,
+    onYearToggle: (nextYear: string | undefined) =>
+      navigate({
+        search: (prev) => ({ ...prev, year: nextYear }),
+        replace: true,
+      }),
+    hasActiveFilters,
+    onClearAll: () => navigate({ search: () => ({}), replace: true }),
+  }
 
   return (
     <div className="flex flex-col max-w-full min-h-screen">
       <div className="flex-1 flex w-full mb-16">
-        <div className="flex-1 p-4 md:p-8 min-w-0 flex justify-center">
-          <div className="w-full max-w-[1100px] space-y-12">
-            <header>
-              <div className="flex gap-3 items-baseline">
-                <h1 className="text-3xl font-black">Blog</h1>
-                <a
-                  href="/rss.xml"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors text-xl"
-                  title="RSS Feed"
-                >
-                  <RssIcon />
-                </a>
-              </div>
+        <div className="flex-1 p-4 md:p-8 min-w-0">
+          <div className="mx-auto w-full max-w-[1280px] space-y-10">
+            <PageHeader
+              align="center"
+              withDivider
+              title="Blog"
+              lede="The latest news and blog posts from TanStack"
+            />
 
-              <p className="text-lg mt-4 text-gray-600 dark:text-gray-400">
-                The latest news and blog posts from TanStack
-              </p>
-            </header>
-
-            <section className="space-y-6">
-              <div className="flex flex-wrap items-center gap-3">
-                <div className="flex items-center gap-3">
-                  <label
-                    htmlFor="blog-search-filter"
-                    className="text-sm font-medium text-gray-600 dark:text-gray-400"
-                  >
-                    Search
-                  </label>
-                  <BlogSearchFilter
-                    id="blog-search-filter"
-                    value={searchQuery}
-                    onChange={(nextQuery) =>
-                      navigate({
-                        search: (prev) => ({
-                          ...prev,
-                          q: nextQuery || undefined,
-                        }),
-                        replace: true,
-                      })
-                    }
-                    className="w-72 max-w-full"
+            <div className="flex gap-8">
+              {/* Desktop: the browse rail floats to the left of the content. */}
+              <aside className="hidden w-[224px] shrink-0 xl:block">
+                <div className="sticky top-[calc(var(--navbar-height)+1.5rem)]">
+                  <BlogBrowseNav
+                    idPrefix="blog-nav-desktop"
+                    {...browseNavProps}
                   />
                 </div>
-                <div className="flex items-center gap-3">
-                  <label
-                    htmlFor="blog-author-filter"
-                    className="text-sm font-medium text-gray-600 dark:text-gray-400"
-                  >
-                    Author
-                  </label>
-                  <div id="blog-author-filter" className="w-64 max-w-full">
-                    <BlogAuthorFilter
-                      authors={authors}
-                      selected={selectedAuthor}
-                      onSelect={(nextAuthor) =>
-                        navigate({
-                          search: (prev) => ({
-                            ...prev,
-                            author: nextAuthor,
-                          }),
-                          replace: true,
-                        })
-                      }
+              </aside>
+
+              <div className="min-w-0 flex-1 space-y-8">
+                {/* Below xl the same nav collapses into a disclosure. */}
+                <details className="group rounded-lg border border-border-subtle xl:hidden">
+                  <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-semibold [&::-webkit-details-marker]:hidden">
+                    Filter &amp; browse
+                    <CaretDownIcon className="h-4 w-4 transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="border-t border-border-subtle px-4 py-4">
+                    <BlogBrowseNav
+                      idPrefix="blog-nav-mobile"
+                      {...browseNavProps}
                     />
                   </div>
-                </div>
-              </div>
+                </details>
 
-              {librariesWithPosts.length ? (
-                <div>
-                  <div className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
-                    Browse by library
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {librariesWithPosts.map((library) => (
-                      <Link
-                        key={library.id}
-                        to="/$libraryId/$version/docs/blog"
-                        params={{
-                          libraryId: library.id,
-                          version: 'latest',
-                        }}
-                        className={`inline-flex items-center rounded-md px-3 py-1.5 text-xs font-black uppercase shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md ${library.bgStyle} ${library.badgeTextStyle ?? 'text-white'}`}
-                      >
-                        {library.name.replace('TanStack ', '')}
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </section>
-
-            <section className="grid grid-cols-1 xl:grid-cols-2 2xl:grid-cols-3 gap-4">
-              {filteredPosts.map((post) => (
-                <BlogCard key={post.slug} post={post} />
-              ))}
-            </section>
-
-            {filteredPosts.length === 0 ? (
-              <div className="text-center text-gray-600 dark:text-gray-400 py-8">
-                No posts found
-                {searchQuery ? (
-                  <>
-                    {' '}
-                    matching <span className="font-medium">{searchQuery}</span>
-                  </>
+                {featuredPost ? (
+                  <section aria-label="Latest post">
+                    <BlogPostCard post={featuredPost} featured />
+                  </section>
                 ) : null}
-                {selectedAuthor ? (
-                  <>
-                    {' '}
-                    by <span className="font-medium">{selectedAuthor}</span>
-                  </>
+
+                <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  {groupPostsByYear(visiblePosts).map((group) => (
+                    <React.Fragment key={group.year}>
+                      <div className="col-span-full flex items-center gap-3 pt-2 first:pt-0">
+                        <Eyebrow tone="muted">{group.year}</Eyebrow>
+                        <span className="h-px flex-1 bg-border-subtle" />
+                      </div>
+                      {group.posts.map((post) => (
+                        <BlogPostCard key={post.slug} post={post} size="lg" />
+                      ))}
+                    </React.Fragment>
+                  ))}
+                </section>
+
+                {remainingCount > 0 ? (
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setVisibleCount((count) => count + POSTS_PER_PAGE)
+                      }
+                      className="inline-flex items-center gap-2 rounded-lg border border-border-default px-5 py-2.5 text-sm font-bold transition-colors hover:border-blue-500 hover:text-blue-500"
+                    >
+                      Load more posts
+                      <span className="font-medium text-text-muted">
+                        {remainingCount} more
+                      </span>
+                    </button>
+                  </div>
                 ) : null}
-                .
+
+                {filteredPosts.length === 0 ? (
+                  <div className="py-8 text-center text-text-secondary">
+                    No posts found
+                    {searchQuery ? (
+                      <>
+                        {' '}
+                        matching{' '}
+                        <span className="font-medium">{searchQuery}</span>
+                      </>
+                    ) : null}
+                    {selectedAuthor ? (
+                      <>
+                        {' '}
+                        by <span className="font-medium">{selectedAuthor}</span>
+                      </>
+                    ) : null}
+                    .
+                  </div>
+                ) : null}
               </div>
-            ) : null}
+            </div>
           </div>
         </div>
         <RightRail breakpoint="md">
@@ -195,12 +283,6 @@ function BlogIndex() {
             analyticsPlacement="blog_rail"
             partners={activePartners}
           />
-          <div className="hidden md:block border border-gray-500/20 rounded-l-lg overflow-hidden w-full">
-            <RecentPostsWidget posts={frontMatters.slice(0, 3)} />
-          </div>
-          <Card>
-            <LibrariesWidget />
-          </Card>
         </RightRail>
       </div>
     </div>

--- a/src/routes/ds.cards.tsx
+++ b/src/routes/ds.cards.tsx
@@ -1,9 +1,97 @@
+import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { twMerge } from 'tailwind-merge'
 import { seo } from '~/utils/seo'
 import { Tooltip } from '~/ui'
 import { Button, Card, InlineCode } from '~/components/ds/ui'
 import { BlogPostCard } from '~/components/ds/ui/BlogPostCard'
-import { ComponentPreview, DsPage, DsSection } from '~/components/ds/DsKit'
+import {
+  ComponentPreview,
+  DsPage,
+  DsSection,
+  PreviewLabel,
+} from '~/components/ds/DsKit'
+
+const BLOG_CARD_SAMPLES = [
+  {
+    slug: 'tanstack-has-a-new-look',
+    title: 'TanStack Has a New Look',
+    published: '2026-07-29',
+    excerpt:
+      'TanStack has a new logo, a design system, and a brand built with care for the details.',
+    headerImage: '/blog-assets/tanstack-has-a-new-look/logo-swatch.svg',
+    authors: ['Tanner Linsley'],
+    library: 'table',
+  },
+  {
+    slug: 'introducing-tanstack-markdown-and-highlight',
+    title: 'Introducing TanStack Markdown and Highlight',
+    published: '2026-07-24',
+    excerpt:
+      'Two tiny, synchronous libraries for turning technical content into deterministic, themeable webpages.',
+    headerImage:
+      '/blog-assets/introducing-tanstack-markdown-and-highlight/header.webp',
+    authors: ['Tanner Linsley'],
+    library: 'markdown,highlight',
+  },
+]
+
+const BLOG_CARD_SIZES = ['sm', 'lg'] as const
+
+// Consolidated Blog post card preview: pick the variant and both the rendered
+// cards and the code snippet update. `sm` (nav/homepage) drops the library tags
+// to mirror its `RecentPost` data; `lg` (Blog index) shows them.
+function BlogPostCardDemo() {
+  const [size, setSize] = React.useState<(typeof BLOG_CARD_SIZES)[number]>('lg')
+  const code =
+    size === 'lg'
+      ? `<BlogPostCard post={post} size="lg" />`
+      : `<BlogPostCard post={post} />`
+
+  return (
+    <ComponentPreview className="block" code={code}>
+      <div className="w-full space-y-6">
+        <div className="flex items-center gap-3">
+          <PreviewLabel>Variant</PreviewLabel>
+          <div
+            role="group"
+            aria-label="Card size"
+            className="inline-flex rounded-lg border border-border-default bg-background-surface p-0.5"
+          >
+            {BLOG_CARD_SIZES.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={size === option}
+                onClick={() => setSize(option)}
+                className={twMerge(
+                  'rounded-md px-3 py-1 font-ds-mono text-ds-mono-caps-xs uppercase transition-colors',
+                  size === option
+                    ? 'bg-background-subtle text-text-primary'
+                    : 'text-text-muted hover:text-text-primary',
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="mx-auto grid max-w-3xl gap-4 md:grid-cols-2">
+          {BLOG_CARD_SAMPLES.map((sample) => (
+            <BlogPostCard
+              key={sample.slug}
+              size={size}
+              post={{
+                ...sample,
+                library: size === 'lg' ? sample.library : undefined,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </ComponentPreview>
+  )
+}
 
 export const Route = createFileRoute('/ds/cards')({
   component: CardsPage,
@@ -63,39 +151,9 @@ function CardsPage() {
 
       <DsSection
         title="Blog post card"
-        description="The canonical blog preview used in the homepage and Blog mega menu. Its padding, hover, focus, selected state, typography, media treatment, and metadata are managed here."
+        description="The canonical blog preview. size='sm' (default) is the compact card in the homepage and Blog mega menu; size='lg' is the roomier treatment for the Blog index grid, and renders library tags when the post carries a library. Padding, hover, focus, selected state, typography, media treatment, and metadata are managed here."
       >
-        <ComponentPreview
-          className="block"
-          code={`<BlogPostCard post={post} />`}
-        >
-          <div className="mx-auto grid max-w-3xl gap-4 md:grid-cols-2">
-            <BlogPostCard
-              post={{
-                slug: 'tanstack-has-a-new-look',
-                title: 'TanStack Has a New Look',
-                published: '2026-07-29',
-                excerpt:
-                  'TanStack has a new logo, a design system, and a brand built with care for the details.',
-                headerImage:
-                  '/blog-assets/tanstack-has-a-new-look/logo-swatch.svg',
-                authors: ['Tanner Linsley'],
-              }}
-            />
-            <BlogPostCard
-              post={{
-                slug: 'introducing-tanstack-markdown-and-highlight',
-                title: 'Introducing TanStack Markdown and Highlight',
-                published: '2026-07-24',
-                excerpt:
-                  'Two tiny, synchronous libraries for turning technical content into deterministic, themeable webpages.',
-                headerImage:
-                  '/blog-assets/introducing-tanstack-markdown-and-highlight/header.webp',
-                authors: ['Tanner Linsley'],
-              }}
-            />
-          </div>
-        </ComponentPreview>
+        <BlogPostCardDemo />
       </DsSection>
 
       <DsSection

--- a/src/routes/ds.stats.tsx
+++ b/src/routes/ds.stats.tsx
@@ -118,7 +118,12 @@ function StatsPage() {
           code={`<StatsSection page="${page}" layout="${layout}" stats={stats} />`}
           codePlacement="side"
         >
-          <StatsSection page={page} layout={layout} stats={stats} />
+          <StatsSection
+            page={page}
+            layout={layout}
+            stats={stats}
+            onImage={page === 'hero'}
+          />
         </ComponentPreview>
       </DsSection>
     </DsPage>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -479,7 +479,7 @@ function WhyTanStackSection() {
       <div className="mx-auto max-w-[960px] py-16 lg:py-20">
         {/* section-header — 478:1737 */}
         <div className="flex flex-col items-center gap-12 text-center">
-          <Eyebrow className="text-text-warning">Principles</Eyebrow>
+          <Eyebrow tone="warning">Principles</Eyebrow>
           <div className="flex flex-col items-center gap-4">
             <h3 className="text-4xl font-[500] leading-[1.05] tracking-[-0.8px] sm:text-5xl lg:text-[64px]">
               Why TanStack?

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1868,6 +1868,44 @@ mark {
   animation: home-prompt-ph-in 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
+/* Home prompt focus glow: a slow horizontal wave (with a gentle width pulse) so
+   the terracotta bloom feels alive instead of static. The wrapper handles the
+   opacity/scale grow-in on focus (see ApplicationStarter); this drives only the
+   flowing drift, on a separate nested element so the two transforms compose. */
+@keyframes prompt-glow-flow {
+  0%,
+  100% {
+    transform: translate3d(-5%, 0, 0) scaleX(1);
+  }
+  50% {
+    transform: translate3d(5%, 0, 0) scaleX(1.12);
+  }
+}
+.prompt-glow-flow {
+  animation: prompt-glow-flow 5.5s ease-in-out infinite;
+  will-change: transform;
+}
+@media (prefers-reduced-motion: reduce) {
+  .prompt-glow-flow {
+    animation: none;
+  }
+}
+
+/* DS brand mark — the TanStack emblem as a monochrome glyph tinted with
+   currentColor, for pairing with a page title (see PageHeader). Sized relative
+   to the title (em units) so it scales with the fluid display type. */
+.ds-brand-mark {
+  display: inline-block;
+  width: 0.82em;
+  height: 0.82em;
+  flex: none;
+  background-color: currentColor;
+  -webkit-mask: url('/images/brand/tanstack-emblem-black.svg') center / contain
+    no-repeat;
+  mask: url('/images/brand/tanstack-emblem-black.svg') center / contain
+    no-repeat;
+}
+
 @keyframes home-stack-builder-reveal {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary

A broad blog + design-system pass, verified in light and dark.

### Blog index
- **Featured hero** (latest post) + **pagination** ("Load more"), replacing the flat 97-card dump.
- **Left "browse" nav** with progressive-disclosure **Topics**/**Archive**, category-colored library icons (from the mega menu), and inline `(count)` labels with a ragged right edge.
- Grid + hero now use the **DS `BlogPostCard`** (new `lg` and `featured` variants) — one consistent card system with proper title/excerpt/byline hierarchy.
- New **DS `PageHeader`** masthead (brand mark + page name) as the standard for global pages.
- RSS moved onto the search line; result-count removed; dividers between filters.

### Design system
- **`PageHeader`** component (theme-aware, generalized from `ShopHero`).
- **`BlogPostCard`** `size`/`featured` variants + optional library tags.
- **Buttons** default to full-rounded pills with a **squircle** corner shape.
- **`StatsSection`** `onImage` prop → dark ink when overlaid on a light image (homepage unaffected).
- Consolidated blog-card preview with an SM/LG selector; +112px page padding; `/ds/cards` documents both variants.

### Navbar / landing
- Mega-menu: single-line descriptions, **elevated-white** light-mode hover (shadow + hairline ring), and library buttons that hug their own label with more right padding.
- Library-landing feature tabs never wrap (e.g. "State Management").

### Home
- Focus-only animated prompt glow; `Eyebrow` `warning` tone.

## Testing
- `pnpm test` (tsc + lint + unit) green: 123/123 unit, 0 type errors, 0 lint issues across 951 files.
- Verified in the browser (light + dark) across the blog, `/ds/*`, and `/query`.
- Merges cleanly into `main` (in-memory test-merge, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer blog browsing experience with search, author/topic/year filters, RSS access, and featured post cards.
  * Introduced a new editorial page header style with optional branding, actions, and centered or left-aligned layouts.
  * Added interactive card demos and more flexible blog/stat display options across the design system.

* **UI Improvements**
  * Refined navigation, button, and filter styling for a more polished look in light and dark modes.
  * Improved focus effects, image handling, and reduced-motion behavior for smoother, more accessible interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->