### PR TITLE
Add ShadCN Charts catalog collection

### DIFF
--- a/src/components/charts/ChartsCatalogPages.tsx
+++ b/src/components/charts/ChartsCatalogPages.tsx
@@ -1,9 +1,13 @@
 import { ArrowsOutSimpleIcon, GridFourIcon } from '@phosphor-icons/react'
 import { ClientOnly, Link } from '@tanstack/react-router'
 import * as React from 'react'
-import type { ChartsCatalogAuthoredSource } from '~/utils/charts-catalog'
 import type { ChartsCatalogIndexCase } from '~/utils/charts-catalog-index'
 import type { ExampleDefinition } from '~/utils/example-workspace'
+import {
+  chartsCatalogCollections,
+  findChartsCatalogCollection,
+  type ChartsCatalogAuthoredSource,
+} from '~/utils/charts-catalog'
 import { ChartsCatalogPreview } from './ChartsCatalogPreview'
 import { ChartsCatalogSource } from './ChartsCatalogSource'
 
@@ -17,9 +21,11 @@ type CatalogCaseMetadata = ChartsCatalogIndexCase
 
 export function ChartsCatalog({
   cases,
+  collection,
   revision,
 }: {
   cases: Array<CatalogCaseMetadata>
+  collection?: (typeof chartsCatalogCollections)[number]
   revision: string
 }) {
   const [query, setQuery] = React.useState('')
@@ -41,9 +47,51 @@ export function ChartsCatalog({
         ))
     )
   })
