### PR TITLE
perf: lazy-load global login and libraries overlays

### DIFF
--- a/src/contexts/LibrariesOverlayContext.tsx
+++ b/src/contexts/LibrariesOverlayContext.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { useLocation } from '@tanstack/react-router'
-import { LibrariesOverlay } from '~/components/LibrariesOverlay'
+
+const LazyLibrariesOverlay = React.lazy(() =>
+  import('~/components/LibrariesOverlay').then((m) => ({
+    default: m.LibrariesOverlay,
+  })),
+)
 
 interface LibrariesOverlayContextValue {
   openLibraries: (options?: { onBack?: () => void }) => void
@@ -35,6 +40,7 @@ export function LibrariesOverlayProvider({
   children: React.ReactNode
 }) {
   const [isOpen, setIsOpen] = React.useState(false)
+  const [hasLoadedOverlay, setHasLoadedOverlay] = React.useState(false)
   const [returnTarget, setReturnTarget] = React.useState<{
     onBack: () => void
   } | null>(null)
@@ -42,6 +48,7 @@ export function LibrariesOverlayProvider({
   const openLibraries = React.useCallback(
     (options?: { onBack?: () => void }) => {
       setReturnTarget(options?.onBack ? { onBack: options.onBack } : null)
+      setHasLoadedOverlay(true)
       setIsOpen(true)
     },
     [],
@@ -74,11 +81,15 @@ export function LibrariesOverlayProvider({
   return (
     <LibrariesOverlayContext.Provider value={value}>
       {children}
-      <LibrariesOverlay
-        open={isOpen}
-        onBack={returnTarget ? returnToMenu : undefined}
-        onClose={closeLibraries}
-      />
+      {hasLoadedOverlay ? (
+        <React.Suspense fallback={null}>
+          <LazyLibrariesOverlay
+            open={isOpen}
+            onBack={returnTarget ? returnToMenu : undefined}
+            onClose={closeLibraries}
+          />
+        </React.Suspense>
+      ) : null}
     </LibrariesOverlayContext.Provider>
   )
 }

--- a/src/contexts/LoginModalContext.tsx
+++ b/src/contexts/LoginModalContext.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { LoginModal } from '~/components/LoginModal'
 import { currentUserQueryOptions } from '~/hooks/useCurrentUser'
+
+const LazyLoginModal = React.lazy(() =>
+  import('~/components/LoginModal').then((m) => ({ default: m.LoginModal })),
+)
 
 interface LoginModalContextValue {
   openLoginModal: (options?: {
@@ -38,6 +41,7 @@ interface LoginModalProviderProps {
 export function LoginModalProvider({ children }: LoginModalProviderProps) {
   const queryClient = useQueryClient()
   const [isOpen, setIsOpen] = React.useState(false)
+  const [hasLoadedModal, setHasLoadedModal] = React.useState(false)
   const [description, setDescription] = React.useState<string>()
   const pendingOnSuccessRef = React.useRef<(() => void) | undefined>(undefined)
 
@@ -45,6 +49,7 @@ export function LoginModalProvider({ children }: LoginModalProviderProps) {
     (options?: { description?: string; onSuccess?: () => void }) => {
       pendingOnSuccessRef.current = options?.onSuccess
       setDescription(options?.description)
+      setHasLoadedModal(true)
       setIsOpen(true)
     },
     [],
@@ -89,11 +94,15 @@ export function LoginModalProvider({ children }: LoginModalProviderProps) {
   return (
     <LoginModalContext.Provider value={value}>
       {children}
-      <LoginModal
-        open={isOpen}
-        description={description}
-        onOpenChange={handleOpenChange}
-      />
+      {hasLoadedModal ? (
+        <React.Suspense fallback={null}>
+          <LazyLoginModal
+            open={isOpen}
+            description={description}
+            onOpenChange={handleOpenChange}
+          />
+        </React.Suspense>
+      ) : null}
     </LoginModalContext.Provider>
   )
 }


### PR DESCRIPTION
The global shell eagerly imported the login dialog and libraries overlay even when visitors never opened them. Load each through React.lazy on its first explicit open, with a local Suspense boundary. Keep it mounted after that first open so Radix can handle closing animations and subsequent opens.

Production build comparison using the same installed dependencies:

| Client entry and static JS imports | Before | After |
| --- | ---: | ---: |
| Raw bytes | 1,305,258 | 1,278,499 |
| Gzip bytes | 397,499 | 389,414 |
| Brotli bytes | 326,403 | 319,692 |

This moves 8,085 gzip bytes out of the entry's static import graph. Both overlays emit separate async chunks. These figures exclude route chunks and are not a whole-page transfer measurement; the first opening now waits for its async chunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Libraries and login interfaces now load only when opened, helping improve initial application loading performance.
  - Unused overlays and modals no longer load until they are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->