### PR TITLE
feat: redirect latest v# to /latest and canonicalize old-version docs

### DIFF
--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -101,7 +101,7 @@ function useVersionConfig({
     const available = versions.map(
       (version): SelectOption =>
         version === latestVersion
-          ? { label: `${version} (latest)`, value: 'latest' }
+          ? { label: `${version} (Latest)`, value: 'latest' }
           : { label: version, value: version },
     )
 

--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -13,6 +13,7 @@ export function VersionSelect({ libraryId }: { libraryId: LibraryId }) {
   const library = getLibrary(libraryId)
   const versionConfig = useVersionConfig({
     versions: library.availableVersions,
+    latestVersion: library.latestVersion,
   })
   return (
     <Select
@@ -85,37 +86,38 @@ function useCurrentVersion(versions: string[]) {
   }
 }
 
-function useVersionConfig({ versions }: { versions: string[] }) {
+function useVersionConfig({
+  versions,
+  latestVersion,
+}: {
+  versions: string[]
+  latestVersion: string
+}) {
   const currentVersion = useCurrentVersion(versions)
 
   const versionConfig = React.useMemo(() => {
-    const available = versions.reduce(
-      (acc: SelectOption[], version) => {
-        acc.push({
-          label: version,
-          value: version,
-        })
-        return acc
-      },
-      [
-        {
-          label: 'Latest',
-          value: 'latest',
-        },
-      ],
+    // The latest numbered version and 'latest' are the same docs, so they
+    // collapse into a single option that navigates to the /latest URL.
+    const available = versions.map(
+      (version): SelectOption =>
+        version === latestVersion
+          ? { label: `${version} (latest)`, value: 'latest' }
+          : { label: version, value: version },
     )
+
+    const isLatest =
+      currentVersion.version === latestVersion ||
+      !versions.includes(currentVersion.version)
 
     return {
       label: 'Version',
-      selected: versions.includes(currentVersion.version)
-        ? currentVersion.version
-        : 'latest',
+      selected: isLatest ? 'latest' : currentVersion.version,
       available,
       onSelect: (option: { label: string; value: string }) => {
         currentVersion.setVersion(option.value)
       },
     }
-  }, [currentVersion, versions])
+  }, [currentVersion, versions, latestVersion])
 
   return versionConfig
 }

--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -101,7 +101,7 @@ function useVersionConfig({
     const available = versions.map(
       (version): SelectOption =>
         version === latestVersion
-          ? { label: `${version} (Latest)`, value: 'latest' }
+          ? { label: `${version} - Latest`, value: 'latest' }
           : { label: version, value: version },
     )
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -81,6 +81,7 @@ declare module '@tanstack/react-router' {
     baseParent?: boolean
     showNavbar?: boolean
     includeSearchInCanonical?: boolean
+    ownsCanonicalLink?: boolean
   }
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -75,6 +75,28 @@ type CanonicalHeadMatch = {
   staticData?: {
     includeSearchInCanonical?: boolean
   }
+  loaderData?: unknown
+}
+
+// Loaders can point a page's canonical at a different URL (e.g. old-version
+// docs canonicalize to /latest) by returning `canonicalPathOverride`.
+function getCanonicalPathOverride(
+  matches: ReadonlyArray<CanonicalHeadMatch>,
+): string | null {
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const loaderData = matches[i]?.loaderData
+
+    if (
+      loaderData &&
+      typeof loaderData === 'object' &&
+      'canonicalPathOverride' in loaderData &&
+      typeof loaderData.canonicalPathOverride === 'string'
+    ) {
+      return loaderData.canonicalPathOverride
+    }
+  }
+
+  return null
 }
 
 function getCanonicalHeadTags(matches: ReadonlyArray<CanonicalHeadMatch>): {
@@ -90,7 +112,9 @@ function getCanonicalHeadTags(matches: ReadonlyArray<CanonicalHeadMatch>): {
     includeSearchInCanonical && lastMatch
       ? defaultStringifySearch(lastMatch.search)
       : ''
-  const preferredCanonicalPath = getCanonicalPath(canonicalPath)
+  const preferredCanonicalPath = getCanonicalPath(
+    getCanonicalPathOverride(matches) ?? canonicalPath,
+  )
   const pageUrl = canonicalUrl(
     preferredCanonicalPath ?? canonicalPath,
     canonicalSearch,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -74,29 +74,8 @@ type CanonicalHeadMatch = {
   search: Record<string, unknown>
   staticData?: {
     includeSearchInCanonical?: boolean
+    ownsCanonicalLink?: boolean
   }
-  loaderData?: unknown
-}
-
-// Loaders can point a page's canonical at a different URL (e.g. old-version
-// docs canonicalize to /latest) by returning `canonicalPathOverride`.
-function getCanonicalPathOverride(
-  matches: ReadonlyArray<CanonicalHeadMatch>,
-): string | null {
-  for (let i = matches.length - 1; i >= 0; i--) {
-    const loaderData = matches[i]?.loaderData
-
-    if (
-      loaderData &&
-      typeof loaderData === 'object' &&
-      'canonicalPathOverride' in loaderData &&
-      typeof loaderData.canonicalPathOverride === 'string'
-    ) {
-      return loaderData.canonicalPathOverride
-    }
-  }
-
-  return null
 }
 
 function getCanonicalHeadTags(matches: ReadonlyArray<CanonicalHeadMatch>): {
@@ -108,27 +87,34 @@ function getCanonicalHeadTags(matches: ReadonlyArray<CanonicalHeadMatch>): {
   const includeSearchInCanonical = matches.some(
     (match) => match.staticData?.includeSearchInCanonical === true,
   )
+  // Routes whose canonical depends on loader data (e.g. old-version docs
+  // canonicalizing to /latest) emit their own link tag from their head().
+  // The root must not also emit one — the router does not dedupe links, and
+  // this head only sees pre-loader match snapshots, so it can't compute the
+  // override itself.
+  const ownsCanonicalLink = matches.some(
+    (match) => match.staticData?.ownsCanonicalLink === true,
+  )
   const canonicalSearch =
     includeSearchInCanonical && lastMatch
       ? defaultStringifySearch(lastMatch.search)
       : ''
-  const preferredCanonicalPath = getCanonicalPath(
-    getCanonicalPathOverride(matches) ?? canonicalPath,
-  )
+  const preferredCanonicalPath = getCanonicalPath(canonicalPath)
   const pageUrl = canonicalUrl(
     preferredCanonicalPath ?? canonicalPath,
     canonicalSearch,
   )
 
   return {
-    links: preferredCanonicalPath
-      ? [
-          {
-            rel: 'canonical',
-            href: canonicalUrl(preferredCanonicalPath, canonicalSearch),
-          },
-        ]
-      : [],
+    links:
+      preferredCanonicalPath && !ownsCanonicalLink
+        ? [
+            {
+              rel: 'canonical',
+              href: canonicalUrl(preferredCanonicalPath, canonicalSearch),
+            },
+          ]
+        : [],
     meta: [
       { property: 'og:url', content: pageUrl },
       { name: 'twitter:url', content: pageUrl },

--- a/src/routes/_library/$libraryId/$version.docs.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.$.tsx
@@ -1,4 +1,4 @@
-import { seo } from '~/utils/seo'
+import { canonicalUrl, seo } from '~/utils/seo'
 import { ogImageUrl } from '~/utils/og'
 import { Doc } from '~/components/Doc'
 import {
@@ -19,6 +19,11 @@ import {
 
 export const Route = createFileRoute('/_library/$libraryId/$version/docs/$')({
   staleTime: 1000 * 60 * 5,
+  // This route's head() emits the rel=canonical link (it may point at the
+  // /latest equivalent), so the root route must not emit its own.
+  staticData: {
+    ownsCanonicalLink: true,
+  },
   loader: async (ctx) => {
     const { _splat: docsPath, version, libraryId } = ctx.params
     const library = findLibrary(libraryId)
@@ -86,18 +91,30 @@ export const Route = createFileRoute('/_library/$libraryId/$version/docs/$')({
       }),
     )
 
+    const canonicalHref = canonicalUrl(
+      loaderData?.canonicalPathOverride ??
+        appendPathToDocsHref({ docsPath: docsPath ?? '', libraryId, version }),
+    )
+
     return {
-      meta: seo({
-        title: `${loaderData?.title} | ${library.name} Docs`,
-        description: loaderData?.description,
-        keywords: loaderData?.keywords,
-        image: ogImageUrl(library.id, {
-          title: loaderData?.title,
+      meta: [
+        ...seo({
+          title: `${loaderData?.title} | ${library.name} Docs`,
           description: loaderData?.description,
+          keywords: loaderData?.keywords,
+          image: ogImageUrl(library.id, {
+            title: loaderData?.title,
+            description: loaderData?.description,
+          }),
+          noindex: library.visible === false,
         }),
-        noindex: library.visible === false,
-      }),
-      links: frameworkVariantLinks,
+        { property: 'og:url', content: canonicalHref },
+        { name: 'twitter:url', content: canonicalHref },
+      ],
+      links: [
+        { rel: 'canonical', href: canonicalHref },
+        ...frameworkVariantLinks,
+      ],
     }
   },
   component: Docs,

--- a/src/routes/_library/$libraryId/$version.docs.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.$.tsx
@@ -1,7 +1,11 @@
 import { seo } from '~/utils/seo'
 import { ogImageUrl } from '~/utils/og'
 import { Doc } from '~/components/Doc'
-import { buildDocsRedirectHref, loadDocsRoute } from '~/utils/docs'
+import {
+  appendPathToDocsHref,
+  buildDocsRedirectHref,
+  loadDocsRoute,
+} from '~/utils/docs'
 import { findLibrary, getBranch, getLibrary } from '~/libraries'
 import { DocContainer } from '~/components/DocContainer'
 import { getDocsCacheHeaders } from '~/utils/docs-cache-headers'
@@ -33,6 +37,7 @@ export const Route = createFileRoute('/_library/$libraryId/$version/docs/$')({
       docsPath: requestedDocsPath,
       defaultDocs: library.defaultDocs ?? 'overview',
       frameworks: library.frameworks,
+      latestBranch: getBranch(library, 'latest'),
       redirectFromPaths: requestedDocsPath ? [requestedDocsPath] : [],
     })
 
@@ -52,7 +57,18 @@ export const Route = createFileRoute('/_library/$libraryId/$version/docs/$')({
       throw notFound()
     }
 
-    return result.doc
+    return {
+      ...result.doc,
+      // Old-version pages that still exist on latest canonicalize to /latest
+      // (read by getCanonicalHeadTags in __root.tsx).
+      canonicalPathOverride: result.latestDocsPath
+        ? appendPathToDocsHref({
+            docsPath: result.latestDocsPath,
+            libraryId,
+            version: 'latest',
+          })
+        : undefined,
+    }
   },
   head: ({ loaderData, params }) => {
     const { libraryId, version, _splat: docsPath } = params

--- a/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
@@ -7,7 +7,11 @@ import {
 import { seo } from '~/utils/seo'
 import { ogImageUrl } from '~/utils/og'
 import { Doc } from '~/components/Doc'
-import { buildDocsRedirectHref, loadDocsRoute } from '~/utils/docs'
+import {
+  appendPathToDocsHref,
+  buildDocsRedirectHref,
+  loadDocsRoute,
+} from '~/utils/docs'
 import { getBranch, getLibrary } from '~/libraries'
 import { capitalize } from '~/utils/utils'
 import { DocContainer } from '~/components/DocContainer'
@@ -31,6 +35,7 @@ export const Route = createFileRoute(
       docsPath: requestedDocsPath,
       defaultDocs: library.defaultDocs ?? 'overview',
       frameworks: library.frameworks,
+      latestBranch: getBranch(library, 'latest'),
       redirectFromPaths: docsPath
         ? [requestedDocsPath, `${framework}/${docsPath}`]
         : [requestedDocsPath],
@@ -55,7 +60,18 @@ export const Route = createFileRoute(
       })
     }
 
-    return result.doc
+    return {
+      ...result.doc,
+      // Old-version pages that still exist on latest canonicalize to /latest
+      // (read by getCanonicalHeadTags in __root.tsx).
+      canonicalPathOverride: result.latestDocsPath
+        ? appendPathToDocsHref({
+            docsPath: result.latestDocsPath,
+            libraryId,
+            version: 'latest',
+          })
+        : undefined,
+    }
   },
   component: Docs,
   headers: ({ params }) => {

--- a/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
@@ -4,7 +4,7 @@ import {
   useMatch,
   createFileRoute,
 } from '@tanstack/react-router'
-import { seo } from '~/utils/seo'
+import { canonicalUrl, seo } from '~/utils/seo'
 import { ogImageUrl } from '~/utils/og'
 import { Doc } from '~/components/Doc'
 import {
@@ -21,6 +21,11 @@ export const Route = createFileRoute(
   '/_library/$libraryId/$version/docs/framework/$framework/$',
 )({
   staleTime: 1000 * 60 * 5,
+  // This route's head() emits the rel=canonical link (it may point at the
+  // /latest equivalent), so the root route must not emit its own.
+  staticData: {
+    ownsCanonicalLink: true,
+  },
   loader: async (ctx) => {
     const { _splat: docsPath, framework, version, libraryId } = ctx.params
 
@@ -80,22 +85,37 @@ export const Route = createFileRoute(
     return getDocsCacheHeaders({ libraryId, version })
   },
   head: (ctx) => {
-    const library = getLibrary(ctx.params.libraryId)
-    const tail = `${library.name} ${capitalize(ctx.params.framework)} Docs`
+    const { libraryId, version, framework, _splat: docsPath } = ctx.params
+    const library = getLibrary(libraryId)
+    const tail = `${library.name} ${capitalize(framework)} Docs`
+
+    const canonicalHref = canonicalUrl(
+      ctx.loaderData?.canonicalPathOverride ??
+        appendPathToDocsHref({
+          docsPath: `framework/${framework}/${docsPath ?? ''}`,
+          libraryId,
+          version,
+        }),
+    )
 
     return {
-      meta: seo({
-        title: ctx.loaderData?.title
-          ? `${ctx.loaderData.title} | ${tail}`
-          : tail,
-        description: ctx.loaderData?.description,
-        keywords: ctx.loaderData?.keywords,
-        image: ogImageUrl(library.id, {
-          title: ctx.loaderData?.title,
+      meta: [
+        ...seo({
+          title: ctx.loaderData?.title
+            ? `${ctx.loaderData.title} | ${tail}`
+            : tail,
           description: ctx.loaderData?.description,
+          keywords: ctx.loaderData?.keywords,
+          image: ogImageUrl(library.id, {
+            title: ctx.loaderData?.title,
+            description: ctx.loaderData?.description,
+          }),
+          noindex: library.visible === false,
         }),
-        noindex: library.visible === false,
-      }),
+        { property: 'og:url', content: canonicalHref },
+        { name: 'twitter:url', content: canonicalHref },
+      ],
+      links: [{ rel: 'canonical', href: canonicalHref }],
     }
   },
 })

--- a/src/routes/_library/$libraryId/$version.tsx
+++ b/src/routes/_library/$libraryId/$version.tsx
@@ -25,6 +25,18 @@ export const Route = createFileRoute('/_library/$libraryId/$version')({
       })
     })
 
+    // The latest numbered version (e.g. /query/v5) serves the exact same
+    // content as /latest; permanently redirect so only one URL gets indexed.
+    if (version === library.latestVersion) {
+      throw redirect({
+        href: ctx.location.href.replace(
+          `/${libraryId}/${version}`,
+          `/${libraryId}/latest`,
+        ),
+        statusCode: 308,
+      })
+    }
+
     library.handleRedirects?.(ctx.location.href)
   },
   loader: async (ctx) => {

--- a/src/utils/docs-redirects.ts
+++ b/src/utils/docs-redirects.ts
@@ -77,6 +77,21 @@ export function resolveDocsPathRedirect({
   return { type: 'not-found' }
 }
 
+export function docsManifestHasPath(
+  manifest: DocsRedirectManifest,
+  docsPath: string,
+) {
+  const normalizedPath = normalizeDocsPath(docsPath)
+
+  if (normalizedPath === null) {
+    return false
+  }
+
+  return manifest.paths.some(
+    (path) => normalizeManifestPath(path) === normalizedPath,
+  )
+}
+
 export function appendPathToDocsHref(opts: {
   docsPath: string
   libraryId: string

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -8,8 +8,10 @@ import {
   fetchRepoDirectoryContents,
 } from './docs.functions'
 import {
+  appendPathToDocsHref,
   buildDocsMarkdownRedirectHref,
   buildDocsRedirectHref,
+  docsManifestHasPath,
   resolveDocsPathRedirect,
   type DocsPathResolution,
 } from './docs-redirects'
@@ -161,6 +163,7 @@ export type LoadDocsRouteResult =
       type: 'loaded'
       docsPath: string
       doc: Awaited<ReturnType<typeof loadDocs>>
+      latestDocsPath: string | null
     }
   | {
       type: 'redirect'
@@ -176,6 +179,7 @@ export async function loadDocsRoute(opts: {
   docsPath: string
   docsRoot: string
   frameworks: Array<string>
+  latestBranch?: string
   redirectFromPaths: Array<string>
   repo: string
 }): Promise<LoadDocsRouteResult> {
@@ -186,15 +190,21 @@ export async function loadDocsRoute(opts: {
   }
 
   try {
-    return {
-      type: 'loaded',
-      docsPath: resolution.docsPath,
-      doc: await loadDocs({
+    const [doc, latestDocsPath] = await Promise.all([
+      loadDocs({
         repo: opts.repo,
         branch: opts.branch,
         docsRoot: opts.docsRoot,
         docsPath: resolution.docsPath,
       }),
+      findLatestDocsPath(opts, resolution.docsPath),
+    ])
+
+    return {
+      type: 'loaded',
+      docsPath: resolution.docsPath,
+      doc,
+      latestDocsPath,
     }
   } catch (error) {
     if (!isDocsNotFoundError(error)) {
@@ -211,6 +221,39 @@ export async function loadDocsRoute(opts: {
     }
 
     return { type: 'not-found' }
+  }
+}
+
+/**
+ * When serving an old version, checks whether the same doc path exists on the
+ * latest branch so the page can canonicalize to its /latest equivalent.
+ * Fails open (null) so a manifest hiccup never breaks the doc itself.
+ */
+async function findLatestDocsPath(
+  opts: {
+    branch: string
+    docsRoot: string
+    latestBranch?: string
+    repo: string
+  },
+  docsPath: string,
+): Promise<string | null> {
+  if (!opts.latestBranch || opts.latestBranch === opts.branch) {
+    return null
+  }
+
+  try {
+    const manifest = await fetchDocsPathManifest({
+      data: {
+        repo: opts.repo,
+        branch: opts.latestBranch,
+        docsRoot: opts.docsRoot,
+      },
+    })
+
+    return docsManifestHasPath(manifest, docsPath) ? docsPath : null
+  } catch {
+    return null
   }
 }
 
@@ -278,6 +321,7 @@ export async function resolveDocsRedirect(opts: {
 }
 
 export {
+  appendPathToDocsHref,
   buildDocsMarkdownRedirectHref,
   buildDocsRedirectHref,
   fetchFile,

--- a/tests/docs-redirects.test.ts
+++ b/tests/docs-redirects.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import {
   buildDocsMarkdownRedirectHref,
   buildDocsRedirectHref,
+  docsManifestHasPath,
   resolveDocsPathRedirect,
   type DocsRedirectManifest,
 } from '../src/utils/docs-redirects'
@@ -207,5 +208,31 @@ assert.equal(
   }),
   'https://tanstack.com/query/v5/docs/framework/react/overview.md?pm=pnpm#motivation',
 )
+
+assert.equal(
+  docsManifestHasPath(
+    manifestWithPaths(['guides/queries.md', 'framework/react/overview.md']),
+    'guides/queries',
+  ),
+  true,
+)
+
+assert.equal(
+  docsManifestHasPath(
+    manifestWithPaths(['guides/queries/index.md']),
+    'guides/queries',
+  ),
+  true,
+)
+
+assert.equal(
+  docsManifestHasPath(
+    manifestWithPaths(['guides/queries.md']),
+    'guides/removed-in-latest',
+  ),
+  false,
+)
+
+assert.equal(docsManifestHasPath(manifestWithPaths(['overview.md']), ''), false)
 
 console.log('docs redirect tests passed')


### PR DESCRIPTION
Addresses old-version docs (e.g. Table v8, Query v3/v4) outranking latest docs in search results.

- 308 redirect the latest numbered version (e.g. `/query/v5/...`, per each library's `latestVersion`) to `/latest/...` — both serve identical content from the same branch, so only one URL should be indexed
- Old-version docs pages now emit `<link rel="canonical">` (and matching `og:url`/`twitter:url`) pointing to their `/latest` equivalent when the same doc path exists on the latest branch
- Existence check reuses the cached docs path manifest, fetched in parallel with the doc itself; fails open to a self-canonical so a manifest hiccup never breaks the page
- Old versions are never redirected — they stay readable, just no longer compete with latest in search
- Version dropdown collapses "Latest" and the latest numbered version into a single "v# - Latest" option
- The canonical link is emitted by the docs routes' own `head()` (route `head()` only sees fresh `loaderData` for its own match, never for children), and those routes set `staticData.ownsCanonicalLink` so the root suppresses its default self-canonical — the router doesn't dedupe links, so exactly one tag renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)