### PR TITLE
fix: stop Charts catalog navigation freeze

### DIFF
--- a/src/components/LibraryLayout.tsx
+++ b/src/components/LibraryLayout.tsx
@@ -38,6 +38,7 @@ import { Card } from './Card'
 import { PartnersRail, RightRail } from './RightRail'
 import { trackEvent, useTrackedImpression } from '~/utils/analytics'
 import {
+  getLibraryLayoutVersion,
   getLibraryTabLinkOptions,
   getMenuGroupInitialOpenState,
   isChartsCatalogTarget,
@@ -812,14 +813,16 @@ export function LibraryLayout({
   isLandingPage = false,
 }: LibraryLayoutProps) {
   const { _splat, version: routeVersion } = useParams({ strict: false })
-  const version =
-    typeof routeVersion === 'string' ? routeVersion : layoutVersion
+  const matches = useMatches()
+  const lastMatch = last(matches)
+  const version = getLibraryLayoutVersion({
+    layoutVersion,
+    pathname: lastMatch.pathname,
+    routeVersion,
+  })
   const menuConfig = useMenuConfig({ config, frameworks, repo, libraryId })
   const LibraryIcon = libraryIcons[libraryId] ?? fallbackLibraryIcon
   const libraryGroupColor = categoryTextColor[categoryOf(libraryId)]
-
-  const matches = useMatches()
-  const lastMatch = last(matches)
 
   const isExample = matches.some(
     (d) =>

--- a/src/components/library-layout-navigation.ts
+++ b/src/components/library-layout-navigation.ts
@@ -4,6 +4,19 @@ export function isChartsCatalogTarget(to: string) {
   return to === '/charts/catalog' || to.startsWith('/charts/catalog/')
 }
 
+export function getLibraryLayoutVersion({
+  layoutVersion,
+  pathname,
+  routeVersion,
+}: {
+  layoutVersion: string
+  pathname: string
+  routeVersion: unknown
+}) {
+  if (typeof routeVersion === 'string') return routeVersion
+  return isChartsCatalogTarget(pathname) ? 'latest' : layoutVersion
+}
+
 export function getLibraryTabLinkOptions({
   libraryId,
   version,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -368,7 +368,9 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
                     : '-translate-y-6 opacity-0',
                 )}
               >
-                <Spinner className="text-4xl" />
+                {showNavigationSpinner ? (
+                  <Spinner className="text-4xl" />
+                ) : null}
               </div>
             </div>
           </ToastProvider>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -368,7 +368,7 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
                     : '-translate-y-6 opacity-0',
                 )}
               >
-                {showNavigationSpinner ? (
+                {isNavigating && showNavigationSpinner ? (
                   <Spinner className="text-4xl" />
                 ) : null}
               </div>

--- a/tests/charts-sidebar-navigation.test.ts
+++ b/tests/charts-sidebar-navigation.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import {
+  getLibraryLayoutVersion,
   getLibraryTabLinkOptions,
   getMenuGroupInitialOpenState,
   isChartsCatalogTarget,
@@ -9,6 +10,34 @@ assert.equal(isChartsCatalogTarget('/charts/catalog'), true)
 assert.equal(isChartsCatalogTarget('/charts/catalog/charts/01-line'), true)
 assert.equal(isChartsCatalogTarget('/charts/catalog/collections/shadcn'), true)
 assert.equal(isChartsCatalogTarget('/charts/catalogue'), false)
+
+assert.equal(
+  getLibraryLayoutVersion({
+    layoutVersion: 'v0',
+    pathname: '/charts/catalog',
+    routeVersion: undefined,
+  }),
+  'latest',
+  'the versionless catalog generates canonical docs links instead of redirecting version aliases',
+)
+assert.equal(
+  getLibraryLayoutVersion({
+    layoutVersion: 'v0',
+    pathname: '/charts/v0/docs/overview',
+    routeVersion: 'v0',
+  }),
+  'v0',
+  'versioned docs retain their requested version',
+)
+assert.equal(
+  getLibraryLayoutVersion({
+    layoutVersion: 'v1',
+    pathname: '/table',
+    routeVersion: undefined,
+  }),
+  'v1',
+  'other versionless library pages retain their layout version',
+)
 
 assert.deepEqual(
   getLibraryTabLinkOptions({


### PR DESCRIPTION
Fixes two independent site-wide performance problems exposed by the Charts catalog.\n\nThe root freeze was caused by versionless catalog pages generating sidebar links through the v0 alias. Pointer-intent preloading followed the v0-to-latest redirect and entered a runaway renderer path. The catalog now emits canonical latest docs links while preserving intent preloading.\n\nThe global navigation spinner also remained mounted and animated after its wrapper became transparent. It is now mounted only while navigation is pending.\n\nMeasured reproduction before the canonical-link fix: one renderer reached 478% CPU, 6.8-7.3 GB resident memory, repeated multi-second GCs, and V8 OOM. After: hover remains responsive, navigation completes in about 259 ms, settled renderer CPU is 0%, and JS heap is about 41 MB after hover.\n\nTests: pnpm test (159 passed, 1 skipped). Added regression coverage for canonical catalog docs-link versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The navigation spinner now appears only when navigation activity requires it, preventing it from displaying unnecessarily.
  * Library navigation now selects the correct layout version for versioned pages and charts catalog routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->