### PR TITLE
chore: update redact to 0.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "@tanstack/devtools-vite": "^0.7.0",
     "@tanstack/react-devtools": "^0.10.5",
     "@tanstack/react-query-devtools": "^5.100.11",
-    "@tanstack/redact": "^0.0.20",
+    "@tanstack/redact": "^0.0.21",
     "@types/d3-interpolate": "3.0.4",
     "@types/d3-scale": "4.0.9",
     "@types/d3-shape": "3.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ importers:
         specifier: ^5.100.11
         version: 5.100.11(@tanstack/react-query@5.100.11(react@19.2.3))(react@19.2.3)
       '@tanstack/redact':
-        specifier: ^0.0.20
-        version: 0.0.20(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: ^0.0.21
+        version: 0.0.21(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/d3-interpolate':
         specifier: 3.0.4
         version: 3.0.4
@@ -3636,8 +3636,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/redact@0.0.20':
-    resolution: {integrity: sha512-YBekp8UaZh+P2uj7W8j7+hjHm34YCNFNdTYBOfWR/A0o343RsT9V1pKlI/r5rwn5KDn+ffTDhK1qLzYiz0QikQ==}
+  '@tanstack/redact@0.0.21':
+    resolution: {integrity: sha512-8wYcXuehAYPR2qUAMfhz72yVlY2nUKKLrTopBjhdUxCjsdSTQP/cRV57BFtD18/vHZeIjMvTpuCxskhVyovE7Q==}
     peerDependencies:
       vite: '>=5'
     peerDependenciesMeta:
@@ -9868,7 +9868,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/redact@0.0.20(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/redact@0.0.21(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     optionalDependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 


### PR DESCRIPTION
Updates @tanstack/redact to the latest published version, 0.0.21, and refreshes the pnpm lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->