### PR TITLE
chore: upgrade Redact to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@tanstack/devtools-vite": "^0.7.0",
     "@tanstack/react-devtools": "^0.10.5",
     "@tanstack/react-query-devtools": "^5.100.11",
-    "@tanstack/redact": "^0.0.21",
+    "@tanstack/redact": "^0.1.0",
     "@types/d3-interpolate": "3.0.4",
     "@types/d3-scale": "4.0.9",
     "@types/d3-shape": "3.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: ^5.100.11
         version: 5.100.11(@tanstack/react-query@5.100.11(react@19.2.3))(react@19.2.3)
       '@tanstack/redact':
-        specifier: ^0.0.21
-        version: 0.0.21(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: ^0.1.0
+        version: 0.1.0(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/d3-interpolate':
         specifier: 3.0.4
         version: 3.0.4
@@ -3645,8 +3645,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/redact@0.0.21':
-    resolution: {integrity: sha512-8wYcXuehAYPR2qUAMfhz72yVlY2nUKKLrTopBjhdUxCjsdSTQP/cRV57BFtD18/vHZeIjMvTpuCxskhVyovE7Q==}
+  '@tanstack/redact@0.1.0':
+    resolution: {integrity: sha512-iauMc/2TLcrlEu0yt58k9ntVraIbKcijp7qJ79wWLPMGxznk6mO436DiSYHoAD0+OP3Yo1WOiGiooRfD8/Ic8Q==}
     peerDependencies:
       vite: '>=5'
     peerDependenciesMeta:
@@ -9888,7 +9888,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/redact@0.0.21(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/redact@0.1.0(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     optionalDependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 


### PR DESCRIPTION
## Changes

Upgrade `@tanstack/redact` from 0.0.21 to the published 0.1.0 release. Only the dependency and lockfile change. The Vite configuration and feature flags stay the same.

## Checks

- `pnpm test` passed, including content generation, type checking, lint, and 503 unit tests with 2 skips.
- The production build passed with the installed npm package in an isolated copy of this worktree.
- All 5 local Worker route checks passed, including the expected 404.
- Browser checks passed for hydration, theme changes, navigation/history without reload, blog pagination, controlled search/reset, Radix portals, URL filters, and mobile navigation/overflow. No page or console errors.
- The same build and browser checks passed with 0.0.21 as a control.
- All 83 source files and 249 built files in the installed package match the verified 0.1.0 release hashes.

These checks cover local production output, not authenticated flows, external services, or whole-site speed. The production deployment will be checked after merge.

[Release notes](https://github.com/TanStack/redact/releases/tag/%40tanstack/redact%400.1.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development tooling dependency version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->