### PR TITLE
Fix overlay migration regressions

### DIFF
--- a/src/components/ExampleDeployDialog.tsx
+++ b/src/components/ExampleDeployDialog.tsx
@@ -427,7 +427,7 @@ export function ExampleDeployDialog({
                 </a>
                 {countdown !== null && countdown > 0 && (
                   <p className="mt-4 text-sm text-text-muted">
-                    Redirecting to {providerInfo.name} in {countdown}state...
+                    Redirecting to {providerInfo.name} in {countdown}s...
                   </p>
                 )}
               </DialogStatus>

--- a/src/components/application-starter/DeployDialog.tsx
+++ b/src/components/application-starter/DeployDialog.tsx
@@ -516,7 +516,7 @@ export function DeployDialog({
                 </a>
                 {providerInfo && countdown !== null && countdown > 0 && (
                   <p className="mt-4 text-sm text-text-muted">
-                    Redirecting to {providerInfo.name} in {countdown}state...
+                    Redirecting to {providerInfo.name} in {countdown}s...
                   </p>
                 )}
               </DialogStatus>

--- a/src/components/shop/CartDrawer.tsx
+++ b/src/components/shop/CartDrawer.tsx
@@ -49,7 +49,7 @@ export function CartDrawer({ open, onOpenChange }: CartDrawerProps) {
         <DrawerHeader
           className="border-shop-line px-5 py-3"
           title={
-            <ShopLabel as="h2">
+            <ShopLabel as="span">
               Cart{totalQuantity > 0 ? ` (${totalQuantity})` : ''}
             </ShopLabel>
           }


### PR DESCRIPTION
## Evidence

Merged PR #1205 left two user-visible overlay migration regressions in current main:

- Both deploy success dialogs render countdown text such as `3state...` instead of `3s...`.
- `DrawerHeader` already renders a Radix `h2`, but `CartDrawer` passes another `h2` as its title, producing invalid nested heading markup.

The findings are recorded in unresolved review threads on #1205. Repeated title and body searches found no issue or PR owning these exact regressions. Open PR #1123 touches the cart as part of an older broad primitive migration, but it does not apply this current fix and is not an owner for the countdown regression.

## Impact

- Restores readable deploy redirect feedback.
- Restores one valid accessible heading for the cart drawer.

## Validation

- `pnpm test`
- TypeScript and type-aware lint pass.
- 479 tests total, 478 passed, 1 environment-gated docs smoke test skipped.
- `git diff --check`

## Risk

Low. This changes two literal countdown suffixes and the inner cart title element from `h2` to `span`; the outer Radix title remains the accessible `h2`.

Source: #1205
