### PR TITLE
Avoid caching temporary docs fallbacks

### DIFF
--- a/src/utils/docs.functions.ts
+++ b/src/utils/docs.functions.ts
@@ -161,13 +161,19 @@ async function readRepoFileOrFallback(
     await loadDocumentsServerModule()
 
   try {
-    return await fetchRepoFile(repo, branch, filePath)
+    return {
+      file: await fetchRepoFile(repo, branch, filePath),
+      isFallback: false,
+    }
   } catch (error) {
     if (!isRecoverableGitHubContentError(error)) {
       throw error
     }
 
-    return buildUnavailableFile(filePath)
+    return {
+      file: buildUnavailableFile(filePath),
+      isFallback: true,
+    }
   }
 }
 
@@ -423,19 +429,24 @@ export const fetchDocs = createServerFn({ method: 'GET' })
   .validator(repoFileInput)
   .handler(async ({ data }: { data: RepoFileRequest }) => {
     const { repo, branch, filePath } = data
-    const file = await readRepoFileOrFallback(repo, branch, filePath)
+    const result = await readRepoFileOrFallback(repo, branch, filePath)
 
-    if (!file) {
+    if (!result.file) {
       throw notFound()
     }
 
     const { extractFrontMatter } = await loadDocumentsServerModule()
-    const frontMatter = extractFrontMatter(file)
+    const frontMatter = extractFrontMatter(result.file)
     const description =
       frontMatter.userDescription ?? removeMarkdown(frontMatter.excerpt ?? '')
     const keywords = extractFrontMatterKeywords(frontMatter.data.keywords)
 
-    setDocsCacheHeaders('public, max-age=3600, stale-while-revalidate=86400')
+    setDocsCacheHeaders(
+      result.isFallback
+        ? 'no-store'
+        : 'public, max-age=3600, stale-while-revalidate=86400',
+    )
+    if (result.isFallback) setResponseHeader('Cache-Control', 'no-store')
 
     return {
       content: frontMatter.content,
@@ -470,15 +481,20 @@ export const fetchFile = createServerFn({ method: 'GET' })
   .validator(repoFileInput)
   .handler(async ({ data }: { data: RepoFileRequest }) => {
     const { repo, branch, filePath } = data
-    const file = await readRepoFileOrFallback(repo, branch, filePath)
+    const result = await readRepoFileOrFallback(repo, branch, filePath)
 
-    if (!file) {
+    if (!result.file) {
       throw notFound()
     }
 
-    setDocsCacheHeaders('public, max-age=300, stale-while-revalidate=300')
+    setDocsCacheHeaders(
+      result.isFallback
+        ? 'no-store'
+        : 'public, max-age=300, stale-while-revalidate=300',
+    )
+    if (result.isFallback) setResponseHeader('Cache-Control', 'no-store')
 
-    return file
+    return result.file
   })
 
 export const fetchRepoDirectoryContents = createServerFn({


### PR DESCRIPTION
## Evidence

PR #1167 raised the latest docs edge policy from 60 seconds to one hour plus 24 hours of stale-while-revalidate. Its review identified that `readRepoFileOrFallback` returns a 200 “Content temporarily unavailable” placeholder for recoverable GitHub failures, and both `fetchDocs` and `fetchFile` applied the normal cache policy without knowing the response was a fallback.

That can retain an outage placeholder at the edge for up to 25 hours after GitHub recovers.

## Change

Track whether repository content came from the recoverable fallback. Normal documents keep their existing cache policy; fallback HTML and raw-file responses now send `Cache-Control: no-store` and `Cloudflare-CDN-Cache-Control: no-store`.

Follow-up to #1167.

## Impact

A transient GitHub failure can still render the existing graceful placeholder, but the next request retries instead of receiving a cached outage page.

## Validation

- `pnpm test`
- TypeScript and type-aware lint clean
- 338 tests total: 337 passed, 1 environment-gated docs smoke test skipped
- Commit hook reran formatting and the full test gate successfully
- `git diff --check`

## Risk

Low. Successful docs responses retain the cache durations introduced by #1167. Only recoverable fallback responses change caching behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary documentation-service failures.
  * Prevented unavailable fallback content from being cached, so later requests can retry successfully.
  * Preserved existing caching behavior when documentation is retrieved successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->