### PR TITLE
fix(markdown): serve bundle size report

### DIFF
--- a/src/components/Doc.tsx
+++ b/src/components/Doc.tsx
@@ -141,15 +141,17 @@ export function Doc({
 
   return (
     <div className="flex-1 min-h-0 flex flex-col pt-4 lg:pt-6 xl:pt-8">
-      <a
-        href={`${pagePath}.md`}
-        className="sr-only"
-        tabIndex={-1}
-        aria-hidden="true"
-      >
-        AI/LLM: This documentation page is available in plain markdown format at
-        {pagePath}.md
-      </a>
+      {pagePath ? (
+        <a
+          href={`${pagePath}.md`}
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden="true"
+        >
+          AI/LLM: This documentation page is available in plain markdown format
+          at {pagePath}.md
+        </a>
+      ) : null}
 
       <div
         className={twMerge(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -200,6 +200,7 @@ import { Route as ChartsCatalogPreviewsRevisionChar123caseIdChar125DotsvgRouteIm
 import { Route as ApiBuilderProjectsIdSyncRouteImport } from './routes/api/builder/projects.$id.sync'
 import { Route as ApiBuilderProjectSnapshotsHashQuarantineRouteImport } from './routes/api/builder/project-snapshots.$hash.quarantine'
 import { Route as ApiAuthCliStatusTicketIdRouteImport } from './routes/api/auth/cli/status.$ticketId'
+import { Route as LibraryMarkdownVersionReportsSizesRouteImport } from './routes/_library/markdown.$version.reports.sizes'
 import { Route as LibraryChartsCatalogCollectionsCollectionIdRouteImport } from './routes/_library/charts.catalog.collections.$collectionId'
 import { Route as LibraryChartsCatalogChartsCaseIdRouteImport } from './routes/_library/charts.catalog.charts.$caseId'
 import { Route as LibraryLibraryIdVersionDocsChar123Char125DotmdRouteImport } from './routes/_library/$libraryId/$version.docs.{$}[.]md'
@@ -1219,6 +1220,12 @@ const ApiAuthCliStatusTicketIdRoute =
     path: '/api/auth/cli/status/$ticketId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const LibraryMarkdownVersionReportsSizesRoute =
+  LibraryMarkdownVersionReportsSizesRouteImport.update({
+    id: '/markdown/$version/reports/sizes',
+    path: '/markdown/$version/reports/sizes',
+    getParentRoute: () => LibraryRoute,
+  } as any)
 const LibraryChartsCatalogCollectionsCollectionIdRoute =
   LibraryChartsCatalogCollectionsCollectionIdRouteImport.update({
     id: '/collections/$collectionId',
@@ -1501,6 +1508,7 @@ export interface FileRoutesByFullPath {
   '/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
   '/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
+  '/markdown/$version/reports/sizes': typeof LibraryMarkdownVersionReportsSizesRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/builder/project-snapshots/$hash/quarantine': typeof ApiBuilderProjectSnapshotsHashQuarantineRoute
   '/api/builder/projects/$id/sync': typeof ApiBuilderProjectsIdSyncRoute
@@ -1695,6 +1703,7 @@ export interface FileRoutesByTo {
   '/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
   '/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
+  '/markdown/$version/reports/sizes': typeof LibraryMarkdownVersionReportsSizesRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/builder/project-snapshots/$hash/quarantine': typeof ApiBuilderProjectSnapshotsHashQuarantineRoute
   '/api/builder/projects/$id/sync': typeof ApiBuilderProjectsIdSyncRoute
@@ -1903,6 +1912,7 @@ export interface FileRoutesById {
   '/_library/$libraryId/$version/docs/{$}.md': typeof LibraryLibraryIdVersionDocsChar123Char125DotmdRoute
   '/_library/charts/catalog/charts/$caseId': typeof LibraryChartsCatalogChartsCaseIdRoute
   '/_library/charts/catalog/collections/$collectionId': typeof LibraryChartsCatalogCollectionsCollectionIdRoute
+  '/_library/markdown/$version/reports/sizes': typeof LibraryMarkdownVersionReportsSizesRoute
   '/api/auth/cli/status/$ticketId': typeof ApiAuthCliStatusTicketIdRoute
   '/api/builder/project-snapshots/$hash/quarantine': typeof ApiBuilderProjectSnapshotsHashQuarantineRoute
   '/api/builder/projects/$id/sync': typeof ApiBuilderProjectsIdSyncRoute
@@ -2111,6 +2121,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/{$}.md'
     | '/charts/catalog/charts/$caseId'
     | '/charts/catalog/collections/$collectionId'
+    | '/markdown/$version/reports/sizes'
     | '/api/auth/cli/status/$ticketId'
     | '/api/builder/project-snapshots/$hash/quarantine'
     | '/api/builder/projects/$id/sync'
@@ -2305,6 +2316,7 @@ export interface FileRouteTypes {
     | '/$libraryId/$version/docs/{$}.md'
     | '/charts/catalog/charts/$caseId'
     | '/charts/catalog/collections/$collectionId'
+    | '/markdown/$version/reports/sizes'
     | '/api/auth/cli/status/$ticketId'
     | '/api/builder/project-snapshots/$hash/quarantine'
     | '/api/builder/projects/$id/sync'
@@ -2512,6 +2524,7 @@ export interface FileRouteTypes {
     | '/_library/$libraryId/$version/docs/{$}.md'
     | '/_library/charts/catalog/charts/$caseId'
     | '/_library/charts/catalog/collections/$collectionId'
+    | '/_library/markdown/$version/reports/sizes'
     | '/api/auth/cli/status/$ticketId'
     | '/api/builder/project-snapshots/$hash/quarantine'
     | '/api/builder/projects/$id/sync'
@@ -3958,6 +3971,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthCliStatusTicketIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_library/markdown/$version/reports/sizes': {
+      id: '/_library/markdown/$version/reports/sizes'
+      path: '/markdown/$version/reports/sizes'
+      fullPath: '/markdown/$version/reports/sizes'
+      preLoaderRoute: typeof LibraryMarkdownVersionReportsSizesRouteImport
+      parentRoute: typeof LibraryRoute
+    }
     '/_library/charts/catalog/collections/$collectionId': {
       id: '/_library/charts/catalog/collections/$collectionId'
       path: '/collections/$collectionId'
@@ -4237,6 +4257,7 @@ interface LibraryRouteChildren {
   LibraryTableVersionIndexRoute: typeof LibraryTableVersionIndexRoute
   LibraryVirtualVersionIndexRoute: typeof LibraryVirtualVersionIndexRoute
   LibraryWorkflowVersionIndexRoute: typeof LibraryWorkflowVersionIndexRoute
+  LibraryMarkdownVersionReportsSizesRoute: typeof LibraryMarkdownVersionReportsSizesRoute
 }
 
 const LibraryRouteChildren: LibraryRouteChildren = {
@@ -4262,6 +4283,8 @@ const LibraryRouteChildren: LibraryRouteChildren = {
   LibraryTableVersionIndexRoute: LibraryTableVersionIndexRoute,
   LibraryVirtualVersionIndexRoute: LibraryVirtualVersionIndexRoute,
   LibraryWorkflowVersionIndexRoute: LibraryWorkflowVersionIndexRoute,
+  LibraryMarkdownVersionReportsSizesRoute:
+    LibraryMarkdownVersionReportsSizesRoute,
 }
 
 const LibraryRouteWithChildren =

--- a/src/routes/_library/markdown.$version.reports.sizes.tsx
+++ b/src/routes/_library/markdown.$version.reports.sizes.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Doc } from '~/components/Doc'
+import { DocContainer } from '~/components/DocContainer'
+import { getBranch, getLibrary } from '~/libraries'
+import { docsConfigQueryOptions } from '~/queries/docsConfig'
+import { getDocsCacheHeaders } from '~/utils/docs-cache-headers'
+import { fetchDocs } from '~/utils/docs.functions'
+import { ogImageUrl } from '~/utils/og'
+import { seo } from '~/utils/seo'
+import { beforeLoadLibraryLanding } from '../-library-landing-route'
+
+const library = getLibrary('markdown')
+const filePath = 'reports/sizes.md'
+
+export const Route = createFileRoute(
+  '/_library/markdown/$version/reports/sizes',
+)({
+  staleTime: 1000 * 60 * 5,
+  beforeLoad: ({ params, location }) => {
+    beforeLoadLibraryLanding('markdown', params.version, location.href)
+  },
+  loader: async ({ params, context: { queryClient } }) => {
+    const branch = getBranch(library, params.version)
+    const [config, report] = await Promise.all([
+      queryClient.ensureQueryData(
+        docsConfigQueryOptions('markdown', params.version),
+      ),
+      fetchDocs({
+        data: {
+          repo: library.repo,
+          branch,
+          filePath,
+        },
+      }),
+    ])
+
+    return {
+      ...report,
+      branch,
+      config,
+    }
+  },
+  head: ({ loaderData }) => ({
+    meta: seo({
+      title: `Bundle Size Results | ${library.name}`,
+      description: loaderData?.description,
+      image: ogImageUrl(library.id),
+      noindex: library.visible === false,
+    }),
+  }),
+  headers: ({ params }) =>
+    getDocsCacheHeaders({ libraryId: library.id, version: params.version }),
+  component: MarkdownBundleSizeReport,
+})
+
+function MarkdownBundleSizeReport() {
+  const { branch, content } = Route.useLoaderData()
+
+  return (
+    <DocContainer className="px-4 md:px-8">
+      <Doc
+        title="Bundle Size Results"
+        content={content}
+        repo={library.repo}
+        branch={branch}
+        filePath={filePath}
+        colorFrom={library.colorFrom}
+        colorTo={library.colorTo}
+        textColor={library.textColor}
+      />
+    </DocContainer>
+  )
+}

--- a/tests/docs-route-smoke.test.ts
+++ b/tests/docs-route-smoke.test.ts
@@ -70,6 +70,11 @@ test(
       return paths
     })
 
+    cases.push({
+      path: '/markdown/latest/reports/sizes',
+      expected: 'ok',
+    })
+
     for (const smokeCase of cases) {
       const result = await fetchWithRedirects(new URL(smokeCase.path, baseUrl))
 


### PR DESCRIPTION
## Summary

- add a version-aware Markdown bundle report route backed by the existing cached docs fetcher
- render the generated report with the existing document shell and SEO/cache conventions
- add route smoke coverage and avoid emitting unavailable Markdown endpoints for pages without a page path

## Verification

- TypeScript checks
- type-aware lint
- unit tests: 466 passed, 1 environment-gated smoke test skipped
- git diff --check

Closes #1195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a version-specific bundle-size report page to the Markdown documentation library.
  - Added SEO metadata, caching, and library branding to the new report page.

- **Bug Fixes**
  - Improved screen-reader link handling so the Markdown download link appears only when a valid page path is available.

- **Tests**
  - Added route coverage to verify the new report page loads successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->