### PR TITLE
fix: updated offset feedback button below code block header

### DIFF
--- a/src/components/DocFeedbackProvider.tsx
+++ b/src/components/DocFeedbackProvider.tsx
@@ -401,8 +401,12 @@ function BlockButton({
   if (!portalContainer) {
     portalContainer = document.createElement('div')
     portalContainer.setAttribute('data-button-portal', blockId)
-    portalContainer.className =
-      'absolute top-0 right-0 -translate-y-full z-[100]'
+    // Nudge down when following a <code> block so the button doesn't overlap with the code's top bar
+    const precedesCodeBlock = block.lastElementChild?.tagName === 'CODE'
+    portalContainer.className = twMerge(
+      'absolute right-0 -translate-y-full z-[100]',
+      precedesCodeBlock ? 'top-6' : 'top-0',
+    )
     portalContainer.style.position = 'absolute'
 
     // Make the block relatively positioned if not already


### PR DESCRIPTION
## What

Adjust the feedback button's vertical offset in `DocFeedbackProvider.tsx` so it sits lower (`top-6`) when its portal container is appended right after a `<code>` block, instead of `top-0`.

## Why

The feedback button's portal container (`[data-button-portal]`) is appended as the last child of the block, so when a block ends with a `<code>` element, the button ends up rendering underneath the code block's top bar (with the copy button), making it invisible/mostly unclickable on hover. Offsetting it to `top-6` in that case keeps the button visible below the code block's header.

## Testing

- Tested locally on the Query documentation pages
- Verified the feedback button is visible and clickable on hover for `<code>` blocks
- Verified normal (`top-0`) positioning is unaffected for other block types
- Ran `pnpm lint`

## Screenshot with the provided fix
<img width="608" height="330" alt="Screenshot 2026-09-02 at 22 11 15" src="https://github.com/user-attachments/assets/10b45e9a-b76d-4223-a95f-b4d231bf199f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of feedback controls for content blocks ending with code elements.
  * Preserved the existing positioning for other content blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->