### PR TITLE
perf(docs): keep latest HTML at the Cloudflare edge for 1 hour

### DIFF
--- a/src/utils/docs-cache-headers.ts
+++ b/src/utils/docs-cache-headers.ts
@@ -2,7 +2,7 @@ import { findLibrary, getBranch } from '~/libraries'
 import { docsContentNegotiationVaryHeader } from './http'
 
 const latestDocsCdnCacheControl =
-  'public, max-age=60, stale-while-revalidate=60'
+  'public, max-age=3600, stale-while-revalidate=86400'
 const versionedDocsCdnCacheControl =
   'public, max-age=300, stale-while-revalidate=300'
 

--- a/src/utils/docs.functions.ts
+++ b/src/utils/docs.functions.ts
@@ -435,7 +435,7 @@ export const fetchDocs = createServerFn({ method: 'GET' })
       frontMatter.userDescription ?? removeMarkdown(frontMatter.excerpt ?? '')
     const keywords = extractFrontMatterKeywords(frontMatter.data.keywords)
 
-    setDocsCacheHeaders('public, max-age=60, stale-while-revalidate=60')
+    setDocsCacheHeaders('public, max-age=3600, stale-while-revalidate=86400')
 
     return {
       content: frontMatter.content,


### PR DESCRIPTION
## Summary

- Latest docs HTML (and SPA `fetchDocs`) stay at the Cloudflare edge for **1 hour**, then up to **24 hours** stale-while-revalidate
- Versioned docs stay at 5 minutes; browser `Cache-Control` is unchanged
- GitHub webhook still purges `docs:<lib>:branch:<branch>` on push, so library updates still invalidate that library's HTML

Today latest docs are only good at the edge for ~60–120s. After that the Worker SSRs and talks to GitHub. Production cold TTFB is **1.2–2.1s**; a warm HIT is **~50–150ms**. Query Overview CrUX p75 is **2.3s LCP desktop / 3.0s mobile** — that matches “often a miss,” not “HTML never arrives.”

Measured on an OpenStory Workers Cache preview of this same header change (not tanstack.com's zone cache, same `Cloudflare-CDN-Cache-Control` contract):

| | MISS | HIT |
| --- | ---: | ---: |
| Query Overview | 1.51s | 86ms |
| useQuery | 1.8–2.0s | 94–215ms |
| Router Overview | 1.31s | 78ms |

After ~2 minutes the 60s policy was `UPDATING` (SWR, still ~87ms) while 1 hour stayed `HIT`. SWR already hides expiry for URLs that keep getting traffic; the 1-hour TTL is for the long tail of docs URLs that currently miss.

This does **not** cut the ~200ms client render delay after HTML arrives. It only stops most navigations from paying origin.

## Test plan

- [ ] After deploy, first request to a rarely hit latest docs URL can still be slow
- [ ] Immediate second request TTFB ~50–150ms and `Cf-Cache-Status` / `server-timing` shows an edge HIT (`cfOrigin;dur=0` on the zone)
- [ ] Response still has `Cloudflare-CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
- [ ] Push to a watched docs repo still invalidates that library's HTML via the existing webhook + `Cache-Tag`
- [ ] A versioned docs URL (`/query/v5/...`) still uses the 5-minute CDN TTL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved documentation loading efficiency by extending CDN caching to one hour.
  * Added a 24-hour stale-while-revalidate window to help serve documentation quickly while updates are refreshed in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->