### PR TITLE
Clarify TanStack AI durability setup

### DIFF
--- a/src/blog/tanstack-ai-rc.md
+++ b/src/blog/tanstack-ai-rc.md
@@ -31,7 +31,7 @@ Our initial goal was to create an architecture that could be easily extended not
 
 One of the biggest payoffs since we started has been making the right architectural decisions early and building everything on top of those foundations. One of the strongest parts of that architecture is our [middleware system](https://tanstack.com/ai/latest/docs/advanced/middleware).
 
-You can build just about anything with middleware. Chat persistence, agent harnesses running inside sandboxes, memory, telemetry, and many other features are middleware functions that you pass into your `chat()` method. Durability is separate and plugs into the streaming response through an adapter.
+You can build just about anything with middleware. Chat persistence, agent harnesses running inside sandboxes, memory, telemetry, and many other features are middleware you pass into your `chat()` method. Durability is separate and plugs into the streaming response through an adapter.
 
 Another powerful feature we offer is [lazy tool calling](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery), which can help reduce token costs with a simple Boolean flag. We also support advanced [interrupt scenarios](https://tanstack.com/ai/latest/docs/interrupts/overview) driven by your schemas. You can modify tool-call arguments, trigger multiple interrupts, and mix and match these capabilities while keeping everything completely type-safe from end to end.
 

--- a/src/blog/tanstack-ai-rc.md
+++ b/src/blog/tanstack-ai-rc.md
@@ -31,7 +31,7 @@ Our initial goal was to create an architecture that could be easily extended not
 
 One of the biggest payoffs since we started has been making the right architectural decisions early and building everything on top of those foundations. One of the strongest parts of that architecture is our [middleware system](https://tanstack.com/ai/latest/docs/advanced/middleware).
 
-You can build just about anything with middleware. Chat persistence, agent harnesses running inside sandboxes, memory, telemetry, durability, and many other features are simply middleware functions that you pass into your `chat()` method.
+You can build just about anything with middleware. Chat persistence, agent harnesses running inside sandboxes, memory, telemetry, and many other features are middleware functions that you pass into your `chat()` method. Durability is separate and plugs into the streaming response through an adapter.
 
 Another powerful feature we offer is [lazy tool calling](https://tanstack.com/ai/latest/docs/tools/lazy-tool-discovery), which can help reduce token costs with a simple Boolean flag. We also support advanced [interrupt scenarios](https://tanstack.com/ai/latest/docs/interrupts/overview) driven by your schemas. You can modify tool-call arguments, trigger multiple interrupts, and mix and match these capabilities while keeping everything completely type-safe from end to end.
 


### PR DESCRIPTION
## Evidence

Follow-up to #1174. The RC announcement described durability as middleware passed to `chat()`, but the authoritative TanStack AI resumable-stream docs configure durability as an adapter on the streaming response.

## Change

Keep the middleware examples intact and state the separate durability integration point.

## Impact

Prevents readers from trying to configure resumable delivery through the wrong API.

## Validation

- `pnpm test` passed before commit and again in the commit hook: TypeScript and type-aware lint clean; 366 tests passed, 1 environment-gated docs smoke test skipped
- All 25 TanStack AI documentation links in the announcement return HTTP 200
- `git diff --check` passed

## Risk

Low. One copy-only sentence changes; no runtime or API behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that durability integrates with streaming responses through an adapter, rather than being passed directly as middleware to `chat()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->