### PR TITLE
Fix navbar menus after middle-click navigation

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -769,6 +769,9 @@ function DesktopNavTrigger({
       className="ts-mega-trigger-wrap group/nav"
       data-menu-key={group.key}
       data-menu-dismissed={dismissed ? 'true' : undefined}
+      onAuxClick={(event) => {
+        if (event.button === 1) onDismiss()
+      }}
       onPointerLeave={onResetDismissed}
       onFocusCapture={onResetDismissed}
     >


### PR DESCRIPTION
Closes #1138.

## What changed

Dismiss the active desktop mega menu when an auxiliary click comes from its trigger or any nested link. The existing wrapper-level dismissal state now handles middle-click in addition to ordinary click navigation.

## Root cause and impact

React's `onClick` does not run for middle-click. The clicked link retained focus, so the CSS `:focus-within` rule kept that menu visible while another hovered menu opened. Handling the bubbling `auxclick` once at the menu wrapper removes the stuck panel without duplicating handlers across every link.

## Validation

- `pnpm test` — TypeScript and type-aware lint clean; 127 tests passed, 1 environment-gated docs smoke test skipped
- Headless Chrome at desktop width — focused Blog menu was visible; middle-click set its dismissal state and hid it after the existing transition; focusing Community opened that adjacent menu normally
- `git diff --check`

## Risk

Low. The handler only acts for middle-button auxiliary clicks inside desktop menu wrappers and reuses the current dismissal/reset behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop navigation menus now close when users middle-click a menu trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->