### PR TITLE
Fix docs title during loader failures

### DIFF
--- a/src/routes/_library/$libraryId/$version.docs.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.$.tsx
@@ -99,7 +99,9 @@ export const Route = createFileRoute('/_library/$libraryId/$version/docs/$')({
     return {
       meta: [
         ...seo({
-          title: `${loaderData?.title} | ${library.name} Docs`,
+          title: loaderData?.title
+            ? `${loaderData.title} | ${library.name} Docs`
+            : `${library.name} Docs`,
           description: loaderData?.description,
           keywords: loaderData?.keywords,
           image: ogImageUrl(library.id, {


### PR DESCRIPTION
## What

- Keep the generic docs page title meaningful when its loader data is unavailable.
- Use the same library-level fallback already used by framework docs routes.

## Evidence

Issue #1219 shows `undefined | TanStack Router Docs` while a connectivity failure triggers the route error UI. The generic docs route interpolates the optional loader title into a template string, which converts a missing value into the literal word `undefined`.

## Impact

Connectivity and other transient loader failures now keep a useful title such as `TanStack Router Docs`. Successful document loads keep their existing title.

## Validation

- `pnpm test` passed twice, including the commit hook: TypeScript and type-aware lint are clean, 479 tests total, 478 passed, and 1 environment-gated docs smoke test skipped.
- `git diff --check` passed.

## Risk

Very low. This changes one metadata fallback and does not affect successful loader output.

Closes #1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation page titles by removing the “undefined” prefix when a page title is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->