### PR TITLE
feat(start): link Learn Start course from learning pages

### DIFF
--- a/src/components/landing/StartLanding.tsx
+++ b/src/components/landing/StartLanding.tsx
@@ -124,6 +124,15 @@ export default function StartLanding() {
             icon={<GitBranchIcon aria-hidden="true" size={15} />}
             title="The framework does not replace the application model."
             body="Routes, params, search schemas, loaders, links, pending states, and boundaries stay TanStack Router. Start adds the server and build layers around that same tree."
+            action={
+              <a
+                href="/start/latest/docs/framework/react/tutorial/learn-start"
+                className="inline-flex items-center gap-2 text-ds-label-lg underline underline-offset-4"
+              >
+                Build an app with Learn Start
+                <ArrowRightIcon aria-hidden="true" size={18} />
+              </a>
+            }
           />
           <RouterFoundation />
         </div>

--- a/src/routes/learn.tsx
+++ b/src/routes/learn.tsx
@@ -33,6 +33,16 @@ function LearnPage() {
             individual or team, we have resources that will help you succeed.
           </p>
         </header>
+        <a
+          href="/start/latest/docs/framework/react/tutorial/learn-start"
+          className="block rounded-lg border border-gray-500/20 p-6 hover:border-green-500 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-green-500"
+        >
+          <h2 className="text-xl font-bold">Learn TanStack Start</h2>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Build one React app through eight working checkpoints: routing,
+            PostgreSQL, forms, accounts, SEO, deployment, and tests.
+          </p>
+        </a>
         <div className="flex items-stretch flex-wrap gap-4 max-w-full w-[900px] justify-center">
           <a
             href="https://youtube.com/@tan_stack"


### PR DESCRIPTION
Add a Learn TanStack Start course link to `/learn` and the Start landing page. The course builds one application through eight runnable checkpoints, from routing to production tests.

Depends on https://github.com/TanStack/router/pull/8375. Merge after the course documentation is available so these links have a live destination.

Validation: both links reviewed in the local browser against the Router course checkout. The course destination renders its overview and chapter navigation. Site formatting, tests, lint, and TypeScript checks run through the commit hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Build an app with Learn Start” link to the Router foundation section.
  * Added a “Learn TanStack Start” card to the Learn page, linking to a tutorial covering routing, databases, forms, accounts, SEO, deployment, and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->