### PR TITLE
Keep Charts preview history in sync

### DIFF
--- a/src/components/charts/ChartsBuilderPage.client.tsx
+++ b/src/components/charts/ChartsBuilderPage.client.tsx
@@ -808,15 +808,12 @@ export function ChartsBuilderPage() {
           if (!trustedUrl) return
           const currentHistory = previewHistoryRef.current
           const currentUrl = currentHistory.entries[currentHistory.index] ?? '/'
-
-          setPreviewHistory((current) => {
-            const next = updateExamplePreviewHistory(current, {
-              kind: message.navigationKind,
-              url: trustedUrl,
-            })
-            previewHistoryRef.current = next
-            return next
+          const nextHistory = updateExamplePreviewHistory(currentHistory, {
+            kind: message.navigationKind,
+            url: trustedUrl,
           })
+          previewHistoryRef.current = nextHistory
+          setPreviewHistory(nextHistory)
           setPreviewNavigationError('')
           if (message.navigationKind === 'load' || currentUrl !== trustedUrl) {
             setPreviewAnnotationTarget(undefined)

--- a/src/components/charts/ChartsCatalogResult.client.tsx
+++ b/src/components/charts/ChartsCatalogResult.client.tsx
@@ -168,15 +168,12 @@ export function ChartsCatalogResult({
           if (!trustedUrl) return
           const currentHistory = previewHistoryRef.current
           const currentUrl = currentHistory.entries[currentHistory.index] ?? '/'
-
-          setPreviewHistory((current) => {
-            const next = updateExamplePreviewHistory(current, {
-              kind: message.navigationKind,
-              url: trustedUrl,
-            })
-            previewHistoryRef.current = next
-            return next
+          const nextHistory = updateExamplePreviewHistory(currentHistory, {
+            kind: message.navigationKind,
+            url: trustedUrl,
           })
+          previewHistoryRef.current = nextHistory
+          setPreviewHistory(nextHistory)
           setPreviewNavigationError('')
           if (message.navigationKind === 'load' || currentUrl !== trustedUrl) {
             setPreviewAnnotationTarget(undefined)


### PR DESCRIPTION
## Evidence

Both Charts preview message handlers read previewHistoryRef.current, but updated that ref inside a React state updater. State updaters can be evaluated after the message handler returns, so a second browser-state message can read stale history and calculate navigation or annotation state from the wrong URL. The Builder instance was also left as an unresolved review finding on merged PR #1171.

The same pattern exists in the catalog result handler. No open issue or PR addresses the synchronization bug. PR #1173 touches the catalog result only to remove an unused callback, not preview history behavior.

## Impact

Rapid preview navigation messages now build on the latest accepted history in both Charts surfaces. This prevents stale back and forward entries and annotation targets.

## Change

Compute the next history from the current ref, update the ref synchronously, then pass that exact value to React state. This keeps the existing history helper and behavior, with no new abstraction or API change.

The branch is rebased on current main after the Charts Notebook page was renamed to Charts Builder.

## Validation

- pnpm test
- TypeScript and type-aware lint passed
- 466 tests total, 465 passed, 1 environment-gated docs smoke test skipped
- git diff --check

## Risk

Low. The same pure updateExamplePreviewHistory result still drives state, but the mutable ref now advances in the message handler before another message can arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser navigation and preview history updates for more reliable back-and-forward behavior.
  * Preserved URL normalization, navigation-error clearing, and annotation target resets during history changes.
  * Improved synchronization between sandbox navigation state and the displayed preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->