### PR TITLE
Fix blog filter edge cases

### DIFF
--- a/src/components/BlogFilterBar.tsx
+++ b/src/components/BlogFilterBar.tsx
@@ -343,6 +343,8 @@ export function BlogFilterBar({
       {/* Mobile-only expandable column: the facet dropdowns stacked full-width,
           animated open via a grid-rows height transition. */}
       <div
+        aria-hidden={!mobileOpen}
+        inert={mobileOpen ? undefined : true}
         className={twMerge(
           'grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none md:hidden',
           mobileOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',

--- a/src/routes/_library/$libraryId/$version.docs.blog.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.blog.tsx
@@ -33,11 +33,15 @@ function RouteComponent() {
   const { author, q } = Route.useSearch()
   const navigate = Route.useNavigate()
   const library = getLibrary(libraryId as LibraryId)
-  const selectedAuthor = author ? normalizeBlogAuthor(author) : undefined
   const searchQuery = q ?? ''
 
   const posts = Route.useLoaderData()
   const authors = getDistinctAuthors(posts)
+  const normalizedAuthor = author ? normalizeBlogAuthor(author) : undefined
+  const selectedAuthor =
+    normalizedAuthor && authors.includes(normalizedAuthor)
+      ? normalizedAuthor
+      : undefined
 
   const authorFilteredPosts = selectedAuthor
     ? posts.filter((post) => post.authors.includes(selectedAuthor))
@@ -87,11 +91,7 @@ function RouteComponent() {
               <div className="w-56 max-w-full">
                 <FormSelect
                   aria-label="Filter by author"
-                  value={
-                    selectedAuthor && authors.includes(selectedAuthor)
-                      ? selectedAuthor
-                      : ''
-                  }
+                  value={selectedAuthor ?? ''}
                   onChange={(event) =>
                     navigate({
                       search: (prev) => ({


### PR DESCRIPTION
## Evidence

The design-system blog refresh left two filter edge cases on main:

1. A library blog with an unknown `author` query displayed `All authors`, but still filtered posts using the unknown value. A stale, mistyped, or manually edited URL therefore showed an empty blog while the visible filter said all authors were selected. This remained as an unresolved finding on merged PR #1171: https://github.com/TanStack/tanstack.com/pull/1171#discussion_r3816085034
2. The mobile blog filter drawer collapsed to a zero-height grid without becoming inert. Its visually hidden dropdowns remained in keyboard focus order while the drawer was closed.

Final title, body, keyword, and open-PR file searches found no issue or active change covering either behavior.

## Impact

Invalid author URLs now behave consistently as `All authors`, and keyboard users no longer tab into closed mobile filter controls.

## Change

- Normalize the requested library-blog author, validate it once against the loaded posts, and reuse that value for display, filtering, and empty-state copy.
- Apply native `inert` and `aria-hidden` state to the collapsed mobile filter container.

## Validation

- `pnpm test` after each change
- TypeScript and type-aware lint passed
- 367 tests total, 366 passed, 1 environment-gated docs smoke test skipped
- `git diff --check`

The first sandboxed test attempt hit the known macOS TSX IPC `EPERM`; the identical escalated run and all later full runs passed.

## Risk

Low. Valid author filters and open mobile filters are unchanged. The changes only align hidden or invalid states with what the interface already communicates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved author filtering in the blog view.
  * Invalid or unavailable author selections now show all posts instead of hiding content.
  * The author selector now consistently reflects the valid selection.
  * Improved accessibility by preventing interaction with the closed mobile filter panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->