### PR TITLE
Show loading feedback for Charts catalog details

### DIFF
--- a/src/components/charts/ChartsCatalogPages.tsx
+++ b/src/components/charts/ChartsCatalogPages.tsx
@@ -135,6 +135,20 @@ export function ChartsCatalogDetail({
   )
 }
 
+export function ChartsCatalogDetailPending() {
+  return (
+    <CatalogSurface wide>
+      <p
+        aria-live="polite"
+        className="rounded-lg border border-gray-200 p-6 text-sm text-gray-500 dark:border-gray-800"
+        role="status"
+      >
+        Loading chart example…
+      </p>
+    </CatalogSurface>
+  )
+}
+
 function CatalogWorkbenchFallback({
   catalogCase,
 }: {

--- a/src/routes/_library/charts.catalog.charts.$caseId.tsx
+++ b/src/routes/_library/charts.catalog.charts.$caseId.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute, notFound } from '@tanstack/react-router'
-import { ChartsCatalogDetail } from '~/components/charts/ChartsCatalogPages'
+import {
+  ChartsCatalogDetail,
+  ChartsCatalogDetailPending,
+} from '~/components/charts/ChartsCatalogPages'
 import { getChartsCatalogCase } from '~/utils/charts-catalog.functions'
 import { seo } from '~/utils/seo'
 
@@ -14,6 +17,8 @@ export const Route = createFileRoute('/_library/charts/catalog/charts/$caseId')(
       if (!data) throw notFound()
       return data
     },
+    pendingComponent: ChartsCatalogDetailPending,
+    pendingMs: 250,
     component: ChartsCatalogCaseRoute,
     head: ({ loaderData }) => ({
       meta: seo({

--- a/tests/charts-catalog-source-previews.test.ts
+++ b/tests/charts-catalog-source-previews.test.ts
@@ -13,12 +13,10 @@ import {
 } from '@tanstack/react-router'
 
 import { ChartsCatalogPreview } from '../src/components/charts/ChartsCatalogPreview'
-import { ChartsCatalogDetailPending } from '../src/components/charts/ChartsCatalogPages'
 import {
   CatalogChartsHero,
   ChartsCatalogGallery,
 } from '../src/components/landing/ChartsCatalogGallery'
-import { Route as chartsCatalogCaseRoute } from '../src/routes/_library/charts.catalog.charts.$caseId'
 import { serveChartsCatalogPreview } from '../src/routes/charts.catalog_.previews.$revision.{$caseId}[.]svg'
 import {
   getChartsCatalogPreviewHeaders,
@@ -31,18 +29,6 @@ import { resetGitHubContentCacheForTest } from '../src/utils/github-content-cach
 const revision = 'a'.repeat(40)
 const previewSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 192"><path d="M0 192L288 0" stroke="#2563eb"/></svg>'
-
-test('catalog detail navigation exposes feedback while its source loads', () => {
-  const html = renderToStaticMarkup(createElement(ChartsCatalogDetailPending))
-  const $ = load(html)
-
-  assert.equal(
-    chartsCatalogCaseRoute.options.pendingComponent,
-    ChartsCatalogDetailPending,
-  )
-  assert.equal(chartsCatalogCaseRoute.options.pendingMs, 250)
-  assert.equal($('[role="status"]').text(), 'Loading chart example…')
-})
 
 test('catalog previews map case IDs to immutable source assets', () => {
   assert.equal(

--- a/tests/charts-catalog-source-previews.test.ts
+++ b/tests/charts-catalog-source-previews.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-router'
 
 import { ChartsCatalogPreview } from '../src/components/charts/ChartsCatalogPreview'
+import { ChartsCatalogDetailPending } from '../src/components/charts/ChartsCatalogPages'
 import {
   CatalogChartsHero,
   ChartsCatalogGallery,
@@ -29,6 +30,19 @@ import { resetGitHubContentCacheForTest } from '../src/utils/github-content-cach
 const revision = 'a'.repeat(40)
 const previewSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 192"><path d="M0 192L288 0" stroke="#2563eb"/></svg>'
+
+test('catalog detail navigation exposes feedback while its source loads', () => {
+  const routeSource = readFileSync(
+    'src/routes/_library/charts.catalog.charts.$caseId.tsx',
+    'utf8',
+  )
+  const html = renderToStaticMarkup(createElement(ChartsCatalogDetailPending))
+  const $ = load(html)
+
+  assert.match(routeSource, /pendingComponent: ChartsCatalogDetailPending/)
+  assert.match(routeSource, /pendingMs: 250/)
+  assert.equal($('[role="status"]').text(), 'Loading chart example…')
+})
 
 test('catalog previews map case IDs to immutable source assets', () => {
   assert.equal(

--- a/tests/charts-catalog-source-previews.test.ts
+++ b/tests/charts-catalog-source-previews.test.ts
@@ -18,6 +18,7 @@ import {
   CatalogChartsHero,
   ChartsCatalogGallery,
 } from '../src/components/landing/ChartsCatalogGallery'
+import { Route as chartsCatalogCaseRoute } from '../src/routes/_library/charts.catalog.charts.$caseId'
 import { serveChartsCatalogPreview } from '../src/routes/charts.catalog_.previews.$revision.{$caseId}[.]svg'
 import {
   getChartsCatalogPreviewHeaders,
@@ -32,15 +33,14 @@ const previewSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 288 192"><path d="M0 192L288 0" stroke="#2563eb"/></svg>'
 
 test('catalog detail navigation exposes feedback while its source loads', () => {
-  const routeSource = readFileSync(
-    'src/routes/_library/charts.catalog.charts.$caseId.tsx',
-    'utf8',
-  )
   const html = renderToStaticMarkup(createElement(ChartsCatalogDetailPending))
   const $ = load(html)
 
-  assert.match(routeSource, /pendingComponent: ChartsCatalogDetailPending/)
-  assert.match(routeSource, /pendingMs: 250/)
+  assert.equal(
+    chartsCatalogCaseRoute.options.pendingComponent,
+    ChartsCatalogDetailPending,
+  )
+  assert.equal(chartsCatalogCaseRoute.options.pendingMs, 250)
   assert.equal($('[role="status"]').text(), 'Loading chart example…')
 })
 


### PR DESCRIPTION
## Summary

Chart examples freeze for me, tested on Helium

- show an accessible pending state while a Charts catalog detail route loads
- lower the route's pending threshold to 250 ms so cold loads give prompt feedback without flashing on warm navigation

## Root cause

Catalog card clicks and history updates are not blocking the browser main thread. The detail loader resolves the selected chart's recursive source files from the Charts repository, and a cold example can spend several seconds filling that server-side cache. Because the route had no pending component, the existing catalog remained unchanged during that asynchronous work and made the page appear frozen.

A production browser probe reproduced the distinction on the same example:

- cold detail server function: 5.61 s
- immediately repeated detail server function: 100 ms
- after the detail response, the chart became ready in under 1 s

This keeps the fix scoped to the actual UI defect: long asynchronous navigation had no feedback. A broader source-loading/cache redesign can still reduce cold latency, but is not required to keep the page responsive and understandable while that work runs.

## Validation

- `pnpm test` — 140 passed, 1 environment-gated skip
- `oxfmt --check` on the changed files
- `tsc --noEmit`
- browser check with a forced 1.5-second loader delay: pending status appeared after 421 ms and the detail page completed normally
- production cold/warm browser probes: 5.61 s / 100 ms detail server function
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading state for chart catalog detail pages.
  - Displays an accessible status message while chart examples are loading.
  - Configured a brief delay before showing the pending state to reduce unnecessary flicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->