### PR TITLE
fix(builder): unlock BYOK passkey on the click, not mid-send

### DIFF
--- a/scripts/test-builder-passkey-submit.mjs
+++ b/scripts/test-builder-passkey-submit.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { chromium } from 'playwright-core'
+
+// Run against the local dev server: node scripts/test-builder-passkey-submit.mjs
+const origin = process.env.BUILDER_TEST_ORIGIN ?? 'http://127.0.0.1:3008'
+assert.ok(['localhost', '127.0.0.1'].includes(new URL(origin).hostname))
+const browser = await chromium.launch({ channel: 'chrome', headless: true })
+try {
+  const page = await browser.newPage()
+  await page.addInitScript(() => {
+    class Passkey {
+      rawId = new Uint8Array([1]).buffer
+      getClientExtensionResults() {
+        return {
+          prf: { enabled: true, results: { first: new Uint8Array(32) } },
+        }
+      }
+    }
+    window.passkeyCalls = 0
+    Object.defineProperty(window, 'PublicKeyCredential', { value: Passkey })
+    Object.defineProperty(navigator, 'credentials', {
+      value: {
+        async create() {
+          return new Passkey()
+        },
+        get() {
+          window.passkeyCalls += 1
+          return new Promise((resolve, reject) => {
+            window.cancelPasskey = () =>
+              reject(new Error('Cancelled test passkey'))
+            window.unlockPasskey = () => resolve(new Passkey())
+          })
+        },
+      },
+    })
+  })
+  await page.goto(`${origin}/builder/ai`)
+  await page.evaluate(async () => {
+    const base = await crypto.subtle.importKey(
+      'raw',
+      new Uint8Array(32),
+      'HKDF',
+      false,
+      ['deriveKey'],
+    )
+    const key = await crypto.subtle.deriveKey(
+      {
+        name: 'HKDF',
+        hash: 'SHA-256',
+        salt: new Uint8Array(0),
+        info: new TextEncoder().encode('byok:keyring:v1'),
+      },
+      base,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt'],
+    )
+    const iv = crypto.getRandomValues(new Uint8Array(12))
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      new TextEncoder().encode(
+        JSON.stringify({ openai: 'sk-test-not-a-real-key' }),
+      ),
+    )
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.open(
+        'tanstack-builder-ai:byok:v1:local-spike',
+        1,
+      )
+      request.onupgradeneeded = () =>
+        request.result.createObjectStore('keyring', { keyPath: 'id' })
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => {
+        const tx = request.result.transaction('keyring', 'readwrite')
+        tx.objectStore('keyring').put({
+          id: 'default',
+          credentialId: new Uint8Array([1]).buffer,
+          salt: new Uint8Array(32).buffer,
+          iv: iv.buffer,
+          ciphertext,
+          preview: { openai: '-key' },
+        })
+        tx.oncomplete = () => {
+          request.result.close()
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+    })
+  })
+  await page.reload()
+  const composer = page.locator('#builder-ai-prompt')
+  await composer.waitFor({ timeout: 60_000 })
+  await composer.pressSequentially('Keep this draft after a cancelled unlock', {
+    delay: 30,
+  })
+  await page.getByRole('button', { name: 'Send message', exact: true }).click()
+  await page.waitForFunction(() => window.passkeyCalls === 1)
+  assert.equal(await composer.isDisabled(), true)
+  await page
+    .locator('form')
+    .filter({ has: composer })
+    .evaluate((form) => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      )
+    })
+  assert.equal(await page.evaluate(() => window.passkeyCalls), 1)
+  await page.evaluate(() => window.cancelPasskey())
+  await page.waitForFunction(
+    () => !document.querySelector('#builder-ai-prompt').disabled,
+  )
+  assert.equal(
+    await composer.inputValue(),
+    'Keep this draft after a cancelled unlock',
+  )
+
+  console.log('Builder passkey submission checks passed')
+} finally {
+  await browser.close()
+}

