### PR TITLE
fix(landing): square the bordered edge on accent callouts

### DIFF
--- a/src/components/landing/ConfigLanding.tsx
+++ b/src/components/landing/ConfigLanding.tsx
@@ -242,7 +242,7 @@ function PackageXRay() {
             </div>
           ))}
         </div>
-        <div className="mt-4 flex items-center gap-3 rounded-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.08)] p-4">
+        <div className="mt-4 flex items-center gap-3 rounded-r-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.08)] p-4">
           <ClipboardTextIcon
             aria-hidden="true"
             className="shrink-0 text-[var(--landing-accent-bright)]"

--- a/src/components/landing/RouterLanding.tsx
+++ b/src/components/landing/RouterLanding.tsx
@@ -329,7 +329,7 @@ function SearchStateLab() {
             </div>
           ))}
         </dl>
-        <div className="mt-5 rounded-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.1)] p-4 text-ds-body-xs text-text-primary/45">
+        <div className="mt-5 rounded-r-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.1)] p-4 text-ds-body-xs text-text-primary/45">
           Typed state is now bookmarkable, shareable, and safe to consume in
           loaders and components.
         </div>

--- a/src/components/landing/StartLanding.tsx
+++ b/src/components/landing/StartLanding.tsx
@@ -200,7 +200,7 @@ function ExecutionMapHero() {
           />
         </div>
 
-        <div className="mt-4 rounded-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.1)] px-4 py-3">
+        <div className="mt-4 rounded-r-lg border-l-2 border-[var(--landing-accent)] bg-[color:rgb(var(--landing-glow)/0.1)] px-4 py-3">
           <p className="font-ds-mono text-ds-mono-caps-xs uppercase text-[var(--landing-accent-bright)]">
             {mode.label}
           </p>


### PR DESCRIPTION
Three landing callouts set `rounded-lg` together with `border-l-2`, so the 2px accent border was dragged around an 8px corner radius with no adjacent border to continue into. The bar tapers and detaches at both ends instead of reading as a flush accent rule.

Confirmed on the live build:

```
border-left: 2px    border-top: 0px
border-top-left-radius: 8px
```

## The fix

`rounded-lg` → `rounded-r-lg`. The bordered edge goes square, the bar sits flush, the outer corners stay rounded.

This is the idiom the codebase already uses correctly in two places, so it matches house style rather than introducing a new one:

- `Toc.tsx` — `border-l-2 rounded-r`
- `HomeSectionFallbacks.tsx` — `rounded-r-md border-l-2`

## Scope

All three instances of the pattern, not just the one that was reported — they share the same accent token and fixing one would have left two identical siblings wrong:

- `landing/StartLanding.tsx:203`
- `landing/RouterLanding.tsx:332`
- `landing/ConfigLanding.tsx:245`

I audited every `rounded-*` + `border-{l,r,t,b}-N` pairing in the repo. Everything else is legitimate — already squared on the bordered edge, joining two adjacent surfaces (`rounded-t-*` with `border-b-0`, as in the markdown tabs and `ProductDrawer`), or the spinner idiom (`rounded-full border-b-2`). **These three were the only violations.**

## Verification

`pnpm test` green: 0 type errors, 0 lint warnings, 466 tests.

Not verified visually — the preview pane was bound to another worktree at the time. The change is a deterministic radius swap with in-repo precedent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated landing page callout and note panels to round only their right corners, creating a more consistent visual treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->