### PR TITLE
fix: upgrade Redact to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@tanstack/devtools-vite": "^0.7.0",
     "@tanstack/react-devtools": "^0.10.5",
     "@tanstack/react-query-devtools": "^5.102.8",
-    "@tanstack/redact": "^0.1.0",
+    "@tanstack/redact": "^0.1.2",
     "@types/d3-interpolate": "3.0.4",
     "@types/d3-scale": "4.0.9",
     "@types/d3-shape": "3.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: ^5.102.8
         version: 5.102.8(@tanstack/react-query@5.102.8(react@19.2.3))(react@19.2.3)
       '@tanstack/redact':
-        specifier: ^0.1.0
-        version: 0.1.0(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: ^0.1.2
+        version: 0.1.2(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/d3-interpolate':
         specifier: 3.0.4
         version: 3.0.4
@@ -3702,8 +3702,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/redact@0.1.0':
-    resolution: {integrity: sha512-iauMc/2TLcrlEu0yt58k9ntVraIbKcijp7qJ79wWLPMGxznk6mO436DiSYHoAD0+OP3Yo1WOiGiooRfD8/Ic8Q==}
+  '@tanstack/redact@0.1.2':
+    resolution: {integrity: sha512-rveOZUyTIp4i/D2Koms8NiGljJEOclSOqZ5hW59pRtlDnhklEpe2VZ2EYhGWGemDA5xd9ed3qB8jAQ5zQT12iQ==}
     peerDependencies:
       vite: '>=5'
     peerDependenciesMeta:
@@ -10080,7 +10080,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/redact@0.1.0(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/redact@0.1.2(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     optionalDependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 


### PR DESCRIPTION
Upgrade `@tanstack/redact` from 0.1.0 to 0.1.2 to fix dialogs staying mounted after their closing animation and stale route matches during pending parent updates.

Fixes #1269. Library fixes: https://github.com/TanStack/redact/pull/33

Only the Redact dependency and lockfile entry change. The published package and npm integrity are verified.

Validation:

- `pnpm test`: types, lint, and 515 unit tests pass, with three existing skips.
- The production Vite build and isolated browser smoke pass with the installed npm package, including hydration, navigation/history, blog filters, Radix menus, theme changes, and mobile navigation.
- Production-bundle integration with Router 1.170.35 and Radix Dialog 1.1.15 passes 15 navigations and five animated dialog cycles for both React and Redact, with no browser errors.
- The live deployment still reproduces the stuck dialog before this upgrade. Follow-up verification covers Query, Router, and Start docs navigation plus library, cart, and search overlays.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling package to version 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->