--- a/src/components/builder/BuilderAssistant.client.tsx
+++ b/src/components/builder/BuilderAssistant.client.tsx
@@ -364,6 +364,7 @@ export const BuilderAssistant = React.forwardRef<
   const [queueAnnouncement, setQueueAnnouncement] = React.useState('')
   const [showLatest, setShowLatest] = React.useState(false)
   const abortRef = React.useRef<AbortController>(null)
+  const unlockingRef = React.useRef(false)
   const onRunningChangeRef = React.useRef(onRunningChange)
   const abortIntentRef = React.useRef<'steer' | 'stop' | undefined>(undefined)
   const agentStreamingRef = React.useRef(false)
@@ -1395,13 +1396,24 @@ export const BuilderAssistant = React.forwardRef<
     // prompt (it silently never resolves) if the unlock runs later in the
     // async send pipeline, past the activation window.
     if (selectedModel.connection === 'byok') {
-      await unlockApiKey(selectedModel.provider)
+      // Guard the async unlock window: ignore repeat submits while the passkey
+      // ceremony is pending (a second ceremony would be rejected anyway), and
+      // read the model once so a mid-await model change cannot alter the target.
+      if (unlockingRef.current) return
+      const provider = selectedModel.provider
+      unlockingRef.current = true
+      try {
+        await unlockApiKey(provider)
+      } finally {
+        unlockingRef.current = false
+      }
       // Bail if it is still locked (unlock cancelled or failed) — the run
       // pipeline can no longer surface the WebAuthn prompt itself.
-      const client = byokConnection.getClient(selectedModel.provider, {
-        allowUnlock: false,
-      })
-      if (!client) return
+      const client = byokConnection.getClient(provider, { allowUnlock: false })
+      if (!client) {
+        setError('Could not unlock the API key. Try again.')
+        return
+      }
     }
     submitInstruction(prompt, sendMode, true)
   }

--- a/src/components/builder/BuilderAssistant.client.tsx
+++ b/src/components/builder/BuilderAssistant.client.tsx
@@ -1388,8 +1388,21 @@ export const BuilderAssistant = React.forwardRef<
     discardUnrecordedPrompt()
   }
 
-  function submit(event: React.FormEvent) {
+  async function submit(event: React.FormEvent) {
     event.preventDefault()
+    // Unlock the passkey-encrypted BYOK key here, on the click, while the
+    // user activation is still fresh. Safari and Dia suppress the WebAuthn
+    // prompt (it silently never resolves) if the unlock runs later in the
+    // async send pipeline, past the activation window.
+    if (selectedModel.connection === 'byok') {
+      await unlockApiKey(selectedModel.provider)
+      // Bail if it is still locked (unlock cancelled or failed) — the run
+      // pipeline can no longer surface the WebAuthn prompt itself.
+      const client = byokConnection.getClient(selectedModel.provider, {
+        allowUnlock: false,
+      })
+      if (!client) return
+    }
     submitInstruction(prompt, sendMode, true)
   }
 

--- a/src/components/builder/BuilderAssistant.client.tsx
+++ b/src/components/builder/BuilderAssistant.client.tsx
@@ -365,6 +365,7 @@ export const BuilderAssistant = React.forwardRef<
   const [showLatest, setShowLatest] = React.useState(false)
   const abortRef = React.useRef<AbortController>(null)
   const unlockingRef = React.useRef(false)
+  const [unlocking, setUnlocking] = React.useState(false)
   const onRunningChangeRef = React.useRef(onRunningChange)
   const abortIntentRef = React.useRef<'steer' | 'stop' | undefined>(undefined)
   const agentStreamingRef = React.useRef(false)
@@ -412,6 +413,10 @@ export const BuilderAssistant = React.forwardRef<
   promptValueRef.current = prompt
   canUsePendingPromptRef.current = canUsePendingPrompt
   startPromptSequenceRef.current = startPromptSequence
+
+  React.useLayoutEffect(() => {
+    pendingSubmissionGenerationRef.current += 1
+  }, [threadId, storageScope, credentialScope, selectedModel])
 
   React.useLayoutEffect(() => {
     if (credentialScopeRef.current === credentialScope) return
@@ -661,7 +666,17 @@ export const BuilderAssistant = React.forwardRef<
       setHydratedThreadId(threadId)
       return
     }
+  }, [
+    hydratedThreadId,
+    syncedMessages,
+    syncedProjectId,
+    syncedRuns,
+    syncedThreads,
+    threadId,
+  ])
 
