### PR TITLE
Fix blog View as Markdown links

### DIFF
--- a/src/components/CopyPageDropdown.tsx
+++ b/src/components/CopyPageDropdown.tsx
@@ -192,7 +192,7 @@ export function CopyPageDropdown({
       markdownCache.set(urlToFetch, content)
       await copyContent(
         content,
-        repo === 'tanstack/tanstack.com'
+        repo === 'tanstack/tanstack.com' && hasPageMarkdownEndpoint
           ? 'Markdown content copied from markdown endpoint'
           : 'Markdown content copied from GitHub',
       )

--- a/src/components/CopyPageDropdown.tsx
+++ b/src/components/CopyPageDropdown.tsx
@@ -140,8 +140,11 @@ export function CopyPageDropdown({
     return queryString ? `${base}?${queryString}` : base
   })()
 
+  const hasPageMarkdownEndpoint =
+    typeof window !== 'undefined' && window.location.pathname.includes('/docs/')
+
   const sourceMarkdownUrl =
-    repo === 'tanstack/tanstack.com'
+    repo === 'tanstack/tanstack.com' && hasPageMarkdownEndpoint
       ? pageMarkdownUrl
       : repo && branch && filePath
         ? `https://raw.githubusercontent.com/${repo}/${branch}/${filePath}`


### PR DESCRIPTION
## What changed

- Use the first-party `.md` endpoint only on docs routes.
- Open repository-backed blog Markdown from the existing raw GitHub source path.

## Why

`CopyPageDropdown` treated every `tanstack/tanstack.com` source file as if its page exposed a local `.md` endpoint. Blog routes do not, so “View as Markdown” opened a 404 even though the exact source file was already available through `repo`, `branch`, and `filePath`.

Fixes #1146.

## Impact

Blog readers can open and copy the original Markdown again. Docs keep their cached first-party Markdown endpoint.

## Validation

- `pnpm test` — TypeScript and type-aware lint clean; 140 tests passed, 1 environment-gated docs smoke test skipped.
- Chrome on the reported post opened `https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/blog/announcing-tanstack-form-v2-alpha.md`.
- `git diff --check`

## Risk

Low. The change only chooses the existing raw-source path outside `/docs/`; no content parsing or route behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page copying for TanStack documentation by using the correct Markdown source within documentation pages.
  * Preserved fallback behavior for other pages and configured source URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->