### PR TITLE
fix(Tooltip): raise tooltips above the navbar, modals and dropdowns

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -72,7 +72,7 @@ export function Tooltip({
           <div
             ref={refs.setFloating /* eslint-disable-line react-hooks/refs */}
             style={floatingStyles}
-            className={`z-50 rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-lg dark:bg-gray-800 ${className}`}
+            className={`z-1300 rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-lg dark:bg-gray-800 ${className}`}
           >
             {content}
           </div>

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -33,7 +33,7 @@ export function Tooltip({
             align={align}
             sideOffset={5}
             className={twMerge(
-              'z-50 rounded-lg px-3 py-2 text-xs',
+              'z-1300 rounded-lg px-3 py-2 text-xs',
               'bg-background-inverse text-text-inverse',
               'shadow-lg',
               'animate-in fade-in-0 zoom-in-95',


### PR DESCRIPTION
Hovering the **Ask AI** button in the navbar produced a tooltip whose top edge was clipped by the navbar itself.

The tooltip opens `side="bottom"`, so it starts 55px down — inside the navbar's 0–58px band. The navbar is `z-[100]` and the tooltip was `z-50`, so the navbar won the overlap.

### Why 1300

The repo has no declared z-index scale, so the layers were read off the code:

| layer | z-index |
|---|---|
| dropdown | 1200 |
| modal | 1000 / 999 |
| navbar | 100 |
| tooltip | **50** |

Every layer follows the usual ordering except the tooltip, which sat 24× below the dropdown it is supposed to annotate. Bootstrap, Chakra and MUI all place tooltips at or near the top of the stack for the same reason: a tooltip explains another control, so nothing should cover it.

`z-[1300]` puts it above the dropdown, which is the highest ordinary layer here.

Both tooltip implementations carried `z-50` and both are fixed — `~/ui/Tooltip` (5 consumers) and `~/components/Tooltip` (8 consumers, npm-stats).

### Verified in the browser

Measured rather than eyeballed, since the overlap is only a few pixels:

```
tooltip   top 55 → bottom 87   z-index 1300
navbar    top  0 → bottom 58   z-index 100
```

`document.elementFromPoint` at `(1035, 57)` — a point inside the overlap — now returns the tooltip. Before the change it returned the navbar.

`tsc`, `oxlint` and the 142 unit tests pass.

### Screenshot

#### AS-IS

<img width="811" height="296" alt="image" src="https://github.com/user-attachments/assets/14901222-7ac0-4be6-92e9-a519e17261f1" />

#### TO-BE

<img width="697" height="317" alt="image" src="https://github.com/user-attachments/assets/a0fe2d89-f161-4814-aab1-1b4ff81356ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip layering so tooltips appear above other interface elements and remain visible when overlapping content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->