+  const availableCollections = chartsCatalogCollections
+    .map((metadata) => ({
+      metadata,
+      count: cases.filter(
+        (catalogCase) => catalogCase.collection === metadata.id,
+      ).length,
+    }))
+    .filter((entry) => entry.count > 0)
 
   return (
     <CatalogSurface>
+      {collection ? (
+        <header className="mb-6 max-w-2xl">
+          <Link
+            className="text-sm text-text-muted hover:text-action-primary"
+            preload={false}
+            search={true}
+            to="/charts/catalog"
+          >
+            All examples
+          </Link>
+          <h1 className="mt-2 font-ds-display text-3xl font-bold tracking-tight text-text-primary">
+            {collection.title}
+          </h1>
+          <p className="mt-2 text-text-secondary">{collection.description}</p>
+        </header>
+      ) : availableCollections.length > 0 ? (
+        <nav aria-label="Chart collections" className="mb-4 flex gap-2">
+          {availableCollections.map((entry) => (
+            <Link
+              key={entry.metadata.id}
+              className="rounded-lg border border-border-subtle bg-background-surface px-3 py-2 text-sm font-medium text-text-primary hover:border-action-primary"
+              params={{ collectionId: entry.metadata.id }}
+              preload={false}
+              search={true}
+              to="/charts/catalog/collections/$collectionId"
+            >
+              {entry.metadata.title}
+              <span className="ml-2 font-ds-mono text-ds-mono-caps-xs text-text-muted">
+                {entry.count}
+              </span>
+            </Link>
+          ))}
+        </nav>
+      ) : null}
       <CatalogToolbar
         count={filtered.length}
         family={family}
@@ -103,18 +151,34 @@ export function ChartsCatalogDetail({
     }
   }
 }) {
+  const collection = catalogCase.collection
+    ? findChartsCatalogCollection(catalogCase.collection)
+    : undefined
+
   return (
     <CatalogSurface wide>
       <div className="mb-6 flex flex-wrap items-start justify-between gap-5">
         <div>
-          <Link
-            to="/charts/catalog"
-            search={true}
-            preload={false}
-            className="text-sm text-gray-500 hover:text-blue-600 dark:hover:text-blue-400"
-          >
-            Catalog
-          </Link>
+          {collection ? (
+            <Link
+              className="text-sm text-gray-500 hover:text-blue-600 dark:hover:text-blue-400"
+              params={{ collectionId: collection.id }}
+              preload={false}
+              search={true}
+              to="/charts/catalog/collections/$collectionId"
+            >
+              {collection.title}
+            </Link>
+          ) : (
+            <Link
+              className="text-sm text-gray-500 hover:text-blue-600 dark:hover:text-blue-400"
+              preload={false}
+              search={true}
+              to="/charts/catalog"
+            >
+              Catalog
+            </Link>
+          )}
           <h1 className="mt-2 text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
             {catalogCase.title}
           </h1>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -190,6 +190,7 @@ import { Route as LibraryLibraryIdVersionDocsIndexRouteImport } from './routes/_
 import { Route as ChartsCatalogPreviewsRevisionChar123caseIdChar125DotsvgRouteImport } from './routes/charts.catalog_.previews.$revision.{$caseId}[.]svg'
 import { Route as ApiNotebookProjectsHashQuarantineRouteImport } from './routes/api/notebook/projects.$hash.quarantine'
 import { Route as ApiAuthCliStatusTicketIdRouteImport } from './routes/api/auth/cli/status.$ticketId'
+import { Route as LibraryChartsCatalogCollectionsCollectionIdRouteImport } from './routes/_library/charts.catalog.collections.$collectionId'
 import { Route as LibraryChartsCatalogChartsCaseIdRouteImport } from './routes/_library/charts.catalog.charts.$caseId'
 import { Route as LibraryLibraryIdVersionDocsChar123Char125DotmdRouteImport } from './routes/_library/$libraryId/$version.docs.{$}[.]md'
 import { Route as LibraryLibraryIdVersionDocsNpmStatsRouteImport } from './routes/_library/$libraryId/$version.docs.npm-stats'
@@ -1148,6 +1149,12 @@ const ApiAuthCliStatusTicketIdRoute =
     path: '/api/auth/cli/status/$ticketId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const LibraryChartsCatalogCollectionsCollectionIdRoute =
+  LibraryChartsCatalogCollectionsCollectionIdRouteImport.update({
+    id: '/collections/$collectionId',
+    path: '/collections/$collectionId',
+    getParentRoute: () => LibraryChartsCatalogRoute,
+  } as any)
 const LibraryChartsCatalogChartsCaseIdRoute =
   LibraryChartsCatalogChartsCaseIdRouteImport.update({
     id: '/charts/$caseId',
@@ -1414,6 +1421,7 @@ export interface FileRoutesByFullPath {
   '/$libraryId/$version/docs/npm-stats': typeof LibraryLibraryIdVersionDocsNpmStatsRoute
   '/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
+  '/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/notebook/projects/$hash/quarantine': typeof ApiNotebookProjectsHashQuarantineRoute
   '/charts/catalog/previews/$revision/{$caseId}.svg': typeof ChartsCatalogPreviewsRevisionChar123caseIdChar125DotsvgRoute
@@ -1597,6 +1605,7 @@ export interface FileRoutesByTo {
   '/$libraryId/$version/docs/npm-stats': typeof LibraryLibraryIdVersionDocsNpmStatsRoute
   '/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
+  '/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/notebook/projects/$hash/quarantine': typeof ApiNotebookProjectsHashQuarantineRoute
   '/charts/catalog/previews/$revision/{$caseId}.svg': typeof ChartsCatalogPreviewsRevisionChar123caseIdChar125DotsvgRoute
@@ -1794,6 +1803,7 @@ export interface FileRoutesById {
   '/_library/$libraryId/$version/docs/npm-stats': typeof LibraryLibraryIdVersionDocsNpmStatsRoute
   '/_library/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/_library/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
+  '/_library/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/notebook/projects/$hash/quarantine': typeof ApiNotebookProjectsHashQuarantineRoute
   '/charts/catalog_/previews/$revision/{$caseId}.svg': typeof ChartsCatalogPreviewsRevisionChar123caseIdChar125DotsvgRoute
@@ -1991,6 +2001,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/npm-stats'
     | '/$libraryId/$version/docs/{$}.md'
     | '/charts/catalog/charts/$caseId'
+    | '/charts/catalog/collections/$collectionId'
     | '/api/auth/cli/status/$ticketId'
     | '/api/notebook/projects/$hash/quarantine'
     | '/charts/catalog/previews/$revision/{$caseId}.svg'
@@ -2174,6 +2185,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/npm-stats'
     | '/$libraryId/$version/docs/{$}.md'
     | '/charts/catalog/charts/$caseId'
+    | '/charts/catalog/collections/$collectionId'
     | '/api/auth/cli/status/$ticketId'
     | '/api/notebook/projects/$hash/quarantine'
     | '/charts/catalog/previews/$revision/{$caseId}.svg'
@@ -2370,6 +2382,7 @@ export interface FileRouteTypes {
     | '/_library/$libraryId/$version/docs/npm-stats'
     | '/_library/$libraryId/$version/docs/{$}.md'
     | '/_library/charts/catalog/charts/$caseId'
+    | '/_library/charts/catalog/collections/$collectionId'
     | '/api/auth/cli/status/$ticketId'
     | '/api/notebook/projects/$hash/quarantine'
     | '/charts/catalog_/previews/$revision/{$caseId}.svg'
@@ -3740,6 +3753,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthCliStatusTicketIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_library/charts/catalog/collections/$collectionId': {
+      id: '/_library/charts/catalog/collections/$collectionId'
+      path: '/collections/$collectionId'
+      fullPath: '/charts/catalog/collections/$collectionId'
+      preLoaderRoute: typeof LibraryChartsCatalogCollectionsCollectionIdRouteImport
+      parentRoute: typeof LibraryChartsCatalogRoute
+    }
     '/_library/charts/catalog/charts/$caseId': {
       id: '/_library/charts/catalog/charts/$caseId'
       path: '/charts/$caseId'
@@ -3975,12 +3995,15 @@ interface LibraryChartsCatalogRouteChildren {
   LibraryChartsCatalogAllRoute: typeof LibraryChartsCatalogAllRoute
   LibraryChartsCatalogIndexRoute: typeof LibraryChartsCatalogIndexRoute
   LibraryChartsCatalogChartsCaseIdRoute: typeof LibraryChartsCatalogChartsCaseIdRoute
+  LibraryChartsCatalogCollectionsCollectionIdRoute: typeof LibraryChartsCatalogCollectionsCollectionIdRoute
 }
 
 const LibraryChartsCatalogRouteChildren: LibraryChartsCatalogRouteChildren = {
   LibraryChartsCatalogAllRoute: LibraryChartsCatalogAllRoute,
   LibraryChartsCatalogIndexRoute: LibraryChartsCatalogIndexRoute,
   LibraryChartsCatalogChartsCaseIdRoute: LibraryChartsCatalogChartsCaseIdRoute,
+  LibraryChartsCatalogCollectionsCollectionIdRoute:
+    LibraryChartsCatalogCollectionsCollectionIdRoute,
 }
 
 const LibraryChartsCatalogRouteWithChildren =

--- a/src/routes/_library/charts.catalog.collections.$collectionId.tsx
+++ b/src/routes/_library/charts.catalog.collections.$collectionId.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { ChartsCatalog } from '~/components/charts/ChartsCatalogPages'
+import { getChartsCatalogCollection } from '~/utils/charts-catalog.functions'
+import { seo } from '~/utils/seo'
+
+export const Route = createFileRoute(
+  '/_library/charts/catalog/collections/$collectionId',
+)({
+  loader: async ({ params }) => {
+    const data = await getChartsCatalogCollection({
+      data: { collectionId: params.collectionId },
+    })
+    if (!data) throw notFound()
+    return data
+  },
+  component: ChartsCatalogCollectionRoute,
+  head: ({ loaderData }) => ({
+    meta: seo({
+      title: loaderData
+        ? `${loaderData.collection.title} | TanStack Charts`
+        : 'TanStack Charts',
+      description:
+        loaderData?.collection.description ?? 'TanStack Charts examples.',
+    }),
+  }),
+})
+
+function ChartsCatalogCollectionRoute() {
+  const data = Route.useLoaderData()
+  return (
+    <ChartsCatalog
+      cases={data.cases}
+      collection={data.collection}
+      revision={data.revision}
+    />
+  )
+}

--- a/src/utils/charts-catalog-index.ts
+++ b/src/utils/charts-catalog-index.ts
@@ -52,6 +52,7 @@ const catalogCaseSchema = v.pipe(
     schemaVersion: v.literal(1),
     order: nonNegativeIntegerSchema,
     id: caseIdSchema,
+    collection: v.optional(caseIdSchema),
     title: nonEmptyStringSchema,
     family: nonEmptyStringSchema,
     intent: nonEmptyStringSchema,

--- a/src/utils/charts-catalog.functions.ts
+++ b/src/utils/charts-catalog.functions.ts
@@ -1,11 +1,19 @@
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import * as v from 'valibot'
-import { chartsCatalogCaseIdSchema } from './charts-catalog'
+import {
+  chartsCatalogCaseIdSchema,
+  chartsCatalogCollectionIdSchema,
+  findChartsCatalogCollection,
+} from './charts-catalog'
 import { chartsCatalogIndexCacheHeaders } from './charts-catalog-index'
 
 const caseInputSchema = v.strictObject({
   caseId: chartsCatalogCaseIdSchema,
+})
+
+const collectionInputSchema = v.strictObject({
+  collectionId: chartsCatalogCollectionIdSchema,
 })
 
 const embedCaseInputSchema = v.strictObject({
@@ -25,6 +33,26 @@ export const getChartsCatalogAll = createServerFn({ method: 'GET' }).handler(
     }
   },
 )
+
+export const getChartsCatalogCollection = createServerFn({ method: 'GET' })
+  .validator(collectionInputSchema)
+  .handler(async ({ data }) => {
+    const collection = findChartsCatalogCollection(data.collectionId)
+    if (!collection) return null
+
+    const publication = await loadPublication()
+    const cases = publication.index.cases.filter(
+      (catalogCase) => catalogCase.collection === collection.id,
+    )
+    if (cases.length === 0) return null
+
+    setCatalogResponseHeaders()
+    return {
+      collection,
+      revision: publication.revision,
+      cases,
+    }
+  })
 
 export const getChartsCatalogLanding = createServerFn({
   method: 'GET',

--- a/src/utils/charts-catalog.ts
+++ b/src/utils/charts-catalog.ts
@@ -14,6 +14,26 @@ export const chartsCatalogCaseIdSchema = v.pipe(
   v.regex(chartsCatalogCaseIdPattern, 'Invalid catalog case ID'),
 )
 
+export const chartsCatalogCollectionIdSchema = v.pipe(
+  v.string(),
+  v.regex(chartsCatalogCaseIdPattern, 'Invalid catalog collection ID'),
+)
+
+export const chartsCatalogCollections = [
+  {
+    id: 'shadcn',
+    title: 'shadcn/ui Charts',
+    description:
+      'TanStack Charts implementations of every official shadcn/ui chart example, plus the dashboard.',
+  },
+]
+
+export function findChartsCatalogCollection(collectionId: string) {
+  return chartsCatalogCollections.find(
+    (collection) => collection.id === collectionId,
+  )
+}
+
 export function isChartsCatalogCaseId(value: string) {
   return chartsCatalogCaseIdPattern.test(value)
 }
@@ -35,8 +55,15 @@ export type ChartsCatalogAuthoredSource = {
 }
 
 export function getChartsCatalogSitemapEntries(index: ChartsCatalogIndex) {
+  const collections = chartsCatalogCollections.filter((collection) =>
+    index.cases.some((catalogCase) => catalogCase.collection === collection.id),
+  )
+
   return [
     { path: chartsCatalogBasePath },
+    ...collections.map((collection) => ({
+      path: `${chartsCatalogBasePath}collections/${collection.id}/`,
+    })),
     ...index.cases.map((catalogCase) => ({
       path: `${chartsCatalogBasePath}charts/${catalogCase.id}/`,
     })),

--- a/tests/charts-catalog-index.test.ts
+++ b/tests/charts-catalog-index.test.ts
@@ -9,11 +9,16 @@ import { resetGitHubContentCacheForTest } from '../src/utils/github-content-cach
 
 const revision = '1'.repeat(40)
 
-function createCatalogCase(id = '01-line-gaps', order = 1) {
+function createCatalogCase(
+  id = '01-line-gaps',
+  order = 1,
+  collection?: string,
+) {
   return {
     schemaVersion: 1,
     order,
     id,
+    ...(collection ? { collection } : {}),
     title: 'Apple stock line with seasonal gaps',
     family: 'trend',
     intent: 'Show gaps in a time series.',
@@ -38,21 +43,22 @@ function createCatalogCase(id = '01-line-gaps', order = 1) {
   }
 }
 
-function createCatalogIndex() {
+function createCatalogIndex(collection?: string) {
   return {
     schemaVersion: 1,
     source: {
       repo: 'tanstack/charts',
       pathRoot: 'benchmarks/conformance/',
     },
-    cases: [createCatalogCase()],
+    cases: [createCatalogCase('01-line-gaps', 1, collection)],
   }
 }
 
 test('catalog index retains only the site-owned contract', () => {
-  const index = parseChartsCatalogIndex(createCatalogIndex())
+  const index = parseChartsCatalogIndex(createCatalogIndex('shadcn'))
 
   assert.equal(index.cases[0]?.id, '01-line-gaps')
+  assert.equal(index.cases[0]?.collection, 'shadcn')
   assert.equal('geometry' in (index.cases[0] ?? {}), false)
   assert.equal(
     chartsCatalogIndexCacheHeaders['Cache-Tag'],

--- a/tests/charts-catalog-site-contracts.test.ts
+++ b/tests/charts-catalog-site-contracts.test.ts
@@ -24,6 +24,7 @@ test('sitemap exposes catalog pages but not runtime resources', () => {
         schemaVersion: 1,
         order: 1,
         id: '01-line',
+        collection: 'shadcn',
         title: 'Line chart',
         family: 'trend',
         intent: 'Show a line.',
@@ -50,6 +51,7 @@ test('sitemap exposes catalog pages but not runtime resources', () => {
 
   assert.deepEqual(getChartsCatalogSitemapEntries(index), [
     { path: '/charts/catalog/' },
+    { path: '/charts/catalog/collections/shadcn/' },
     { path: '/charts/catalog/charts/01-line/' },
   ])
 })

--- a/tests/charts-sidebar-navigation.test.ts
+++ b/tests/charts-sidebar-navigation.test.ts
@@ -6,6 +6,7 @@ import {
 
 assert.equal(isChartsCatalogTarget('/charts/catalog'), true)
 assert.equal(isChartsCatalogTarget('/charts/catalog/charts/01-line'), true)
+assert.equal(isChartsCatalogTarget('/charts/catalog/collections/shadcn'), true)
 assert.equal(isChartsCatalogTarget('/charts/catalogue'), false)
 
 const groups = [


### PR DESCRIPTION
## Summary
- add a native Charts catalog collection route
- expose the ShadCN collection in the catalog and sitemap
- keep collection/detail navigation within the Examples tab

## Validation
- pnpm test
- local visual audit of collection and detail routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added chart collections to the catalog, including collection pages with headings, descriptions, breadcrumbs, and example counts.
  - Added the “shadcn” collection and navigation to browse its charts.
  - Added collection-specific sitemap entries and SEO metadata.
- **Bug Fixes**
  - Unknown or empty collections now return a not-found result instead of displaying incomplete content.
- **Tests**
  - Added coverage for collection parsing, navigation, sitemap generation, and catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->