### PR TITLE
Return 404 for missing framework documentation

### DIFF
--- a/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
+++ b/src/routes/_library/$libraryId/$version.docs.framework.$framework.$.tsx
@@ -60,10 +60,7 @@ export const Route = createFileRoute(
     }
 
     if (result.type === 'not-found') {
-      throw redirect({
-        to: '/$libraryId/$version/docs/framework/$framework',
-        params: { libraryId, version, framework },
-      })
+      throw notFound()
     }
 
     return {

--- a/tests/docs-route-smoke.test.ts
+++ b/tests/docs-route-smoke.test.ts
@@ -12,6 +12,31 @@ type SmokeCase = {
 const baseUrl = process.env.TANSTACK_DOCS_SMOKE_BASE_URL
 
 test(
+  'missing Start documents return 404 without redirecting to the framework index',
+  {
+    skip: baseUrl
+      ? false
+      : 'Set TANSTACK_DOCS_SMOKE_BASE_URL to run docs route smoke tests',
+  },
+  async () => {
+    assert.ok(baseUrl)
+
+    for (const framework of ['react', 'solid']) {
+      const path = `/start/latest/docs/framework/${framework}/missing-docs-smoke-test`
+      const response: Response = await fetch(new URL(path, baseUrl), {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(30_000),
+      })
+      const html = await response.text()
+
+      assert.equal(response.status, 404, `${path} should return 404 directly`)
+      assert.equal(response.headers.get('location'), null)
+      assert.match(html, /404 Not Found/)
+    }
+  },
+)
+
+test(
   'docs legacy and canonical routes complete for every public library',
   {
     skip: baseUrl


### PR DESCRIPTION
Unknown framework documentation URLs currently redirect to a generic documentation index that returns 200. Return the existing not-found response instead, so missing pages produce HTTP 404 and readers can recover through the existing navigation. Explicit redirects for moved documents are preserved.

Validation:
- `pnpm test` passes: type checks, lint, and 510 unit tests (3 environment-dependent tests skipped).
- Ran the new HTTP smoke test against the local site for both React and Solid: direct 404, no Location header, and the existing not-found content.
- Verified the rendered page, recovery link to Start docs, and browser back navigation.
