### PR TITLE
Abort settled notebook AI turns

### DIFF
--- a/src/components/notebook/NotebookAssistant.client.tsx
+++ b/src/components/notebook/NotebookAssistant.client.tsx
@@ -1139,6 +1139,7 @@ export function NotebookAssistant({
         return 'error'
       }
     } finally {
+      abortController.abort()
       if (abortRef.current === abortController) abortRef.current = null
       onFinish?.()
     }


### PR DESCRIPTION
## Evidence

The local notebook validation flow can fail while staging or validating a candidate. The assistant catches that failure and rolls the notebook back, but the per-prompt AbortController stayed live. The fetch SSE adapter releases its reader without cancelling the response when iteration exits through an error, so the local Codex request, turn, and validation broker could remain active until the five-minute idle timeout.

No open issue or pull request addresses this cleanup. PR #1123 touches the same component only for the Base UI migration and does not modify the request lifecycle.

## Change

Always abort the per-prompt controller in the existing finally block after the prompt settles.

## Impact

Failed or completed notebook AI requests now release their fetch, local bridge turn, and validation wait immediately instead of relying on the idle timeout.

## Validation

- pnpm test
- TypeScript and type-aware lint clean
- 361 tests total: 360 passed, 1 environment-gated docs smoke test skipped
- Commit hook repeated formatting and the full test gate successfully
- git diff --check

## Risk

Low. Abort is idempotent and runs only after success, failure, or user cancellation has already settled. Successful streams are already complete at that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after notebook assistant requests finish, fail, or are cancelled.
  * Helps prevent lingering request activity and ensures cancellations are handled reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->