+  React.useEffect(() => {
+    if (syncedProjectId) return
     const generation = hydrationGenerationRef.current + 1
     hydrationGenerationRef.current = generation
     setHydratedThreadId(undefined)
@@ -692,16 +707,7 @@ export const BuilderAssistant = React.forwardRef<
         hydrationGenerationRef.current += 1
       }
     }
-  }, [
-    hydratedThreadId,
-    refreshThreads,
-    storageScope,
-    syncedMessages,
-    syncedProjectId,
-    syncedRuns,
-    syncedThreads,
-    threadId,
-  ])
+  }, [refreshThreads, storageScope, syncedProjectId, threadId])
 
   React.useEffect(() => {
     const currentProjectSync = projectSync
@@ -1029,7 +1035,7 @@ export const BuilderAssistant = React.forwardRef<
   }, [])
 
   function selectModel(model: ModelChoice) {
-    if (running) return
+    if (running || unlockingRef.current) return
     didSelectConnectionRef.current =
       model.connection !== 'chatgpt' || Boolean(model.model)
     setSelectedModel(model)
@@ -1326,7 +1332,10 @@ export const BuilderAssistant = React.forwardRef<
     const promptQueue = promptQueueRef.current
     promptQueue.enqueuePrompt(queuedPrompt)
     syncQueuedPrompts()
-    if (clearComposer) {
+    if (
+      clearComposer &&
+      promptValueRef.current.trim() === queuedPrompt.content
+    ) {
       promptValueRef.current = ''
       setPrompt('')
       setSendMode('queue')
@@ -1389,32 +1398,8 @@ export const BuilderAssistant = React.forwardRef<
     discardUnrecordedPrompt()
   }
 
-  async function submit(event: React.FormEvent) {
+  function submit(event: React.FormEvent) {
     event.preventDefault()
-    // Unlock the passkey-encrypted BYOK key here, on the click, while the
-    // user activation is still fresh. Safari and Dia suppress the WebAuthn
-    // prompt (it silently never resolves) if the unlock runs later in the
-    // async send pipeline, past the activation window.
-    if (selectedModel.connection === 'byok') {
-      // Guard the async unlock window: ignore repeat submits while the passkey
-      // ceremony is pending (a second ceremony would be rejected anyway), and
-      // read the model once so a mid-await model change cannot alter the target.
-      if (unlockingRef.current) return
-      const provider = selectedModel.provider
-      unlockingRef.current = true
-      try {
-        await unlockApiKey(provider)
-      } finally {
-        unlockingRef.current = false
-      }
-      // Bail if it is still locked (unlock cancelled or failed) — the run
-      // pipeline can no longer surface the WebAuthn prompt itself.
-      const client = byokConnection.getClient(provider, { allowUnlock: false })
-      if (!client) {
-        setError('Could not unlock the API key. Try again.')
-        return
-      }
-    }
     submitInstruction(prompt, sendMode, true)
   }
 
@@ -1435,11 +1420,50 @@ export const BuilderAssistant = React.forwardRef<
       !instruction ||
       instruction.length > 10_000 ||
       hydrating ||
-      needsConnection
+      needsConnection ||
+      unlockingRef.current
     ) {
       return false
     }
 
+    // Both the composer and preview comments enter here, directly from the
+    // user action, before persistence or sandbox work can expire activation.
+    if (
+      selectedModel.connection === 'byok' &&
+      !byokConnection.getClient(selectedModel.provider, { allowUnlock: false })
+    ) {
+      const provider = selectedModel.provider
+      const generation = pendingSubmissionGenerationRef.current
+      unlockingRef.current = true
+      setUnlocking(true)
+      void unlockApiKey(provider).then(() => {
+        unlockingRef.current = false
+        if (mountedRef.current) setUnlocking(false)
+        if (
+          !mountedRef.current ||
+          generation !== pendingSubmissionGenerationRef.current
+        ) {
+          lifecycle?.onDiscarded?.()
+          return
+        }
+        if (!byokConnection.getClient(provider, { allowUnlock: false })) {
+          setError('Could not unlock the API key. Try again.')
+          lifecycle?.onDiscarded?.()
+          return
+        }
+        enqueueInstruction(instruction, mode, clearComposer, lifecycle)
+      })
+      return true
+    }
+    return enqueueInstruction(instruction, mode, clearComposer, lifecycle)
+  }
+
+  function enqueueInstruction(
+    instruction: string,
+    mode: BuilderAiSendMode,
+    clearComposer: boolean,
+    lifecycle?: BuilderAiPromptLifecycle,
+  ) {
     const promptQueue = promptQueueRef.current
     const claimed = promptQueue.claim()
     const queuedPrompt: BuilderAiQueuedPrompt = {
@@ -1540,7 +1564,10 @@ export const BuilderAssistant = React.forwardRef<
     initialPrompt: BuilderAiQueuedPrompt,
     clearComposer: boolean,
   ) {
-    if (clearComposer) {
+    if (
+      clearComposer &&
+      promptValueRef.current.trim() === initialPrompt.content
+    ) {
       promptValueRef.current = ''
       setPrompt('')
       setSendMode('queue')
@@ -2641,7 +2668,8 @@ export const BuilderAssistant = React.forwardRef<
     }
   }
 
-  const submitDisabled = hydrating || !prompt.trim() || needsConnection
+  const submitDisabled =
+    hydrating || unlocking || !prompt.trim() || needsConnection
   const stopLabel =
     queuedPrompts.length === 0
       ? 'Stop response'
@@ -2968,6 +2996,7 @@ export const BuilderAssistant = React.forwardRef<
                 ref={promptRef}
                 id="builder-ai-prompt"
                 value={prompt}
+                disabled={unlocking}
                 rows={1}
                 maxLength={10_000}
                 placeholder="Describe a builder change"
@@ -2987,7 +3016,7 @@ export const BuilderAssistant = React.forwardRef<
               <div className="flex items-center justify-between gap-3 pl-1">
                 <ModelPicker
                   chatGptModels={chatGptModels}
-                  disabled={running}
+                  disabled={running || unlocking}
                   selected={selectedModel}
                   showChatGpt={supportsChatGptLogin}
                   onSelect={selectModel}


### PR DESCRIPTION
Saved BYOK keys could stall Builder sends because the passkey unlock started too late in the send pipeline. Jack traced the failure to expired browser user activation.

## Fix

- Start unlock from the shared submission handler, for both composer messages and preview comments.
- Block duplicate submissions and composer/model edits while unlock is pending.
- Discard pending submissions after a conversation, credential scope, or model change. Restore preview comments when unlock fails.
- Only clear the composer when it still contains the submitted message.
- Separate local transcript hydration from synced-project updates. Local hydration previously retriggered itself and kept Send disabled.

## Testing

- `pnpm test`: passed, including type checks, lint, and 478 passing tests, with one skipped test.
- `node scripts/test-builder-passkey-submit.mjs`: passed against a local dev server. It uses an isolated browser and a fake encrypted key to check duplicate submission, disabled editing during unlock, and draft preservation after cancellation.
- Jack's original investigation covered fresh-click versus delayed unlock in Dia/Safari. The automated browser check mocks the passkey ceremony, it does not test 1Password itself.

## Companion SDK change

https://github.com/TanStack/ai/pull/1332 adds the failed-activation error for existing keyrings while preserving first-time registration's follow-up PRF ceremony.

## Attribution

Original fix and investigation by Jack Herrington. Follow-up fixes are added to his existing PR without replacing his commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate submissions while passkey unlocking is in progress.
  * Ensured the submission continues with the provider selected when unlocking begins.
  * Disabled the composer, submit button, and model picker during passkey unlocking.
  * Preserved draft text when a passkey unlock is canceled.
  * Prevented outdated in-progress unlocks from affecting newer conversations, credential scopes, or model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->