### PR TITLE
feat(Select): mark the latest version with a badge instead of a label suffix

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -66,7 +66,7 @@ export function Select<T extends SelectOption>({
             ) : null}
             <span className="truncate font-medium">{selectedOption.label}</span>
             {selectedOption.badge ? (
-              <Badge variant="success">{selectedOption.badge}</Badge>
+              <Badge>{selectedOption.badge}</Badge>
             ) : null}
             <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
               <CaretUpDownIcon
@@ -97,9 +97,7 @@ export function Select<T extends SelectOption>({
                 />
               ) : null}
               <span className="truncate">{option.label}</span>
-              {option.badge ? (
-                <Badge variant="success">{option.badge}</Badge>
-              ) : null}
+              {option.badge ? <Badge>{option.badge}</Badge> : null}
               {selected === option.value ? (
                 <CheckIcon
                   className="h-4 w-4 absolute right-2 text-gray-800 dark:text-gray-400"

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import { Badge } from '~/components/ds/ui'
 import { CaretUpDownIcon } from '@phosphor-icons/react/CaretUpDown'
 import { CheckIcon } from '@phosphor-icons/react/Check'
 import { twMerge } from 'tailwind-merge'
@@ -13,6 +14,7 @@ export type SelectOption = {
   label: string
   value: string
   logo?: string
+  badge?: string
 }
 
 export type SelectProps<T extends SelectOption> = {
@@ -63,6 +65,9 @@ export function Select<T extends SelectOption>({
               </span>
             ) : null}
             <span className="truncate font-medium">{selectedOption.label}</span>
+            {selectedOption.badge ? (
+              <Badge variant="success">{selectedOption.badge}</Badge>
+            ) : null}
             <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
               <CaretUpDownIcon
                 className="h-4 w-4 opacity-40"
@@ -92,6 +97,9 @@ export function Select<T extends SelectOption>({
                 />
               ) : null}
               <span className="truncate">{option.label}</span>
+              {option.badge ? (
+                <Badge variant="success">{option.badge}</Badge>
+              ) : null}
               {selected === option.value ? (
                 <CheckIcon
                   className="h-4 w-4 absolute right-2 text-gray-800 dark:text-gray-400"

--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -101,7 +101,7 @@ function useVersionConfig({
     const available = versions.map(
       (version): SelectOption =>
         version === latestVersion
-          ? { label: `${version} - Latest`, value: 'latest' }
+          ? { label: version, value: 'latest', badge: 'Latest' }
           : { label: version, value: version },
     )
 


### PR DESCRIPTION
The version picker rendered the current version as one string, `v5 - Latest`, so the version number and the "this is current" marker competed for the same reading. Pulling the marker into a badge lets the number carry the label on its own.

`SelectOption` gains an optional `badge`, matching the existing optional `logo`:

```tsx
{ label: version, value: 'latest', badge: 'Latest' }
```

`label` stays a `string`, so the two places `Select` consumes it as text (`alt={`${option.label} logo`}`) are unaffected.

The badge is the DS `Badge` with no props and no style overrides, so it renders the neutral `default` variant (`bg-background-subtle` / `text-text-secondary`). That keeps it clear of every library's accent colour — the docs sidebar sits inside a library-themed page, and a coloured badge would compete there. UI-chrome badges across `admin/` and `account/` use the component's defaults the same way; the squared, mono, uppercase treatment belongs to the landing pages, which are a separate visual language.

### Scope

`SelectOption` is constructed in exactly one place (`VersionSelect`). `FrameworkSelect` passes no `badge`, so its render path is unchanged — verified by measurement, not just by reading: its trigger still measures 207px with no badge node. `ShopSelect` is an unrelated component in `shop/ui/`. Nothing in `src/`, `tests/`, or `scripts/` depends on the `" - Latest"` string.

### Verified in the browser

`VersionSelect` renders in two places in `LibraryLayout` — the desktop sidebar and the mobile drawer — and both were checked:

| | trigger width | overflow |
|---|---|---|
| desktop sidebar (1152px) | 207px | none |
| mobile drawer (500px) | 468px | none |

In the open dropdown the badge's right edge sits 66px clear of the check mark, so the row's `pr-8` reservation still holds. Checked on Query (v5/v4/v3) and Router (v1, single option).

**Accessibility is unchanged.** The badge is `display: flex`, so the accessible name computation inserts a boundary: `innerText` reads `"v5\nLatest"` where it previously read `"v5 - Latest"`. Both announce as two words. Separately, the select trigger has no accessible name at all — but `FrameworkSelect`, which this PR does not touch, has the same gap, so it predates this change and is left for its own fix.

`tsc`, `oxlint` and the 140 unit tests pass.

### Screenshot

#### AS-IS

<img width="241" height="430" alt="image" src="https://github.com/user-attachments/assets/137c777d-7572-4f6d-83a7-846c8a1bee5e" />

#### TO-BE

<img width="238" height="432" alt="image" src="https://github.com/user-attachments/assets/1a0c7f7a-6d3a-4ef9-a6a3-ab04d9596ffd" />

<img width="241" height="429" alt="image" src="https://github.com/user-attachments/assets/1d659fa1-02f3-43dd-b04d-41bafffcf20e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select options can now display an optional badge alongside their labels in the selected value and dropdown list.

* **UI Improvements**
  * The latest-version option now shows only the version number with a separate “Latest” badge for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
