### PR TITLE
Keep docs webhook invalidation alive

### DIFF
--- a/src/routes/api/github/webhook.ts
+++ b/src/routes/api/github/webhook.ts
@@ -79,11 +79,13 @@ export const Route = createFileRoute("/api/github/webhook")({
           { env },
           { libraries },
           { purgeHostingCacheTags },
+          { scheduleHostRuntimeTask },
         ] = await Promise.all([
           import("~/utils/github-content-cache.server"),
           import("~/utils/env"),
           import("~/libraries"),
           import("~/utils/hosting-cache.server"),
+          import("~/server/runtime/host.server"),
         ]);
         const bodyResult = await readTextBody(request, MAX_GITHUB_WEBHOOK_BYTES);
         if (!bodyResult.success) {
@@ -154,11 +156,6 @@ export const Route = createFileRoute("/api/github/webhook")({
           ),
         );
 
-        const [staleContentCount, staleArtifactCount] = await Promise.all([
-          markGitHubContentStale({ repo, gitRef }),
-          markDocsArtifactsStale({ repo, gitRef }),
-        ]);
-
         const tags = [
           `docs-config:${repo}:${gitRef}`,
           ...libraries
@@ -169,7 +166,39 @@ export const Route = createFileRoute("/api/github/webhook")({
             .map((library) => `docs:${library.id}:branch:${gitRef}`),
         ];
 
-        const purge = await purgeHostingCacheTags(tags);
+        const invalidate = async () => {
+          const [staleContentCount, staleArtifactCount] = await Promise.all([
+            markGitHubContentStale({ repo, gitRef }),
+            markDocsArtifactsStale({ repo, gitRef }),
+          ]);
+          const purge = await purgeHostingCacheTags(tags);
+
+          return { purge, staleArtifactCount, staleContentCount };
+        };
+
+        if (
+          scheduleHostRuntimeTask(async () => {
+            try {
+              await invalidate();
+            } catch (error) {
+              console.error("[GitHub webhook] cache invalidation failed", {
+                error,
+                gitRef,
+                repo,
+              });
+            }
+          })
+        ) {
+          return jsonResponse({
+            ok: true,
+            gitRef,
+            changedPathCount: changedPaths.length,
+            scheduled: true,
+          });
+        }
+
+        const { purge, staleArtifactCount, staleContentCount } =
+          await invalidate();
 
         return jsonResponse({
           ok: true,


### PR DESCRIPTION
Closes #1216

## Evidence

The Query main push for commit a29ca6886 reached the configured tanstack.com webhook at 2026-09-03 09:08:40 UTC, but GitHub stopped waiting after 10 seconds and recorded a timeout with no response. The matching production redirect still fell through to the framework index. The handler currently waits for every cached content record and docs artifact to be marked stale, then waits for the Cloudflare tag purge, before it returns.

## Fix

Use the existing host runtime waitUntil path to keep cache invalidation and the CDN purge alive after returning a successful webhook response. Non-host runtimes retain the synchronous behavior, and background failures are logged with the repository and ref.

## Impact

Docs pushes can acknowledge GitHub before its 10 second deadline while preserving the complete invalidation and purge sequence. This prevents large cached repositories from missing updates such as redirect_from changes.

## Validation

- pnpm test
- TypeScript and type-aware lint clean
- 479 tests total, 478 passed, 1 environment-gated docs smoke test skipped
- git diff --check

## Risk

Low. The invalidation work is unchanged and still runs in the same order. In the Cloudflare runtime the webhook response reports that work was scheduled instead of waiting for its counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * GitHub webhook processing now responds immediately when cache invalidation can be scheduled in the background.
  * A fallback continues to complete cache invalidation before responding when scheduling is unavailable.
  * Webhook responses indicate when invalidation has been successfully scheduled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->