### PR TITLE
chore(maintainers): update 'sukvvon' entry

### DIFF
--- a/src/libraries/maintainers.ts
+++ b/src/libraries/maintainers.ts
@@ -262,6 +262,19 @@ export const allMaintainers: Maintainer[] = [
     specialties: ['Sync Engines', 'Incremental View Maintenance'],
   },
   {
+    name: 'Wonsuk Choi',
+    avatar: 'https://github.com/sukvvon.png',
+    github: 'sukvvon',
+    maintainerOf: ['query'],
+    frameworkExpertise: ['react', 'preact'],
+    specialties: ['TypeScript', 'Test', 'Documentation'],
+    social: {
+      linkedIn: 'https://www.linkedin.com/in/sukvvon',
+      twitter: 'https://x.com/sukvvon',
+      bluesky: 'https://bsky.app/profile/sukvvon.bsky.social',
+    },
+  },
+  {
     name: 'Vedanta Somnathe',
     avatar: 'https://github.com/theVedanta.png',
     github: 'theVedanta',
@@ -339,19 +352,6 @@ export const allMaintainers: Maintainer[] = [
       twitter: 'https://x.com/manudeli_',
       bluesky: 'https://bsky.app/profile/manudeli.bsky.social',
       linkedIn: 'https://www.linkedin.com/in/jonghyeonko',
-    },
-  },
-  {
-    name: 'Wonsuk Choi',
-    avatar: 'https://github.com/sukvvon.png',
-    github: 'sukvvon',
-    maintainerOf: ['query'],
-    frameworkExpertise: ['react'],
-    specialties: ['TypeScript', 'Test'],
-    social: {
-      linkedIn: 'https://www.linkedin.com/in/sukvvon',
-      twitter: 'https://x.com/sukvvon',
-      bluesky: 'https://bsky.app/profile/sukvvon.bsky.social',
     },
   },
   {


### PR DESCRIPTION
Updates my own entry — adds `preact` to `frameworkExpertise`, adds `Documentation` to `specialties`, and moves the entry earlier in the array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the maintainer profile for Wonsuk Choi.
  * Added Preact to the listed framework expertise.
  * Added Documentation to the listed specialties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->