### PR TITLE
feat(seo): add site and blog structured data

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -25,16 +25,22 @@ const posts = defineCollection({
   name: 'posts',
   directory: './src/blog',
   include: '*.md',
-  schema: z.object({
-    title: z.string(),
-    published: z.iso.date(),
-    draft: z.boolean().optional(),
-    excerpt: z.string(),
-    authors: z.string().array(),
-    library: libraryListSchema.optional(),
-    content: z.string(),
-    redirect_from: z.string().array().optional(),
-  }),
+  schema: z
+    .object({
+      title: z.string(),
+      published: z.iso.date(),
+      updated: z.iso.date().optional(),
+      draft: z.boolean().optional(),
+      excerpt: z.string(),
+      authors: z.string().array(),
+      library: libraryListSchema.optional(),
+      content: z.string(),
+      redirect_from: z.string().array().optional(),
+    })
+    .refine((post) => !post.updated || post.updated >= post.published, {
+      message: 'updated must be on or after published',
+      path: ['updated'],
+    }),
   transform: ({ content, ...post }) => {
     // Extract header image (first image after frontmatter)
     const headerImageMatch = content.match(/!\[([^\]]*)\]\(([^)]+)\)/)

--- a/src/blog/incident-followup.md
+++ b/src/blog/incident-followup.md
@@ -1,6 +1,7 @@
 ---
 title: 'Hardening TanStack After the npm Compromise'
 published: 2026-05-12
+updated: 2026-05-15
 draft: false
 excerpt: "A companion to our incident postmortem: what we're changing across the org so the May 11 supply-chain attack can't happen the same way again."
 authors:

--- a/src/blog/npm-supply-chain-compromise-postmortem.md
+++ b/src/blog/npm-supply-chain-compromise-postmortem.md
@@ -1,6 +1,7 @@
 ---
 title: 'Postmortem: TanStack npm supply-chain compromise'
 published: 2026-05-11
+updated: 2026-05-15
 excerpt: On 2026-05-11, an attacker chained a pull_request_target Pwn Request, GitHub Actions cache poisoning across the fork↔base trust boundary, and OIDC token extraction from runner memory to publish 84 malicious versions across 42 @tanstack/* packages on npm. Full postmortem.
 authors:
   - Tanner Linsley

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react'
 import { Link } from '@tanstack/react-router'
+import { LinkedinLogoIcon } from '@phosphor-icons/react/LinkedinLogo'
 import { BSkyIcon } from '~/components/icons/BSkyIcon'
 import { BrandXIcon } from '~/components/icons/BrandXIcon'
 import { GithubIcon } from '~/components/icons/GithubIcon'
@@ -88,6 +89,11 @@ const SOCIAL_LINKS: Array<
     label: 'YouTube',
     to: 'https://youtube.com/@tan_stack',
     Icon: YouTubeIcon,
+  },
+  {
+    label: 'LinkedIn',
+    to: 'https://www.linkedin.com/company/tanstack',
+    Icon: LinkedinLogoIcon,
   },
 ]
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,6 +27,7 @@ import { HeartIcon } from '@phosphor-icons/react/Heart'
 import { InfinityIcon } from '@phosphor-icons/react/Infinity'
 import { LifebuoyIcon } from '@phosphor-icons/react/Lifebuoy'
 import { ListIcon } from '@phosphor-icons/react/List'
+import { LinkedinLogoIcon } from '@phosphor-icons/react/LinkedinLogo'
 import { MagnifyingGlassIcon } from '@phosphor-icons/react/MagnifyingGlass'
 import { MailboxIcon } from '@phosphor-icons/react/Mailbox'
 import { NotebookIcon } from '@phosphor-icons/react/Notebook'
@@ -1699,6 +1700,11 @@ const SOCIAL_LINKS = [
     label: 'Instagram',
     href: 'https://instagram.com/tan_stack',
     Icon: InstagramIcon,
+  },
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/company/tanstack',
+    Icon: LinkedinLogoIcon,
   },
 ] as const
 

--- a/src/routes/blog.$.tsx
+++ b/src/routes/blog.$.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { seo } from '~/utils/seo'
 import { PostNotFound } from './blog'
-import { formatAuthors } from '~/utils/blog-format'
 import * as React from 'react'
 import { MarkdownContent } from '~/components/markdown'
 import { Card } from '~/components/Card'
@@ -16,7 +14,7 @@ import { Breadcrumbs } from '~/components/Breadcrumbs'
 import { CoverFallback } from '~/components/CoverFallback'
 import { fetchBlogPost } from '~/utils/blog.functions'
 import { parseSiteMarkdown } from '~/utils/markdown'
-import { getAbsoluteOptimizedImageUrl } from '~/utils/optimizedImage'
+import { getBlogPostHead, getBlogSocialImageUrl } from '~/utils/blog-post-seo'
 
 export const Route = createFileRoute('/blog/$')({
   staleTime: Infinity,
@@ -30,40 +28,11 @@ export const Route = createFileRoute('/blog/$')({
     return fetchBlogPost({ data: blogPath })
   },
   head: ({ loaderData }) => {
-    const getSocialImageUrl = (headerImage?: string) => {
-      if (!headerImage) return undefined
+    const socialImage = getBlogSocialImageUrl(loaderData?.headerImage)
 
-      if (headerImage.startsWith('http')) {
-        return headerImage
-      }
-
-      return getAbsoluteOptimizedImageUrl(headerImage, {
-        fit: 'cover',
-        format: 'auto',
-        height: 630,
-        quality: 80,
-        width: 1200,
-      })
-    }
-
-    return {
-      meta: loaderData
-        ? [
-            ...seo({
-              title: `${loaderData?.title ?? 'Docs'} | TanStack Blog`,
-              description: loaderData?.description,
-              image: getSocialImageUrl(loaderData?.headerImage),
-              noindex: loaderData?.isUnpublished,
-            }),
-            {
-              name: 'author',
-              content: `${
-                loaderData.authors.length > 1 ? 'co-authored by ' : ''
-              }${formatAuthors(loaderData.authors)}`,
-            },
-          ]
-        : [],
-    }
+    return getBlogPostHead(
+      loaderData ? { ...loaderData, socialImage } : undefined,
+    )
   },
   notFoundComponent: () => <PostNotFound />,
   component: BlogPost,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,6 +27,7 @@ import { useLibrariesOverlay } from '~/contexts/LibrariesOverlayContext'
 import { fetchRecentPosts } from '~/utils/blog.functions'
 import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 import { seo } from '~/utils/seo'
+import { getTanStackHomepageJsonLd } from '~/utils/organization-structured-data'
 
 export const Route = createFileRoute('/')({
   loader: async ({ context: { queryClient } }) => {
@@ -44,6 +45,12 @@ export const Route = createFileRoute('/')({
       description:
         'Headless, type-safe, composable tools for building modern web applications that work naturally for developers and reliably for agents.',
     }),
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(getTanStackHomepageJsonLd()),
+      },
+    ],
   }),
   component: Index,
 })

--- a/src/utils/blog-format.ts
+++ b/src/utils/blog-format.ts
@@ -1,5 +1,6 @@
 import { matchSorter } from 'match-sorter'
 import { findLibrary, type LibrarySlim } from '~/libraries'
+import { SITE_URL } from '~/utils/site'
 
 const listJoiner = new Intl.ListFormat('en-US', {
   style: 'long',
@@ -22,6 +23,17 @@ export type BlogCardPost = {
   source?: string
 }
 
+export type BlogAuthorIdentity = {
+  type: 'Organization' | 'Person'
+  name: string
+  url?: string
+}
+
+type BlogAuthorProfile = {
+  name: string
+  github: string
+}
+
 export function normalizeBlogAuthor(author: string) {
   return authorAliases.get(author) ?? author
 }
@@ -40,6 +52,33 @@ export function normalizeBlogAuthors(authors: Array<string>) {
   }
 
   return normalizedAuthors
+}
+
+export function getBlogAuthorIdentities(
+  authors: Array<string>,
+  profiles: ReadonlyArray<BlogAuthorProfile>,
+): Array<BlogAuthorIdentity> {
+  const normalizedAuthors = normalizeBlogAuthors(authors)
+
+  if (!normalizedAuthors.length) {
+    return [
+      {
+        type: 'Organization',
+        name: 'TanStack',
+        url: `${SITE_URL}/`,
+      },
+    ]
+  }
+
+  return normalizedAuthors.map((name) => {
+    const profile = profiles.find((candidate) => candidate.name === name)
+
+    return {
+      type: 'Person',
+      name,
+      ...(profile ? { url: `https://github.com/${profile.github}` } : {}),
+    }
+  })
 }
 
 export function formatAuthors(authors: Array<string>) {
@@ -73,6 +112,13 @@ export function formatPublishedDate(published: string) {
 
 export function isPublishedDateReleased(published: string, now = new Date()) {
   return published <= getUtcDateString(now)
+}
+
+export function isBlogPostUnpublished(
+  post: { draft?: boolean; published: string },
+  now = new Date(),
+) {
+  return Boolean(post.draft) || !isPublishedDateReleased(post.published, now)
 }
 
 export function publishedDateToUTCString(published: string) {

--- a/src/utils/blog-post-seo.ts
+++ b/src/utils/blog-post-seo.ts
@@ -1,0 +1,109 @@
+import type { BlogAuthorIdentity } from '~/utils/blog-format'
+import { formatAuthors } from '~/utils/blog-format'
+import {
+  getTanStackOrganizationJsonLd,
+  TANSTACK_ORGANIZATION_ID,
+} from '~/utils/organization-structured-data'
+import { getAbsoluteOptimizedImageUrl } from '~/utils/optimizedImage'
+import { canonicalUrl, seo } from '~/utils/seo'
+
+export type BlogPostHeadData = {
+  authorIdentities: Array<BlogAuthorIdentity>
+  authors: Array<string>
+  description: string
+  isUnpublished: boolean
+  published: string
+  slug: string
+  socialImage?: string
+  title: string
+  updated?: string
+}
+
+export function getBlogSocialImageUrl(headerImage: string | undefined) {
+  if (!headerImage) {
+    return undefined
+  }
+
+  if (headerImage.startsWith('http')) {
+    return headerImage
+  }
+
+  return getAbsoluteOptimizedImageUrl(headerImage, {
+    fit: 'cover',
+    format: 'auto',
+    height: 630,
+    quality: 80,
+    width: 1200,
+  })
+}
+
+export function getBlogPostingJsonLd(post: BlogPostHeadData) {
+  const pageUrl = canonicalUrl(`/blog/${post.slug}`)
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      getTanStackOrganizationJsonLd(),
+      {
+        '@type': 'BlogPosting' as const,
+        '@id': `${pageUrl}#blog-post`,
+        headline: post.title,
+        description: post.description,
+        url: pageUrl,
+        mainEntityOfPage: {
+          '@type': 'WebPage' as const,
+          '@id': pageUrl,
+        },
+        ...(post.socialImage ? { image: post.socialImage } : {}),
+        datePublished: post.published,
+        ...(post.updated ? { dateModified: post.updated } : {}),
+        author: post.authorIdentities.map((author) =>
+          author.type === 'Organization' && author.name === 'TanStack'
+            ? { '@id': TANSTACK_ORGANIZATION_ID }
+            : {
+                '@type': author.type,
+                name: author.name,
+                ...(author.url ? { url: author.url } : {}),
+              },
+        ),
+        publisher: {
+          '@id': TANSTACK_ORGANIZATION_ID,
+        },
+      },
+    ],
+  }
+}
+
+export function getBlogPostHead(post: BlogPostHeadData | undefined) {
+  if (!post) {
+    return { meta: [], scripts: [] }
+  }
+
+  return {
+    meta: [
+      ...seo({
+        title: `${post.title} | TanStack Blog`,
+        description: post.description,
+        image: post.socialImage,
+        noindex: post.isUnpublished,
+        ogType: 'article',
+        articlePublishedTime: post.published,
+        articleModifiedTime: post.updated,
+      }),
+      {
+        name: 'author',
+        content: `${
+          post.authors.length > 1 ? 'co-authored by ' : ''
+        }${formatAuthors(post.authors)}`,
+      },
+    ],
+    scripts: post.isUnpublished
+      ? []
+      : [
+          {
+            type: 'application/ld+json',
+            children: JSON.stringify(getBlogPostingJsonLd(post)),
+          },
+        ],
+  }
+}

--- a/src/utils/blog.functions.ts
+++ b/src/utils/blog.functions.ts
@@ -4,6 +4,7 @@ import { setResponseHeaders } from '@tanstack/react-start/server'
 import { allPosts } from 'content-collections'
 import * as v from 'valibot'
 import { findLibrary, type LibraryId } from '~/libraries'
+import { allMaintainers } from '~/libraries/maintainers'
 import {
   getPostsForLibrary,
   getVisiblePosts,
@@ -14,8 +15,10 @@ import {
   type BlogCardPost,
   formatAuthors,
   formatPublishedDate,
+  getBlogAuthorIdentities,
   getBlogLibraries,
-  isPublishedDateReleased,
+  isBlogPostUnpublished,
+  normalizeBlogAuthors,
 } from '~/utils/blog-format'
 import { getExternalBlogPosts } from '~/utils/external-blog-posts.server'
 import { buildRedirectManifest } from './redirects'
@@ -117,16 +120,18 @@ export const fetchBlogPost = createServerFn({ method: 'GET' })
       }),
     )
 
-    const blogContent = `<small><em>by ${formatAuthors(post.authors)} on ${formatPublishedDate(
+    const authors = normalizeBlogAuthors(post.authors)
+    const blogContent = `<small><em>by ${formatAuthors(authors)} on ${formatPublishedDate(
       post.published || '1970-01-01',
     )}.</em></small>
 
 ${post.content}`
 
-    const isUnpublished = post.draft || !isPublishedDateReleased(post.published)
+    const isUnpublished = isBlogPostUnpublished(post)
 
     return {
-      authors: post.authors,
+      authorIdentities: getBlogAuthorIdentities(authors, allMaintainers),
+      authors,
       content: blogContent,
       description: post.excerpt,
       filePath: `src/blog/${data}.md`,
@@ -134,7 +139,9 @@ ${post.content}`
       isUnpublished,
       library: post.library,
       published: post.published,
+      slug: post.slug,
       title: post.title,
+      updated: post.updated,
     }
   })
 

--- a/src/utils/organization-structured-data.ts
+++ b/src/utils/organization-structured-data.ts
@@ -1,0 +1,48 @@
+import { SITE_URL } from '~/utils/site'
+
+const siteUrl = `${SITE_URL.replace(/\/$/, '')}/`
+
+export const TANSTACK_ORGANIZATION_ID = `${siteUrl}#organization`
+export const TANSTACK_WEBSITE_ID = `${siteUrl}#website`
+
+export function getTanStackWebsiteJsonLd() {
+  return {
+    '@type': 'WebSite' as const,
+    '@id': TANSTACK_WEBSITE_ID,
+    name: 'TanStack',
+    url: siteUrl,
+    publisher: {
+      '@id': TANSTACK_ORGANIZATION_ID,
+    },
+  }
+}
+
+export function getTanStackOrganizationJsonLd() {
+  return {
+    '@type': 'Organization' as const,
+    '@id': TANSTACK_ORGANIZATION_ID,
+    name: 'TanStack',
+    url: siteUrl,
+    logo: {
+      '@type': 'ImageObject' as const,
+      '@id': `${siteUrl}#organization-logo`,
+      url: `${siteUrl}images/brand/social/stacked-green@2x.png`,
+      contentUrl: `${siteUrl}images/brand/social/stacked-green@2x.png`,
+      width: 800,
+      height: 800,
+    },
+    sameAs: [
+      'https://github.com/TanStack',
+      'https://x.com/tan_stack',
+      'https://bsky.app/profile/tanstack.com',
+      'https://youtube.com/@tan_stack',
+    ],
+  }
+}
+
+export function getTanStackHomepageJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [getTanStackWebsiteJsonLd(), getTanStackOrganizationJsonLd()],
+  }
+}

--- a/src/utils/organization-structured-data.ts
+++ b/src/utils/organization-structured-data.ts
@@ -26,8 +26,8 @@ export function getTanStackOrganizationJsonLd() {
     logo: {
       '@type': 'ImageObject' as const,
       '@id': `${siteUrl}#organization-logo`,
-      url: `${siteUrl}images/brand/social/stacked-green@2x.png`,
-      contentUrl: `${siteUrl}images/brand/social/stacked-green@2x.png`,
+      url: `${siteUrl}images/brand/social/stacked-light@2x.png`,
+      contentUrl: `${siteUrl}images/brand/social/stacked-light@2x.png`,
       width: 800,
       height: 800,
     },

--- a/src/utils/organization-structured-data.ts
+++ b/src/utils/organization-structured-data.ts
@@ -36,6 +36,7 @@ export function getTanStackOrganizationJsonLd() {
       'https://x.com/tan_stack',
       'https://bsky.app/profile/tanstack.com',
       'https://youtube.com/@tan_stack',
+      'https://www.linkedin.com/company/tanstack',
     ],
   }
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -68,6 +68,9 @@ type SeoOptions = {
   image?: string
   keywords?: string
   noindex?: boolean
+  ogType?: 'article' | 'website'
+  articlePublishedTime?: string
+  articleModifiedTime?: string
 }
 
 export const seo = ({
@@ -76,6 +79,9 @@ export const seo = ({
   keywords,
   image,
   noindex,
+  ogType = 'website',
+  articlePublishedTime,
+  articleModifiedTime,
 }: SeoOptions) => {
   const tags = [
     { title },
@@ -85,10 +91,26 @@ export const seo = ({
     { name: 'twitter:description', content: description },
     { name: 'twitter:creator', content: '@tan_stack' },
     { name: 'twitter:site', content: '@tan_stack' },
-    { property: 'og:type', content: 'website' },
+    { property: 'og:type', content: ogType },
     { property: 'og:site_name', content: 'TanStack' },
     { property: 'og:title', content: title },
     { property: 'og:description', content: description },
+    ...(ogType === 'article' && articlePublishedTime
+      ? [
+          {
+            property: 'article:published_time',
+            content: articlePublishedTime,
+          },
+        ]
+      : []),
+    ...(ogType === 'article' && articleModifiedTime
+      ? [
+          {
+            property: 'article:modified_time',
+            content: articleModifiedTime,
+          },
+        ]
+      : []),
     ...(image
       ? [
           { name: 'twitter:image', content: image },

--- a/tests/blog-post-seo.test.ts
+++ b/tests/blog-post-seo.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { allMaintainers } from '../src/libraries/maintainers'
+import {
+  getBlogAuthorIdentities,
+  isBlogPostUnpublished,
+} from '../src/utils/blog-format'
+import {
+  type BlogPostHeadData,
+  getBlogPostHead,
+  getBlogSocialImageUrl,
+} from '../src/utils/blog-post-seo'
+import {
+  getTanStackOrganizationJsonLd,
+  TANSTACK_ORGANIZATION_ID,
+} from '../src/utils/organization-structured-data'
+
+Object.assign(globalThis, {
+  __TANSTACK_ENABLE_IMAGE_TRANSFORMATIONS__: true,
+  __TANSTACK_SITE_URL__: 'https://tanstack.com',
+})
+
+type MetaTag = ReturnType<typeof getBlogPostHead>['meta'][number]
+type JsonLdNode = Record<string, unknown>
+
+const basePost: BlogPostHeadData = {
+  authorIdentities: getBlogAuthorIdentities(['TkDodo'], allMaintainers),
+  authors: ['TkDodo'],
+  description: 'A representative article description.',
+  isUnpublished: false,
+  published: '2026-08-01',
+  slug: 'structured-data-test',
+  socialImage: 'https://tanstack.com/blog-assets/test/header.png',
+  title: 'Structured Data Test',
+}
+
+function hasMetaTag(
+  meta: Array<MetaTag>,
+  attribute: 'name' | 'property',
+  value: string,
+  content?: string,
+) {
+  return meta.some(
+    (tag) =>
+      attribute in tag &&
+      tag[attribute] === value &&
+      (content === undefined || tag.content === content),
+  )
+}
+
+function getJsonLd(head: ReturnType<typeof getBlogPostHead>) {
+  assert.equal(head.scripts.length, 1)
+  return JSON.parse(head.scripts[0]!.children) as {
+    '@context': string
+    '@graph': Array<JsonLdNode>
+  }
+}
+
+function findGraphNode(
+  graph: Array<JsonLdNode>,
+  type: 'BlogPosting' | 'Organization',
+) {
+  const node = graph.find((candidate) => candidate['@type'] === type)
+  assert.ok(node, `expected a ${type} node`)
+  return node
+}
+
+test('published posts emit article metadata and connected BlogPosting JSON-LD', () => {
+  const head = getBlogPostHead(basePost)
+  const jsonLd = getJsonLd(head)
+  const organization = findGraphNode(jsonLd['@graph'], 'Organization')
+  const article = findGraphNode(jsonLd['@graph'], 'BlogPosting')
+
+  assert.equal(jsonLd['@context'], 'https://schema.org')
+  assert.deepEqual(organization, getTanStackOrganizationJsonLd())
+  assert.deepEqual(article.publisher, { '@id': TANSTACK_ORGANIZATION_ID })
+  assert.deepEqual(article.mainEntityOfPage, {
+    '@type': 'WebPage',
+    '@id': 'https://tanstack.com/blog/structured-data-test',
+  })
+  assert.equal(article.headline, basePost.title)
+  assert.equal(article.description, basePost.description)
+  assert.equal(article.datePublished, basePost.published)
+  assert.equal('dateModified' in article, false)
+  assert.equal(article.image, basePost.socialImage)
+  assert.deepEqual(article.author, [
+    {
+      '@type': 'Person',
+      name: 'Dominik Dorfmeister',
+      url: 'https://github.com/tkdodo',
+    },
+  ])
+
+  assert.equal(hasMetaTag(head.meta, 'property', 'og:type', 'article'), true)
+  assert.equal(
+    hasMetaTag(
+      head.meta,
+      'property',
+      'article:published_time',
+      basePost.published,
+    ),
+    true,
+  )
+  assert.equal(
+    hasMetaTag(head.meta, 'name', 'author', 'Dominik Dorfmeister'),
+    true,
+  )
+})
+
+test('multiple authors are normalized and retain verified maintainer URLs', () => {
+  const authorIdentities = getBlogAuthorIdentities(
+    ['TkDodo', 'Tanner Linsley', 'TkDodo'],
+    allMaintainers,
+  )
+  const head = getBlogPostHead({
+    ...basePost,
+    authorIdentities,
+    authors: authorIdentities.map((author) => author.name),
+  })
+  const article = findGraphNode(getJsonLd(head)['@graph'], 'BlogPosting')
+
+  assert.deepEqual(article.author, [
+    {
+      '@type': 'Person',
+      name: 'Dominik Dorfmeister',
+      url: 'https://github.com/tkdodo',
+    },
+    {
+      '@type': 'Person',
+      name: 'Tanner Linsley',
+      url: 'https://github.com/tannerlinsley',
+    },
+  ])
+  assert.equal(
+    hasMetaTag(
+      head.meta,
+      'name',
+      'author',
+      'co-authored by Dominik Dorfmeister and Tanner Linsley',
+    ),
+    true,
+  )
+})
+
+test('unknown authors get names without unverified profile URLs', () => {
+  const authorIdentities = getBlogAuthorIdentities(
+    ['Niall Crosby'],
+    allMaintainers,
+  )
+  const article = findGraphNode(
+    getJsonLd(
+      getBlogPostHead({
+        ...basePost,
+        authorIdentities,
+        authors: ['Niall Crosby'],
+      }),
+    )['@graph'],
+    'BlogPosting',
+  )
+
+  assert.deepEqual(article.author, [
+    {
+      '@type': 'Person',
+      name: 'Niall Crosby',
+    },
+  ])
+})
+
+test('posts without header images omit image metadata instead of inventing one', () => {
+  const head = getBlogPostHead({ ...basePost, socialImage: undefined })
+  const article = findGraphNode(getJsonLd(head)['@graph'], 'BlogPosting')
+
+  assert.equal('image' in article, false)
+  assert.equal(hasMetaTag(head.meta, 'property', 'og:image'), false)
+  assert.equal(getBlogSocialImageUrl(undefined), undefined)
+})
+
+test('social images reuse the route image transformation and stay absolute', () => {
+  assert.equal(
+    getBlogSocialImageUrl('/blog-assets/test/header.png'),
+    'https://tanstack.com/cdn-cgi/image/width=1200,height=630,fit=cover,quality=80,format=auto/blog-assets/test/header.png',
+  )
+  assert.equal(
+    getBlogSocialImageUrl('https://images.example.com/post.png'),
+    'https://images.example.com/post.png',
+  )
+})
+
+test('drafts, future posts, and failed loads do not emit BlogPosting JSON-LD', () => {
+  const now = new Date('2026-08-14T12:00:00.000Z')
+
+  assert.equal(
+    isBlogPostUnpublished({ draft: true, published: '2026-08-01' }, now),
+    true,
+  )
+  assert.equal(isBlogPostUnpublished({ published: '2026-08-15' }, now), true)
+  assert.equal(isBlogPostUnpublished({ published: '2026-08-14' }, now), false)
+
+  const unpublishedHead = getBlogPostHead({
+    ...basePost,
+    isUnpublished: true,
+  })
+  assert.deepEqual(unpublishedHead.scripts, [])
+  assert.equal(
+    hasMetaTag(unpublishedHead.meta, 'name', 'robots', 'noindex, nofollow'),
+    true,
+  )
+  assert.deepEqual(getBlogPostHead(undefined), { meta: [], scripts: [] })
+})
+
+test('known modification dates reach frontmatter, JSON-LD, and article metadata', () => {
+  for (const slug of [
+    'incident-followup',
+    'npm-supply-chain-compromise-postmortem',
+  ]) {
+    assert.match(
+      readFileSync(new URL(`../src/blog/${slug}.md`, import.meta.url), 'utf8'),
+      /^updated: 2026-05-15$/m,
+    )
+  }
+
+  const updatedPost = { ...basePost, updated: '2026-08-10' }
+  const head = getBlogPostHead(updatedPost)
+  const article = findGraphNode(getJsonLd(head)['@graph'], 'BlogPosting')
+
+  assert.equal(article.dateModified, updatedPost.updated)
+  assert.equal(
+    hasMetaTag(
+      head.meta,
+      'property',
+      'article:modified_time',
+      updatedPost.updated,
+    ),
+    true,
+  )
+})

--- a/tests/homepage-structured-data.test.ts
+++ b/tests/homepage-structured-data.test.ts
@@ -47,6 +47,7 @@ test('homepage Organization uses a square logo and verified profiles', () => {
     'https://x.com/tan_stack',
     'https://bsky.app/profile/tanstack.com',
     'https://youtube.com/@tan_stack',
+    'https://www.linkedin.com/company/tanstack',
   ])
 })
 

--- a/tests/homepage-structured-data.test.ts
+++ b/tests/homepage-structured-data.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  TANSTACK_ORGANIZATION_ID,
+  TANSTACK_WEBSITE_ID,
+  getTanStackHomepageJsonLd,
+  getTanStackOrganizationJsonLd,
+} from '../src/utils/organization-structured-data'
+
+test('homepage connects one WebSite to one Organization', () => {
+  const structuredData = getTanStackHomepageJsonLd()
+  const websites = structuredData['@graph'].filter(
+    (node) => node['@type'] === 'WebSite',
+  )
+  const organizations = structuredData['@graph'].filter(
+    (node) => node['@type'] === 'Organization',
+  )
+
+  assert.equal(structuredData['@context'], 'https://schema.org')
+  assert.equal(websites.length, 1)
+  assert.equal(organizations.length, 1)
+  assert.deepEqual(websites[0], {
+    '@type': 'WebSite',
+    '@id': TANSTACK_WEBSITE_ID,
+    name: 'TanStack',
+    url: 'https://tanstack.com/',
+    publisher: {
+      '@id': TANSTACK_ORGANIZATION_ID,
+    },
+  })
+  assert.deepEqual(organizations[0], getTanStackOrganizationJsonLd())
+})
+
+test('homepage Organization uses a square logo and verified profiles', () => {
+  const organization = getTanStackOrganizationJsonLd()
+
+  assert.deepEqual(organization.logo, {
+    '@type': 'ImageObject',
+    '@id': 'https://tanstack.com/#organization-logo',
+    url: 'https://tanstack.com/images/brand/social/stacked-green@2x.png',
+    contentUrl: 'https://tanstack.com/images/brand/social/stacked-green@2x.png',
+    width: 800,
+    height: 800,
+  })
+  assert.deepEqual(organization.sameAs, [
+    'https://github.com/TanStack',
+    'https://x.com/tan_stack',
+    'https://bsky.app/profile/tanstack.com',
+    'https://youtube.com/@tan_stack',
+  ])
+})
+
+test('homepage does not advertise a site search action', () => {
+  const serialized = JSON.stringify(getTanStackHomepageJsonLd())
+
+  assert.equal(serialized.includes('SearchAction'), false)
+  assert.equal(serialized.includes('potentialAction'), false)
+})

--- a/tests/homepage-structured-data.test.ts
+++ b/tests/homepage-structured-data.test.ts
@@ -37,8 +37,8 @@ test('homepage Organization uses a square logo and verified profiles', () => {
   assert.deepEqual(organization.logo, {
     '@type': 'ImageObject',
     '@id': 'https://tanstack.com/#organization-logo',
-    url: 'https://tanstack.com/images/brand/social/stacked-green@2x.png',
-    contentUrl: 'https://tanstack.com/images/brand/social/stacked-green@2x.png',
+    url: 'https://tanstack.com/images/brand/social/stacked-light@2x.png',
+    contentUrl: 'https://tanstack.com/images/brand/social/stacked-light@2x.png',
     width: 800,
     height: 800,
   })

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -57,4 +57,7 @@ test('social metadata identifies TanStack and describes its image', () => {
       (tag) => tag.property === 'og:image:alt' && tag.content === title,
     ),
   )
+  assert.ok(
+    tags.some((tag) => tag.property === 'og:type' && tag.content === 'website'),
+  )
 })


### PR DESCRIPTION
## What changed

- Add a homepage-only JSON-LD graph containing one connected `WebSite` and `Organization` node
- Use the 800×800 stacked light TanStack asset as the Organization logo
- Reuse the same stable Organization ID as the publisher for published internal `BlogPosting` markup
- Add article Open Graph metadata, normalized author identities, absolute representative images, and optional modification dates
- Add TanStack's LinkedIn company profile to Organization `sameAs` and the header/footer social links
- Add validated `updated` frontmatter for the two May 2026 incident posts
- Cover homepage graph shape, author normalization, missing images, drafts/future posts, and modification dates

## Why

This gives search engines an explicit site/organization identity on the homepage and richer article semantics on internal blog posts, while keeping the entities connected through `https://tanstack.com/#organization`.

## Edge cases

- Draft and future posts remain `noindex` and do not emit BlogPosting JSON-LD
- Missing article images are omitted instead of substituting an unrelated logo
- Unknown authors retain their names without invented profile URLs
- The homepage does not emit a `SearchAction`
- Non-article pages continue to use `og:type=website`

## Verification

<img width="1002" height="990" alt="image" src="https://github.com/user-attachments/assets/26da920f-7e18-40da-ab15-3d8fbabf4231" />


- `pnpm test` — 155 passed, 1 expected skip
- `pnpm run build`
- Raw SSR checks for the homepage and representative single-author, multi-author, image-less, modified, and missing blog routes
- Confirmed homepage SSR contains exactly one WebSite and one Organization node, with no SearchAction
- Confirmed homepage SSR contains LinkedIn links in both social surfaces and exactly one LinkedIn `sameAs` entry

Closes #1148
Closes #1149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added LinkedIn links to the site navigation and footer.
  - Added richer homepage and blog structured data for improved search-engine presentation.
  - Blog posts now support updated dates, author profiles, publication metadata, and improved social sharing previews.

- **Bug Fixes**
  - Unpublished and future-dated posts are now correctly excluded from indexing.
  - Prevented updated dates from being earlier than publication dates.

- **Tests**
  - Added coverage for blog SEO, structured data, author handling, and metadata generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->