### PR TITLE
Fix Illegal invocation when opening saved Builder projects

### DIFF
--- a/src/utils/builder-project-sync.client.ts
+++ b/src/utils/builder-project-sync.client.ts
@@ -495,7 +495,7 @@ export type BuilderProjectSyncCollection = ReturnType<
 
 export function getBuilderProjectBrowserSessionId({
   storage = getSessionStorage(),
-  createId = crypto.randomUUID,
+  createId = () => crypto.randomUUID(),
 }: {
   storage?: Pick<Storage, 'getItem' | 'setItem'>
   createId?: () => string
@@ -512,7 +512,7 @@ export function getBuilderProjectBrowserSessionId({
 async function claimBuilderProjectBrowserSession({
   storage = getSessionStorage(),
   lockManager = getBrowserSessionLockManager(),
-  createId = crypto.randomUUID,
+  createId = () => crypto.randomUUID(),
 }: {
   storage?: Pick<Storage, 'getItem' | 'setItem'>
   lockManager?: BuilderProjectBrowserSessionLockManager

--- a/tests/builder-project-sync-client.test.ts
+++ b/tests/builder-project-sync-client.test.ts
@@ -131,6 +131,49 @@ test('Builder project browser sessions remain stable in session storage', () => 
   )
 })
 
+test('the default browser session generator preserves the Crypto receiver', (context) => {
+  const original = crypto.randomUUID
+  context.mock.method(crypto, 'randomUUID', function (this: Crypto) {
+    if (this !== crypto) throw new TypeError('Illegal invocation')
+    return original.call(this)
+  })
+  const storage = memoryStorage()
+  const id = getBuilderProjectBrowserSessionId({ storage })
+  assert.match(id, /^[a-f0-9-]{36}$/)
+  assert.equal(getBuilderProjectBrowserSessionId({ storage }), id)
+})
+
+test('saved project sync starts with the browser-native session generator', async (context) => {
+  const original = crypto.randomUUID
+  context.mock.method(crypto, 'randomUUID', function (this: Crypto) {
+    if (this !== crypto) throw new TypeError('Illegal invocation')
+    return original.call(this)
+  })
+  await withFakeIndexedDb(async () => {
+    const storage = memoryStorage()
+    const client = await createBuilderProjectSyncClient({
+      projectId,
+      sessionStorage: storage,
+      browserSessionLockManager: memoryLockManager(),
+      fetch: async () => jsonSnapshotPage(snapshot),
+      createEventSource: () => ({
+        readyState: 1,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        close: () => undefined,
+      }),
+    })
+    try {
+      assert.equal(
+        client.browserSessionId,
+        getBuilderProjectBrowserSessionId({ storage }),
+      )
+    } finally {
+      await client.cleanup()
+    }
+  })
+})
+
 test('durable project revisions enter the outbox before upload', async () => {
   await withFakeIndexedDb(async (indexedDb) => {
     const nextRevisionId = uuid(50)


### PR DESCRIPTION
Saved-project sync detached crypto.randomUUID from its Crypto receiver. Chrome rejects that call with Illegal invocation when generating a browser session after the save redirect. Call it through crypto in both default generators.

Adds regressions that enforce the browser receiver check for both the session helper and saved-project sync startup. Both failed before the fix and pass now. All 16 sync tests pass, and the local full test, type, and lint checks pass.

This PR contains only the sync fix and its tests. No OpenRouter integration, dependency changes, or database migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser session ID generation to reliably use the browser’s native cryptographic context.
  * Ensured saved project sync clients initialize with a consistent browser session ID.

* **Tests**
  * Added coverage for session ID generation and default project sync client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->