### PR TITLE
Pause Query hero animation offscreen

### DIFF
--- a/src/components/landing/QueryLanding.tsx
+++ b/src/components/landing/QueryLanding.tsx
@@ -15,6 +15,7 @@ import {
 } from '@phosphor-icons/react'
 
 import { useToast } from '~/components/ToastProvider'
+import { useInView } from '~/hooks/useInView'
 import { usePrefersReducedMotion } from '~/utils/usePrefersReducedMotion'
 import { LibraryLanding, type LibraryLandingConfig } from './LibraryLanding'
 
@@ -217,6 +218,8 @@ function QueryCachePanel() {
   const prefersReducedMotion = usePrefersReducedMotion()
   const queryClient = useQueryClient()
   const { notify } = useToast()
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const inView = useInView(rootRef)
   const serverRowsRef = React.useRef<Record<string, QueryHeroIssue>>(
     Object.fromEntries(queryHeroRows.map((row) => [row.id, { ...row.seed }])),
   )
@@ -359,6 +362,8 @@ function QueryCachePanel() {
   // Per-frame rather than per-second: the gauges interpolate here instead of
   // through a CSS transition, so their drain rate tracks elapsed time exactly.
   React.useEffect(() => {
+    if (!inView) return
+
     if (prefersReducedMotion === true) {
       const id = setInterval(() => setNow(Date.now()), 1000)
       return () => clearInterval(id)
@@ -371,10 +376,13 @@ function QueryCachePanel() {
 
     let frame = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(frame)
-  }, [prefersReducedMotion])
+  }, [inView, prefersReducedMotion])
 
   return (
-    <div className="library-landing-graphic min-w-0 overflow-hidden rounded-xl border border-[color:rgb(var(--landing-glow)/0.45)] bg-background-surface shadow-[0_24px_70px_-28px_rgb(var(--landing-glow)/0.45)] dark:shadow-[inset_-3px_-4px_18px_-7px_var(--landing-accent),0_24px_70px_rgb(0_0_0/0.18)]">
+    <div
+      ref={rootRef}
+      className="library-landing-graphic min-w-0 overflow-hidden rounded-xl border border-[color:rgb(var(--landing-glow)/0.45)] bg-background-surface shadow-[0_24px_70px_-28px_rgb(var(--landing-glow)/0.45)] dark:shadow-[inset_-3px_-4px_18px_-7px_var(--landing-accent),0_24px_70px_rgb(0_0_0/0.18)]"
+    >
       <div className="flex items-center justify-between border-b border-border-subtle px-4 py-3">
         <div aria-hidden="true" className="flex gap-1.5">
           <span className="size-2.5 rounded-full bg-[#ff5f57]" />

--- a/src/components/landing/QueryLanding.tsx
+++ b/src/components/landing/QueryLanding.tsx
@@ -307,7 +307,7 @@ function QueryCachePanel() {
 
   const rows = queryHeroRows.map((row, index) => {
     const query = rowQueries[index]
-    const elapsed = now - query.dataUpdatedAt
+    const elapsed = Math.max(0, now - query.dataUpdatedAt)
     const drained = Math.max(
       0,
       Math.min(100, (1 - elapsed / row.staleTime) * 100),
@@ -365,16 +365,18 @@ function QueryCachePanel() {
     if (!inView) return
 
     if (prefersReducedMotion === true) {
+      setNow(Date.now())
       const id = setInterval(() => setNow(Date.now()), 1000)
       return () => clearInterval(id)
     }
 
+    let frame = 0
     const tick = () => {
       setNow(Date.now())
       frame = requestAnimationFrame(tick)
     }
 
-    let frame = requestAnimationFrame(tick)
+    tick()
     return () => cancelAnimationFrame(frame)
   }, [inView, prefersReducedMotion])
 


### PR DESCRIPTION
## What changed

- reuse the existing `useInView` hook for the Query landing hero
- stop its per-frame freshness updates while the hero is offscreen
- resume from current timestamps when the hero becomes visible again

## Why

The Query hero updates React state on every animation frame to keep three freshness gauges smooth. That loop continued after visitors scrolled past the hero, causing roughly one component render per frame with no visible result.

## Impact

The hero keeps the same visible animation and interaction behavior. Offscreen work drops from continuous frame-driven renders to none; periodic Query demo updates remain unchanged.

## Validation

- `pnpm test` — TypeScript and type-aware lint passed; 191 tests passed and 1 environment-gated smoke test skipped
- browser measurement — gauge widths changed while visible, stayed unchanged across a 500 ms offscreen sample, and changed again after scrolling back
- `git diff --check`

## Risk

Low. This only gates the existing timer effect with the repository's existing intersection hook. When `IntersectionObserver` is unavailable, that hook preserves the current always-running behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved the query cache panel so animations and time updates pause when it is offscreen.
  * Resumes visual updates automatically when the panel becomes visible again.

* **Bug Fixes**
  * Prevented elapsed-time calculations from displaying incorrect negative freshness values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->