### PR TITLE
Open external Markdown links in new tabs

### DIFF
--- a/src/components/markdown/MarkdownLink.tsx
+++ b/src/components/markdown/MarkdownLink.tsx
@@ -14,6 +14,19 @@ function isRelativeLink(link: string) {
   )
 }
 
+function shouldOpenInNewTab(link: string) {
+  if (!/^https:\/\//i.test(link)) {
+    return false
+  }
+
+  try {
+    const hostname = new URL(link).hostname
+    return hostname !== 'tanstack.com' && !hostname.endsWith('.tanstack.com')
+  } catch {
+    return false
+  }
+}
+
 function isStaticAssetLink(link: string) {
   const [pathname] = link.split(/[?#]/)
   return /\.[a-z0-9]+$/i.test(pathname) && !pathname.endsWith('.md')
@@ -76,8 +89,18 @@ export function MarkdownLink({
   }
 
   if (!isRelativeLink(href)) {
-    // eslint-disable-next-line jsx-a11y/anchor-has-content
-    return <a {...rest} href={hrefProp} />
+    const openInNewTab = shouldOpenInNewTab(href)
+
+    return (
+      <a
+        {...rest}
+        href={hrefProp}
+        target={openInNewTab ? '_blank' : undefined}
+        rel={openInNewTab ? 'noopener noreferrer' : undefined}
+      >
+        {rest.children}
+      </a>
+    )
   }
 
   const [hrefWithoutHash, hash] = href.split('#')

--- a/tests/markdown-link.test.ts
+++ b/tests/markdown-link.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MarkdownLink } from '../src/components/markdown/MarkdownLink'
+
+function renderLink(href: string) {
+  return renderToStaticMarkup(
+    createElement(MarkdownLink, { href }, 'Documentation'),
+  )
+}
+
+test('external HTTPS Markdown links open in a new tab', () => {
+  const html = renderLink('https://example.com/docs')
+
+  assert.match(html, /target="_blank"/)
+  assert.match(html, /rel="noopener noreferrer"/)
+})
+
+test('TanStack HTTPS Markdown links stay in the current tab', () => {
+  for (const href of [
+    'https://tanstack.com/table/latest',
+    'https://docs.tanstack.com/reference',
+  ]) {
+    const html = renderLink(href)
+
+    assert.doesNotMatch(html, /target=/)
+    assert.doesNotMatch(html, /rel=/)
+  }
+})
+
+test('lookalike TanStack hostnames still open in a new tab', () => {
+  const html = renderLink('https://tanstack.com.example.org/docs')
+
+  assert.match(html, /target="_blank"/)
+  assert.match(html, /rel="noopener noreferrer"/)
+})
+
+test('non-HTTPS Markdown links keep their existing behavior', () => {
+  const html = renderLink('http://example.com/docs')
+
+  assert.doesNotMatch(html, /target=/)
+  assert.doesNotMatch(html, /rel=/)
+})


### PR DESCRIPTION
## What changed

- open absolute HTTPS links from rendered Markdown in a new tab
- add `noopener noreferrer` to those external anchors
- keep `tanstack.com` and all of its subdomains in the current tab
- add coverage for external domains, TanStack domains, lookalike hostnames, and non-HTTPS links

## Why

Documentation frequently links to third-party resources. Opening those HTTPS destinations separately preserves the reader's place in the docs, while TanStack-owned links should continue navigating in the current tab.

## Impact

Markdown links to external HTTPS hosts now render with `target="_blank"` and `rel="noopener noreferrer"`. Links to `tanstack.com` or subdomains such as `docs.tanstack.com` retain the existing same-tab behavior. Lookalike hosts such as `tanstack.com.example.org` remain external.

## Validation

- `pnpm test`
- focused Markdown link rendering tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External HTTPS links now open in a new tab with improved security protections.
  * Trusted TanStack links continue opening in the same tab.
  * Invalid, non-HTTPS, and lookalike TanStack links retain same-tab behavior.

* **Bug Fixes**
  * Improved rendering and accessibility for external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->