### PR TITLE
fix: prevent Markdown and Highlight landing link crashes

### DIFF
--- a/src/components/landing/HighlightLanding.tsx
+++ b/src/components/landing/HighlightLanding.tsx
@@ -179,8 +179,8 @@ export default function HighlightLanding() {
             body="Every renderer and adapter receives the highlighter you assembled; none imports every language behind your back."
           />
           <Link
-            to="/$libraryId"
-            params={{ libraryId: markdownLibrary.id }}
+            to="/markdown/$version"
+            params={{ version: 'latest' }}
             className="group rounded-xl border border-border-subtle bg-background-surface p-6 transition-colors hover:border-border-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent-bright)]"
           >
             <p className="font-ds-mono text-ds-mono-caps uppercase text-[var(--landing-accent-bright)]">

--- a/src/components/landing/MarkdownLanding.tsx
+++ b/src/components/landing/MarkdownLanding.tsx
@@ -244,8 +244,8 @@ export default function MarkdownLanding() {
             body="Code fences carry language and metadata. An explicit highlighter renders them later, so the core never silently imports a grammar engine."
           />
           <Link
-            to="/$libraryId"
-            params={{ libraryId: highlightLibrary.id }}
+            to="/highlight/$version"
+            params={{ version: 'latest' }}
             className="group rounded-xl border border-border-subtle bg-background-surface p-6 transition-colors hover:border-border-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent-bright)]"
           >
             <p className="font-ds-mono text-ds-mono-caps uppercase text-[var(--landing-accent-bright)]">


### PR DESCRIPTION
## Summary

- point the Markdown companion card at the dedicated Highlight route template
- point the Highlight companion card at the dedicated Markdown route template
- avoid generic library-route intent preloads that resolve to a different static route and lock up the page

Fixes #1200

## Testing

- `pnpm test`
- hovered both reciprocal landing-page links and confirmed their intent preloads complete without router warnings or page freezes
- navigated from Highlight to Markdown through the companion card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Explore Markdown” and “Explore Highlight” links to open the latest version of each library.
  * Improved navigation consistency between the Highlight and Markdown landing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->