### PR TITLE
fix(seo): describe Start on its landing page

### DIFF
--- a/src/components/landing/StartLanding.tsx
+++ b/src/components/landing/StartLanding.tsx
@@ -120,7 +120,7 @@ export default function StartLanding() {
         >
           <a
             className="text-text-primary underline underline-offset-4 hover:text-(--landing-accent-bright)"
-            href="/start/latest/docs/framework/react/start-vs-nextjs"
+            href="/start/latest/docs/framework/react/comparison"
           >
             Compare with Next.js
           </a>

--- a/src/components/landing/StartLanding.tsx
+++ b/src/components/landing/StartLanding.tsx
@@ -111,8 +111,27 @@ export default function StartLanding() {
   return (
     <LibraryLandingShell
       libraryId="start"
-      headline="One Router-first app, from server request to client navigation."
-      description="Start keeps TanStack Router as the application contract, then adds full-document rendering, streaming, typed server work, middleware, and output for the runtime you choose."
+      headline="A full-stack framework for React and Solid."
+      description="Build with type-safe routing, server-side rendering, streaming, and server functions, powered by TanStack Router."
+      beforeActions={
+        <nav
+          aria-label="Start guides"
+          className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-ds-body-sm"
+        >
+          <a
+            className="text-text-primary underline underline-offset-4 hover:text-(--landing-accent-bright)"
+            href="/start/latest/docs/framework/react/start-vs-nextjs"
+          >
+            Compare with Next.js
+          </a>
+          <a
+            className="text-text-primary underline underline-offset-4 hover:text-(--landing-accent-bright)"
+            href="/start/latest/docs/framework/react/migrate-from-next-js"
+          >
+            Migrate from Next.js
+          </a>
+        </nav>
+      }
       hero={<ExecutionMapHero />}
       prompt={startPrompt}
       promptLabel="Copy Start prompt"

--- a/src/libraries/libraries.ts
+++ b/src/libraries/libraries.ts
@@ -263,7 +263,7 @@ export const start: LibrarySlim = {
   tagline:
     'Full-stack Framework powered by TanStack Router for React and Solid',
   description:
-    'Full-document SSR, Streaming, Server Functions, bundling and more, powered by TanStack Router and Vite - Ready to deploy to your favorite hosting provider.',
+    'TanStack Start is a full-stack framework for React and Solid, with type-safe routing, server-side rendering, streaming, and server functions.',
   badge: 'RC',
   repo: 'tanstack/router',
   frameworks: ['react', 'solid'],

--- a/src/libraries/start.tsx
+++ b/src/libraries/start.tsx
@@ -8,7 +8,6 @@ const textStyles = 'text-category-framework'
 
 export const startProject = {
   ...start,
-  description: `Full-document SSR, Streaming, Server Functions, bundling and more, powered by TanStack Router and Vite - Ready to deploy to your favorite hosting provider.`,
   latestBranch: 'main',
   docsRoot: 'docs/start',
   embedEditor: 'codesandbox' as const,

--- a/src/routes/-library-landing-route.tsx
+++ b/src/routes/-library-landing-route.tsx
@@ -64,7 +64,10 @@ export function getLibraryLandingHead(libraryId: LandingLibraryId) {
 
   return {
     meta: seo({
-      title: library.name,
+      title:
+        libraryId === 'start'
+          ? 'TanStack Start | Full-stack React and Solid Framework'
+          : library.name,
       description: library.description,
       image: ogImageUrl(library.id),
       noindex: library.visible === false,


### PR DESCRIPTION
Start's landing title was only its name, and its introduction assumed familiarity with TanStack Router. Give it a descriptive React and Solid framework title and opening sentence, reuse the shared library description for metadata, and link directly to the existing comparison and migration guides.

Verified the raw HTML title, description, Open Graph title, introduction, and links, then reviewed the rendered page. Full pre-commit checks passed, including both TypeScript projects, lint, and 515 unit tests with 3 skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added navigation links to compare TanStack Start with Next.js and learn how to migrate from Next.js.
  - Added a dedicated page title: “TanStack Start | Full-stack React and Solid Framework.”

- **Updates**
  - Refreshed the TanStack Start landing page headline and description.
  - Updated the library description to highlight React and Solid support, type-safe routing, server-side rendering, streaming, and server functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->